### PR TITLE
New release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,17 @@ script:
 # create the Github repo and add it to Travis, run the
 # following command to finish PyPI deployment setup:
 # $ travis encrypt --add deploy.password
+# Or just use this website:
+# Repository name: AllenCellModeling/aicsimageio
+# http://rkh.github.io/travis-encrypt/public/index.html
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
-  user: AllenCellModeling
+  user: aicspypi
   password:
-    secure: PLEASE_REPLACE_ME
+    secure: Br8fLgBI4xZoM+suSb6yylh/WY6YC4CKIB3/D+4tBRCpVuhs/KrNU1ZZIe6Q9HX6t6D1WNz7VKHc5qnDK8Ld4dN3M7Uxb3fqZxHDkKWiCjGZA5ALtzFeUOLzqFjbNhEjTGbErbyRt93br2cIL+PYHDRvN7CRTb41adb9cA1aRXQCs2qhvaahpaxD+XzqbnZQbzBuDK3TWtX/6kgdV1tLv0HSw2wbXlaC1ylYZJ5opjzZRrOAbBE/WHiXZsLK7x0Tgy2hLU77nIg83DzXhD61rkK+V9r1TUpP/JQeqdBcJgwEPyIi0M2GrsQG3Npcjv8G6jeylFQiW7qQQlRXT1PE+NrOHYRD1YuzRDNMS5OtMfc5sIMSOJntfJbqhKUw4cbGp9VXUaez1bGmrQ8aAb/99SesMES/1de09XjZKdpLm2mcJwaQdfncEYl95X9qdVGDdrDq39vY4UsZltkA8DuqgVkZgIXeZn/FIn9y/YmYn/5TF2cH5Ds10X0LAeFrIyzWhETBJo3s2AayGxSfkJsT73n+YW8Ic1FtLQ5jRzQZ6BApSoAup2/4za4YGQ5f8Rva7OejutFQrmHmfC30T01FQGkeEvcoBV/78XLT/zmoema/UyOd36WpJHdcVTHaXoNBd6vxRMnLfu5u02wyzFUfnwoVTJqHdud9j/0xOc9osUo=
   on:
+    branch: master
     tags: true
     repo: AllenCellModeling/aicsimageio
     python: 3.7

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -82,7 +82,6 @@ class AICSImage:
         ----------
         data: String with path to ometif/czi/tif/png/gif file, or ndarray with up to 6 dimensions
         kwargs: Parameters to be passed through to the reader class
-                       known_dims (required Tif/Png/Gif/numpy.ndarray) known Dimensions of input file, ie "TCZYX"
                        max_workers (optional Czi) specifies the number of worker threads for the backend library
         """
         self.dims = constants.DEFAULT_DIMENSION_ORDER


### PR DESCRIPTION
3.0.0 Release of `aicsimageio`.

Patch notes:
* The core `aicsimageio.AICSImage` object's `data` attribute now returns a 6D `numpy.ndarray` in `Scene-Time-Channel-Z-Y-X` dimension order (shortened: `STCZYX`).
* `aicsimageio` reader APIs have been standardized and a `Reader` abstract base class is available in the case where future custom readers are desired.
* `aicsimageio` now supports many more image formats. Specifically, any image format supported by `imageio` is also supported by `aicsimageio`.
* The core `aicsimageio.AICSImage` object has been made much simpler and many core components of the v0.6.4 class have moved to either reader sub classes or separate modules.
* Tests are cool. `aicsimageio` now has tests and codecov.
* `aicsimageio` is now licensed under BSD-3.

Comments:
* For imaging formats that use `DefaultReader` (`png`, `bmp`, `jpeg`, etc.) or `NumpyReader`, dimension order is assumed and while the data is correct, dimension ordering may be incorrect. Example:
```python
im = AICSImage("example.png")
im.data.shape  # returns (1, 1, 1, 50, 50, 4)
````
The example's dimension ordering is actually `XYC` as it is a `png` but `AICSImage` interprets this as `ZYX`.

* The core `aicsimageio.AICSImage` object's `metadata` attribute will return an object that is managed by an underlying reader. Do not assume that all readers will have the same metadata object type.

Beta / Under Development:
* `aicsimageio` now has an `imread` function that will simply return a `numpy.ndarray` of the imaging data present in the file reshaped to `STCZYX` dimension order.
* `aicsimageio` writers now conform to a `Writer` abstract base class and future writers should use this base class for implementation details.
* Support for six dimension CZI image files (including scene dimension) is in progress!