### PR TITLE
Fixes default reader returning incorrect dim order string

### DIFF
--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+
 from aicsimageio import exceptions
 from aicsimageio.readers.default_reader import DefaultReader
 
@@ -19,7 +20,7 @@ def test_default_reader_get_default_dims(resources_dir, filename):
     # Open
     with DefaultReader(f) as r:
         # Dims should be set to 3D for all of these images
-        assert r.dims == "ZYX"
+        assert r.dims == "YXC"
         assert r.metadata is None
         assert DefaultReader.is_this_type(f)
 

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -109,7 +109,7 @@ def test_reader(resources_dir, filename, expected_reader):
 
 
 @pytest.mark.parametrize("filename, expected_shape", [
-    (PNG_FILE, (1, 1, 1, 800, 537, 4)),
+    (PNG_FILE, (1, 1, 4, 1, 800, 537)),
     (TIF_FILE, (1, 1, 1, 1, 325, 475)),
     (OME_FILE, (1, 1, 1, 1, 325, 475)),
     (CZI_FILE, (1, 1, 1, 1, 325, 475)),


### PR DESCRIPTION
After discussion with @toloudis, we said that default reader dim order bug should be fixed prior to release and that it should make different assumptions than the basic `guess_dim_order` function.