### PR TITLE
bugfix/incorrect-ome-tiff-dim-order

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ im = imread("/path/to/your/file_or_buffer.ome.tiff")
 # For AICSImage object that
 im = AICSImage("/path/to/your/file_or_buffer.ome.tiff")
 
+# To specify a known dimension order
+im = AICSImage("/path/to/your/file_or_buffer.ome.tiff", known_dims="SYX")
+
 # Image data is stored in `data` attribute
 im.data  # returns the image data numpy array
 

--- a/aicsimageio/__init__.py
+++ b/aicsimageio/__init__.py
@@ -3,4 +3,4 @@ from .aics_image import imread  # noqa: F401
 
 # Do not edit this string manually, always use bumpversion
 # Details in CONTRIBUTING.md
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -87,10 +87,7 @@ class AICSImage:
         """
 
         # Hold onto known dims until data is requested
-        if known_dims:
-            self._known_dims = known_dims
-        else:
-            self._known_dims = None
+        self._known_dims = known_dims
 
         # Dims should nearly always be default dim order unless explictly overridden
         self.dims = constants.DEFAULT_DIMENSION_ORDER
@@ -128,15 +125,9 @@ class AICSImage:
         if self._data is None:
             reader_data = self._reader.data
 
-            # Handle delayed known dims reshape
-            if self._known_dims:
-                pass_dims = self._known_dims
-            else:
-                pass_dims = self.reader.dims
-
-            # Read and reshape
+            # Read and reshape and handle delayed known dims reshape
             self._data = transforms.reshape_data(data=reader_data,
-                                                 given_dims=pass_dims,
+                                                 given_dims=self._known_dims or self.reader.dims,
                                                  return_dims=self.dims)
         return self._data
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -1,15 +1,14 @@
-import logging
 import io
+import logging
 import re
 
 import numpy as np
 import tifffile
 
+from .. import types
 from ..vendor import omexml
 from .reader import Reader
 from .tiff_reader import TiffReader
-from .. import types
-
 
 log = logging.getLogger(__name__)
 
@@ -69,9 +68,9 @@ class OmeTiffReader(Reader):
         # this is a tifffile implementation detail -- see squeeze_axes in tifffile.
         if self.size_t() < 2:
             dimension_order = dimension_order.replace("T", "")
-        if self.size_c() < 2:
-            dimension_order = dimension_order.replace("Z", "")
         if self.size_z() < 2:
+            dimension_order = dimension_order.replace("Z", "")
+        if self.size_c() < 2:
             dimension_order = dimension_order.replace("C", "")
         return dimension_order
 

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -44,14 +44,22 @@ class TestOmeTifReader(unittest.TestCase):
     def test_loadSampleOmeTif(self):
         names = [
             "s_1_t_1_c_1_z_1.ome.tiff",
+            "s_1_t_1_c_10_z_1.ome.tiff",
             "s_3_t_1_c_3_z_5.ome.tiff"
         ]
         dims = [
             (325, 475),
+            (10, 1736, 1776),
             (5, 3, 325, 475),
+        ]
+        dim_orders = [
+            "YX",
+            "CYX",  # Inferred from metadata not shape
+            "ZCYX",
         ]
         for i, x in enumerate(names):
             with OmeTiffReader(os.path.join(self.dir_path, "..", "resources", x)) as reader:
                 assert reader.is_ome()
                 data = reader.data
                 self.assertEqual(data.shape, dims[i])
+                self.assertEqual(reader.dims, dim_orders[i])

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -58,6 +58,16 @@ def test_default_dims(data, expected):
     assert img.data.shape == expected
 
 
+@pytest.mark.parametrize("data, dims, expected_shape", [
+    (np.zeros((5, 4, 3)), "SYX", (5, 1, 1, 1, 4, 3)),
+    (np.zeros((1, 2, 3, 4, 5)), "STCYX", (1, 2, 3, 1, 4, 5)),
+    (np.zeros((10, 20)), "XY", (1, 1, 1, 1, 20, 10))
+])
+def test_known_dims(data, dims, expected_shape):
+    img = AICSImage(data, known_dims=dims)
+    assert img.data.shape == expected_shape
+
+
 @pytest.mark.parametrize("data_shape, dims, expected", [
     ((5, 4, 3), "STC", (5, 4, 3, 1, 1, 1)),
     ((1, 2, 3, 4, 5, 6), "XYZCTS", (6, 5, 4, 3, 2, 1)),

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -61,7 +61,8 @@ def test_default_dims(data, expected):
 @pytest.mark.parametrize("data, dims, expected_shape", [
     (np.zeros((5, 4, 3)), "SYX", (5, 1, 1, 1, 4, 3)),
     (np.zeros((1, 2, 3, 4, 5)), "STCYX", (1, 2, 3, 1, 4, 5)),
-    (np.zeros((10, 20)), "XY", (1, 1, 1, 1, 20, 10))
+    (np.zeros((10, 20)), "XY", (1, 1, 1, 1, 20, 10)),
+    pytest.param(np.zeros((2, 2, 2)), "ABI", None, marks=pytest.mark.raises(exception=TypeError))
 ])
 def test_known_dims(data, dims, expected_shape):
     img = AICSImage(data, known_dims=dims)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.1
+current_version = 3.0.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,6 @@ setup(
     url="https://github.com/AllenCellModeling/aicsimageio",
     # Do not edit this string manually, always use bumpversion
     # Details in CONTRIBUTING.md
-    version="3.0.1",
+    version="3.0.2",
     zip_safe=False,
 )


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
   * Resolves #22 
   * Resolves #23
- [x] Provide context of changes.
   * Adds a `known_dims` kwarg to the `AICSImage` object to allow explicit override of dimension ordering. The data is still reshaped to the standard `STCZYX`.
   * Fixes the problem found by @donovanr of the OmeTiffReader not using the parsed metadata to properly return available dimensions and dimension ordering.
- [x] Provide relevant tests for your feature or bug fix.
   * The only unfortunate thing was that I added a 15 MB image to the resources directory to properly test that the ome-tiff reader was fixed. Could probably reduce this but 🤷‍♀.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
