### PR TITLE
fix png writer and tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.pythonPath": "C:\\Users\\danielt\\AppData\\Local\\Continuum\\anaconda3\\envs\\aicsimageio\\python.exe",
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\danielt\\AppData\\Local\\Continuum\\anaconda3\\envs\\aicsimageio\\python.exe",
-    "python.linting.pylintEnabled": false,
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
-}

--- a/aicsimageio/tests/writers/test_png_writer.py
+++ b/aicsimageio/tests/writers/test_png_writer.py
@@ -6,7 +6,6 @@ import os
 import unittest
 
 import numpy as np
-import pytest
 
 from aicsimageio.readers import DefaultReader
 from aicsimageio.writers import PngWriter

--- a/aicsimageio/tests/writers/test_png_writer.py
+++ b/aicsimageio/tests/writers/test_png_writer.py
@@ -35,25 +35,23 @@ class TestPngWriter(unittest.TestCase):
     Test saves an image and compares it with a previously saved image.
     This iotest should assure that the png save() method does not transpose any dimensions as it saves
     """
-    @pytest.mark.xfail
     def test_pngSaveComparison(self):
         self.writer.save(self.image.astype('uint8'))
         reader = DefaultReader(self.file)
         output_image = reader.data.T
-        self.assertTrue(np.array_equal(self.image, output_image))
         reader.close()
+        self.assertTrue(np.array_equal(self.image, output_image))
 
     """
     Test saves an image with various z, c, and t.
     The extra parameters should not change the output from save()'s output
     """
-    @pytest.mark.xfail
     def test_pngSaveImageComparison(self):
         self.writer.save_slice(self.image.astype('uint8'), z=1, c=2, t=3)
         reader = DefaultReader(self.file)
         output_image = reader.data.T
-        self.assertTrue(np.array_equal(self.image, output_image))
         reader.close()
+        self.assertTrue(np.array_equal(self.image, output_image))
 
     """
     Test to check if save() can overwrite a file

--- a/aicsimageio/writers/png_writer.py
+++ b/aicsimageio/writers/png_writer.py
@@ -59,7 +59,7 @@ class PngWriter:
         if len(data.shape) == 3:
             assert data.shape[0] in [4, 3, 2, 1]
             # if three dimensions, transpose to YXC (imsave() needs it in these axes)
-            data = np.transpose(data, (1, 2, 0))
+            data = np.transpose(data, (2, 1, 0))
             # if there's only one channel, repeat across the next two channels
             if data.shape[2] == 1:
                 data = np.repeat(data, repeats=3, axis=2)


### PR DESCRIPTION
png writer tests were marked as `pytest.mark.xfail` but the fail was happening before closing a file handle.  
Also, these tests could be made to pass with a small change to the png writer.
