### PR TITLE
Remove CRON from doc build workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
-    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
-    # Run every Monday at 18:00:00 UTC (Monday at 10:00:00 PST)
-    - cron: '0 18 * * 1'
 
 jobs:
   docs:


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
  If anyone else noticed or received an email this morning at 11 our CRON scheduled task to deploy docs failed while our build master succeeded. After some digging through the logs, the _solution_ (maybe?) is to simply remove the CRON build of docs. I tested this change on the cookiecutter template and on Julie's repo and it works there. I am really not entirely sure why it was caused but even retriggering the CRON job fails while pushing a new commit that removes the CRON job succeeds. You can see that here:

  * Successful master commit build: https://github.com/AllenCellModeling/normal_mode_analysis/commit/9660ed8cc0d8032aad2ecc4e5217fecbbe028f81/checks?check_suite_id=274685352
  * Failing master CRON build:
https://github.com/AllenCellModeling/normal_mode_analysis/commit/ddee87ba3fee35b3665d5a92b34d3ed8da242f2d/checks?check_suite_id=274510367

  Who knows, but at least this is a temporary fix.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
