### PR TITLE
Add pytest for generate and validate

### DIFF
--- a/czi-to-ome-tiff/xslt/tests/conftest.py
+++ b/czi-to-ome-tiff/xslt/tests/conftest.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def czi_to_ome_dir() -> Path:
+    return Path(__file__).parent.parent.parent
+
+
+@pytest.fixture
+def OMEXSD(czi_to_ome_dir: Path) -> Path:
+    return (czi_to_ome_dir / "ome" / "ome.xsd").resolve(strict=True)
+
+
+@pytest.fixture
+def CZIXML(czi_to_ome_dir: Path) -> Path:
+    return (czi_to_ome_dir / "resources" / "example-czi.xml").resolve(strict=True)
+
+
+@pytest.fixture
+def xslt_template(czi_to_ome_dir: Path) -> Path:
+    return (czi_to_ome_dir / "xslt" / "czi-to-ome.xsl").resolve(strict=True)

--- a/czi-to-ome-tiff/xslt/tests/test_xslt.py
+++ b/czi-to-ome-tiff/xslt/tests/test_xslt.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from lxml import etree
+
+
+def test_generate_and_validate(OMEXSD, CZIXML, xslt_template):
+    # Parse template
+    template = etree.parse(str(xslt_template))
+    transform = etree.XSLT(template)
+
+    # Parse CZI XML
+    czixml = etree.parse(str(CZIXML))
+
+    # Attempt to run transform
+    produced = transform(czixml)
+
+    # Parse OME XSD
+    omexsd = etree.parse(str(OMEXSD))
+    omexsd = etree.XMLSchema(omexsd)
+
+    # Validate
+    assert omexsd.validate(produced)

--- a/czi-to-ome-tiff/xslt/transform.py
+++ b/czi-to-ome-tiff/xslt/transform.py
@@ -5,6 +5,7 @@ import lxml.etree as ET
 ###############################################################################
 
 resources = Path("../resources").resolve(strict=True)
+omexsd = str(Path("../ome/ome.xsd").resolve(strict=True))
 czixml = str((resources / "example-czi.xml").resolve(strict=True))
 template = str(Path("czi-to-ome.xsl").resolve(strict=True))
 output = Path("produced.ome.xml").resolve()
@@ -18,6 +19,10 @@ transform = ET.XSLT(template)
 # Parse CZI XML
 czixml = ET.parse(czixml)
 
+# Parse OME XSD
+omexsd = ET.parse(omexsd)
+omexsd = ET.XMLSchema(omexsd)
+
 # Attempt to run transform
 try:
     ome = transform(czixml)
@@ -25,6 +30,15 @@ try:
     # Write file
     with open(output, "w") as write_out:
         write_out.write(str(ome))
+
+    # Validate file
+    passing = omexsd.validate(ome)
+
+    if passing:
+        print(f"Produced XML passes OME XSD: {passing}")
+    else:
+        raise ValueError(f"Produced XML fails validation")
+
 
 # Catch any exception
 except Exception as e:


### PR DESCRIPTION
Adds a pytest for generate and validate using `lxml` also adds the validation to the `transform.py` utility.