### PR TITLE
add get_channel_names to AICSImage class

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -274,7 +274,7 @@ class AICSImage:
             **kwargs,
         )
 
-    def get_channel_names(self, scene=0):
+    def get_channel_names(self, scene: int = 0):
         """
 
         Parameters

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -274,6 +274,23 @@ class AICSImage:
             **kwargs,
         )
 
+    def get_channel_names(self, scene=0):
+        """
+
+        Parameters
+        ----------
+        scene: the index of the scene for which to return channel names
+
+        Returns
+        -------
+        list of strings representing the channel names
+        """
+        try:
+            names = self._reader.get_channel_names(scene)
+        except AttributeError:
+            names = [str(i) for i in range(self.size_c)]
+        return names
+
     def __repr__(self) -> str:
         return f"<AICSImage [{type(self.reader).__name__}]>"
 

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -214,6 +214,6 @@ class CziReader(Reader):
         img_shape = self.czi.filtered_subblock_directory[0].shape
         return img_shape[index] != 1
 
-    def get_channel_names(self, scene=0):
+    def get_channel_names(self, scene: int = 0):
         chelem = self.metadata.findall("./Metadata/Information/Image/Dimensions/Channels/Channel")
         return [ch.get("Name") for ch in chelem]

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -213,3 +213,7 @@ class CziReader(Reader):
             return False
         img_shape = self.czi.filtered_subblock_directory[0].shape
         return img_shape[index] != 1
+
+    def get_channel_names(self, scene=0):
+        chelem = self.metadata.findall("./Metadata/Information/Image/Dimensions/Channels/Channel")
+        return [ch.get("Name") for ch in chelem]

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -102,3 +102,6 @@ class OmeTiffReader(Reader):
 
     def is_ome(self):
         return OmeTiffReader._is_this_type(self._bytes)
+
+    def get_channel_names(self, scene=0):
+        return self.metadata.image(scene).Pixels.get_channel_names()

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -103,5 +103,5 @@ class OmeTiffReader(Reader):
     def is_ome(self):
         return OmeTiffReader._is_this_type(self._bytes)
 
-    def get_channel_names(self, scene=0):
+    def get_channel_names(self, scene: int = 0):
         return self.metadata.image(scene).Pixels.get_channel_names()

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -183,3 +183,17 @@ def test_reader(resources_dir, filename, expected_reader):
 def test_imread(resources_dir, filename, expected_shape):
     img = imread(resources_dir / filename)
     assert img.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "filename, expected_channel_names",
+    [
+        (PNG_FILE, ["0", "1", "2", "3"]),
+        (TIF_FILE, ["0"]),
+        (CZI_FILE, ["Bright"]),
+        (OME_FILE, ["Bright"]),
+    ],
+)
+def test_channel_names(resources_dir, filename, expected_channel_names):
+    img = AICSImage(resources_dir / filename)
+    assert img.get_channel_names() == expected_channel_names

--- a/aicsimageio/vendor/omexml.py
+++ b/aicsimageio/vendor/omexml.py
@@ -819,6 +819,9 @@ class OMEXML(object):
             """
             return len(self.node.findall(qn(self.ns['ome'], "Channel")))
 
+        def get_channel_names(self):
+            return [self.Channel(i).Name for i in range(self.get_channel_count())]
+
         def set_channel_count(self, value):
             assert value >= 0
             channel_count = self.channel_count


### PR DESCRIPTION
Reinstating support for a get_channel_names method on AICSImage class.  Current AICS code depends on being able to get channel names for file conversions for our data releases.

The implementation details are buried in the readers for now - a future refactor might create nicer metadata wrapper classes for ome-tiff and czi.    

The call is duck-typed with respect to readers;  if get_channel_names is not supported by the reader, then integer channel names will be assigned.
