### PR TITLE
Feature/physical pixel size

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -1,7 +1,7 @@
 import io
 import logging
 import warnings
-from typing import Optional
+from typing import Optional, Tuple
 from xml.etree import ElementTree
 
 import numpy as np
@@ -225,8 +225,8 @@ class CziReader(Reader):
             return default
         return ref.text
 
-    def get_physical_pixel_size(self, scene: int = 0):
+    def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         px = float(self._getmetadataxmltext("./Metadata/Scaling/Items/Distance[@Id='X']/Value", "1.0"))
         py = float(self._getmetadataxmltext("./Metadata/Scaling/Items/Distance[@Id='Y']/Value", "1.0"))
         pz = float(self._getmetadataxmltext("./Metadata/Scaling/Items/Distance[@Id='Z']/Value", "1.0"))
-        return [px, py, pz]
+        return (px, py, pz)

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -217,3 +217,16 @@ class CziReader(Reader):
     def get_channel_names(self, scene: int = 0):
         chelem = self.metadata.findall("./Metadata/Information/Image/Dimensions/Channels/Channel")
         return [ch.get("Name") for ch in chelem]
+
+    # TODO refactor this utility function into a metadata wrapper class
+    def _getmetadataxmltext(self, findpath, default=None):
+        ref = self.metadata.find(findpath)
+        if ref is None:
+            return default
+        return ref.text
+
+    def get_physical_pixel_size(self, scene: int = 0):
+        px = float(self._getmetadataxmltext("./Metadata/Scaling/Items/Distance[@Id='X']/Value", "1.0"))
+        py = float(self._getmetadataxmltext("./Metadata/Scaling/Items/Distance[@Id='Y']/Value", "1.0"))
+        pz = float(self._getmetadataxmltext("./Metadata/Scaling/Items/Distance[@Id='Z']/Value", "1.0"))
+        return [px, py, pz]

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -105,3 +105,7 @@ class OmeTiffReader(Reader):
 
     def get_channel_names(self, scene: int = 0):
         return self.metadata.image(scene).Pixels.get_channel_names()
+
+    def get_physical_pixel_size(self, scene: int = 0):
+        p = self.metadata.image(scene).Pixels
+        return [p.get_PhysicalSizeX(), p.get_PhysicalSizeY(), p.get_PhysicalSizeZ()]

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -4,6 +4,7 @@ import re
 
 import numpy as np
 import tifffile
+from typing import Tuple
 
 from .. import types
 from ..vendor import omexml
@@ -106,6 +107,6 @@ class OmeTiffReader(Reader):
     def get_channel_names(self, scene: int = 0):
         return self.metadata.image(scene).Pixels.get_channel_names()
 
-    def get_physical_pixel_size(self, scene: int = 0):
+    def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         p = self.metadata.image(scene).Pixels
-        return [p.get_PhysicalSizeX(), p.get_PhysicalSizeY(), p.get_PhysicalSizeZ()]
+        return (p.get_PhysicalSizeX(), p.get_PhysicalSizeY(), p.get_PhysicalSizeZ())

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -60,6 +60,15 @@ def test_dtype(resources_dir, test_input, expected):
     assert czi.dtype() == expected
 
 
+@pytest.mark.parametrize("test_input, expected", [
+    (TWO_DIM_CZI, [1.0833333333333333e-06, 1.0833333333333333e-06, 1.0]),
+    (SIX_DIM_CZI, [1.0833333333333333e-06, 1.0833333333333333e-06, 1e-06])
+])
+def test_pixel_size(resources_dir, test_input, expected):
+    czi = CziReader(resources_dir / test_input)
+    assert czi.get_physical_pixel_size() == expected
+
+
 def test_shape(resources_dir):
     czi = CziReader(resources_dir / SIX_DIM_CZI)
     data = czi.data

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -61,8 +61,8 @@ def test_dtype(resources_dir, test_input, expected):
 
 
 @pytest.mark.parametrize("test_input, expected", [
-    (TWO_DIM_CZI, [1.0833333333333333e-06, 1.0833333333333333e-06, 1.0]),
-    (SIX_DIM_CZI, [1.0833333333333333e-06, 1.0833333333333333e-06, 1e-06])
+    (TWO_DIM_CZI, (1.0833333333333333e-06, 1.0833333333333333e-06, 1.0)),
+    (SIX_DIM_CZI, (1.0833333333333333e-06, 1.0833333333333333e-06, 1e-06))
 ])
 def test_pixel_size(resources_dir, test_input, expected):
     czi = CziReader(resources_dir / test_input)

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -58,9 +58,9 @@ class TestOmeTifReader(unittest.TestCase):
             "ZCYX",
         ]
         physical_pixel_sizes = [
-            [1.0833333333333333, 1.0833333333333333, 1.0],
-            [1.0, 1.0, 1.0],
-            [1.0833333333333333, 1.0833333333333333, 1.0],
+            (1.0833333333333333, 1.0833333333333333, 1.0),
+            (1.0, 1.0, 1.0),
+            (1.0833333333333333, 1.0833333333333333, 1.0),
         ]
         for i, x in enumerate(names):
             with OmeTiffReader(os.path.join(self.dir_path, "..", "resources", x)) as reader:

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -57,9 +57,15 @@ class TestOmeTifReader(unittest.TestCase):
             "CYX",  # Inferred from metadata not shape
             "ZCYX",
         ]
+        physical_pixel_sizes = [
+            [1.0833333333333333, 1.0833333333333333, 1.0],
+            [1.0, 1.0, 1.0],
+            [1.0833333333333333, 1.0833333333333333, 1.0],
+        ]
         for i, x in enumerate(names):
             with OmeTiffReader(os.path.join(self.dir_path, "..", "resources", x)) as reader:
                 assert reader.is_ome()
                 data = reader.data
                 self.assertEqual(data.shape, dims[i])
                 self.assertEqual(reader.dims, dim_orders[i])
+                self.assertEqual(reader.get_physical_pixel_size(), physical_pixel_sizes[i])

--- a/aicsimageio/vendor/omexml.py
+++ b/aicsimageio/vendor/omexml.py
@@ -273,10 +273,10 @@ def get_namespaces(node):
     return ns_lib
 
 
-def get_float_attr(node, attribute):
+def get_float_attr(node, attribute, default=None):
     """Cast an element attribute to a float or return None if not present"""
     attr = node.get(attribute)
-    return None if attr is None else float(attr)
+    return default if attr is None else float(attr)
 
 
 def get_int_attr(node, attribute):
@@ -782,7 +782,7 @@ class OMEXML(object):
 
         def get_PhysicalSizeX(self):
             """The dimensions of the image in the X direction in physical units"""
-            return get_float_attr(self.node, "PhysicalSizeX")
+            return get_float_attr(self.node, "PhysicalSizeX", 1.0)
 
         def set_PhysicalSizeX(self, value):
             self.node.set("PhysicalSizeX", str(value))
@@ -791,7 +791,7 @@ class OMEXML(object):
 
         def get_PhysicalSizeY(self):
             """The dimensions of the image in the Y direction in physical units"""
-            return get_float_attr(self.node, "PhysicalSizeY")
+            return get_float_attr(self.node, "PhysicalSizeY", 1.0)
 
         def set_PhysicalSizeY(self, value):
             self.node.set("PhysicalSizeY", str(value))
@@ -800,7 +800,7 @@ class OMEXML(object):
 
         def get_PhysicalSizeZ(self):
             """The dimensions of the image in the Z direction in physical units"""
-            return get_float_attr(self.node, "PhysicalSizeZ")
+            return get_float_attr(self.node, "PhysicalSizeZ", 1.0)
 
         def set_PhysicalSizeZ(self, value):
             self.node.set("PhysicalSizeZ", str(value))

--- a/aicsimageio/vendor/omexml.py
+++ b/aicsimageio/vendor/omexml.py
@@ -1255,7 +1255,7 @@ class OMEXML(object):
             return get_text(description)
 
         def set_Description(self, text):
-            make_text_node(self.node, NS_SPW, "Description", test)
+            make_text_node(self.node, self.ns['spw'], "Description", text)
         Description = property(get_Description, set_Description)
 
         def get_Well(self):


### PR DESCRIPTION
Another functionality patch: AICS internal code needs to be able to get the physical pixel size in x, y, and z for volume data.  I implement this on the volume file format readers, and left it out of AICSImage for now.  It can be accessed via the reader.  As with prior PRs, this is probably subject to refactoring into a metadata wrapper class.