### PR TITLE
fix imread bug and allow AICSImage class to close its reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,17 @@ from aicsimageio import AICSImage, imread
 im = imread("/path/to/your/file_or_buffer.ome.tiff")
 
 # For AICSImage object that
-im = AICSImage("/path/to/your/file_or_buffer.ome.tiff")
+with AICSImage("/path/to/your/file_or_buffer.ome.tiff") as im:
+    # use im object
 
 # To specify a known dimension order
-im = AICSImage("/path/to/your/file_or_buffer.ome.tiff", known_dims="SYX")
+with AICSImage("/path/to/your/file_or_buffer.ome.tiff", known_dims="SYX") as im:
+    # use im object
+
+# if you instantiate an AICSImage:
+im = AICSImage("/path/to/your/file_or_buffer.ome.tiff")
+# you should close it when done:
+im.close()
 
 # Image data is stored in `data` attribute
 im.data  # returns the image data numpy array

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -33,18 +33,29 @@ class AICSImage:
 
     zstack_t10 = data[0, 10, 0, :, :, :]  # access the S=0, T=10, C=0 "ZYX" cube
 
-
     File Examples
     -------------
+
+    with AICSImage("filename.ome.tif") as img:
+        # do work with img
+        data = img.data
+        metadata = img.metadata
+        # img will be closed automatically at end of scope
+
     OmeTif
         img = AICSImage("filename.ome.tif")
+        img.close()
     CZI (Zeiss)
         img = AICSImage("filename.czi") or AICSImage("filename.czi", max_workers=8)
+        img.close()
     Tiff
         img = AICSImage("filename.tif")
+        img.close()
     Png/Gif/...
         img = AICSImage("filename.png")
+        img.close()
         img = AICSImage("filename.gif")
+        img.close()
 
     Bytestream Examples
     -------------------
@@ -291,9 +302,20 @@ class AICSImage:
             names = [str(i) for i in range(self.size_c)]
         return names
 
+    def close(self):
+        self.reader.close()
+
     def __repr__(self) -> str:
         return f"<AICSImage [{type(self.reader).__name__}]>"
 
+    def __enter__(self):
+        return self
 
-def imread(data: types.ImageLike, **kwargs):
-    return AICSImage(data, **kwargs).data
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+def imread(data: types.ImageLike, **kwargs) -> np.ndarray:
+    with AICSImage(data, **kwargs) as image:
+        imagedata = image.data
+    return imagedata

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -3,6 +3,7 @@ from xml.etree import cElementTree as etree
 import numpy as np
 import os
 import pytest
+import shutil
 
 from aicsimageio import AICSImage, exceptions, imread, readers
 from aicsimageio.vendor import omexml
@@ -202,12 +203,14 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
 
 def test_aicsimage_close(resources_dir):
     filename = resources_dir / PNG_FILE
+    tempfilename = resources_dir / "temp.png"
+    shutil.copy(filename, tempfilename)
     with pytest.raises(IOError):
-        img = AICSImage(filename)
+        img = AICSImage(tempfilename)
         img.metadata
-        os.rename(filename, filename)
+        os.remove(tempfilename)
     # there is no assertion because the test here is that
     # the following code should not raise.
-    with AICSImage(filename) as img:
+    with AICSImage(tempfilename) as img:
         img.metadata
-    os.rename(filename, filename)
+    os.remove(tempfilename)

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -1,6 +1,7 @@
 from xml.etree import cElementTree as etree
 
 import numpy as np
+import os
 import pytest
 
 from aicsimageio import AICSImage, exceptions, imread, readers
@@ -197,3 +198,16 @@ def test_imread(resources_dir, filename, expected_shape):
 def test_channel_names(resources_dir, filename, expected_channel_names):
     img = AICSImage(resources_dir / filename)
     assert img.get_channel_names() == expected_channel_names
+
+
+def test_aicsimage_close(resources_dir):
+    filename = resources_dir / PNG_FILE
+    with pytest.raises(IOError):
+        img = AICSImage(filename)
+        img.metadata
+        os.rename(filename, filename)
+    # there is no assertion because the test here is that
+    # the following code should not raise.
+    with AICSImage(filename) as img:
+        img.metadata
+    os.rename(filename, filename)

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -199,12 +199,20 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
     assert img.get_channel_names() == expected_channel_names
 
 
-def test_aicsimage_close(resources_dir):
-    filename = resources_dir / PNG_FILE
-    img = AICSImage(filename)
+@pytest.mark.parametrize(
+    "filename",
+    [
+        PNG_FILE,
+        TIF_FILE,
+        CZI_FILE,
+        OME_FILE,
+    ],
+)
+def test_aicsimage_close(resources_dir, filename):
+    img = AICSImage(resources_dir / filename)
     assert img.reader._bytes.closed is False
     img.close()
 
-    with AICSImage(filename) as img:
+    with AICSImage(resources_dir / filename) as img:
         img.metadata
     assert img.reader._bytes.closed is True

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -203,9 +203,8 @@ def test_aicsimage_close(resources_dir):
     filename = resources_dir / PNG_FILE
     img = AICSImage(filename)
     assert img.reader._bytes.closed is False
+    img.close()
 
-    # there is no assertion because the test here is that
-    # the following code should not raise.
     with AICSImage(filename) as img:
         img.metadata
     assert img.reader._bytes.closed is True

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -1,9 +1,7 @@
 from xml.etree import cElementTree as etree
 
 import numpy as np
-import os
 import pytest
-import shutil
 
 from aicsimageio import AICSImage, exceptions, imread, readers
 from aicsimageio.vendor import omexml
@@ -203,14 +201,11 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
 
 def test_aicsimage_close(resources_dir):
     filename = resources_dir / PNG_FILE
-    tempfilename = resources_dir / "temp.png"
-    shutil.copy(filename, tempfilename)
-    with pytest.raises(IOError):
-        img = AICSImage(tempfilename)
-        img.metadata
-        os.remove(tempfilename)
+    img = AICSImage(filename)
+    assert img.reader._bytes.closed is False
+
     # there is no assertion because the test here is that
     # the following code should not raise.
-    with AICSImage(tempfilename) as img:
+    with AICSImage(filename) as img:
         img.metadata
-    os.remove(tempfilename)
+    assert img.reader._bytes.closed is True


### PR DESCRIPTION
The fixes a bug with `imread` which was leaving the file handle open.  It also allows the `with AICSImage as varname` syntax, and adds a public method to close the reader.  
