### PR TITLE
Remove make clean command from make docs call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/aicsimageio*.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ aicsimageio **/tests/
-	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 
 serve-docs: ## generate Sphinx HTML documentation, including API docs


### PR DESCRIPTION
This will fix auto doc generation. This is just this repo's changes because yay GitHub actions pulls from other repos when needed (the `@master` tags on all the tasks). The actual doc deployment task changes can be seen [here](https://github.com/JacksonMaxfield/github-pages-deploy-action-python/commit/bbf57418fe52f4e5961a6516e419aa9cd095782d).