### PR TITLE
bugfix/aicsimage-serialization

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -128,7 +128,6 @@ class AICSImage:
         # Lazy load data from reader and reformat to standard dimensions
         self._dask_data = None
         self._data = None
-        self._metadata = None
 
         # Store dask client and cluster setup
         self._dask_kwargs = dask_kwargs
@@ -272,10 +271,8 @@ class AICSImage:
             The Metadata from the Czi, or Ome.Tiff file, or other base class type with metadata.
             For pure image files an empty string or None is returned.
         """
-        if self._metadata is None:
-            self._metadata = self.reader.metadata
-
-        return self._metadata
+        # The reader can implement read optimization or not.
+        return self.reader.metadata
 
     @property
     def reader(self) -> Reader:

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -363,16 +363,14 @@ class CziReader(Reader):
     @property
     def metadata(self) -> _Element:
         """
-        Lazy load the metadata from the CZI file
+        Load and return the metadata from the CZI file
 
         Returns
         -------
-        The xml Element Tree of the metadata
+        The lxml Element Tree of the metadata
         """
-        if self._metadata is None:
-            # load the metadata
-            self._metadata = CziFile(self._file).meta
-        return self._metadata
+        # We can't serialize lxml element trees so don't save the tree to the object state
+        return CziFile(self._file).meta
 
     def _size_of_dimension(self, dim: str) -> int:
         if dim in self.dims:


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #71

- [x] Provide context of changes.

In switching over to dask as the underlying core I forgot one big thing, the entire object should be serializable to actually distribute. @toloudis encountered a bug where if a user loaded the metadata _then_ tried to distribute the `AICSImage` it would fail because the metadata parser for CZI files isn't pickle-able.

This change, and moving forward, means that file readers should be explicit about whether or not they can store data in a lazy loaded fashion or not.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
