### PR TITLE
feature/get-physical-pixel-size

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -459,10 +459,9 @@ class AICSImage:
             List of strings representing the channel names.
         """
         try:
-            names = self.reader.get_channel_names(scene)
+            return self.reader.get_channel_names(scene)
         except AttributeError:
-            names = [str(i) for i in range(self.size_c)]
-        return names
+            return [str(i) for i in range(self.size_c)]
 
     def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         """

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -464,6 +464,26 @@ class AICSImage:
             names = [str(i) for i in range(self.size_c)]
         return names
 
+    def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
+        """
+        Attempts to retrieve physical pixel size for the specified scene.
+        If none available, returns `1.0` for each spatial dimension.
+
+        Parameters
+        ----------
+        scene: int
+            The index of the scene for which to return physical pixel sizes.
+
+        Returns
+        -------
+        sizes: Tuple[float]
+            Tuple of floats representing the pixel sizes for X, Y, Z, in that order.
+        """
+        try:
+            return self.reader.get_physical_pixel_size(scene)
+        except AttributeError:
+            return (1.0, 1.0, 1.0)
+
     def __repr__(self) -> str:
         return f"<AICSImage [{type(self.reader).__name__}]>"
 

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -478,10 +478,7 @@ class AICSImage:
         sizes: Tuple[float]
             Tuple of floats representing the pixel sizes for X, Y, Z, in that order.
         """
-        try:
-            return self.reader.get_physical_pixel_size(scene)
-        except AttributeError:
-            return (1.0, 1.0, 1.0)
+        return self.reader.get_physical_pixel_size(scene)
 
     def __repr__(self) -> str:
         return f"<AICSImage [{type(self.reader).__name__}]>"

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -132,6 +132,23 @@ class Reader(ABC):
     def metadata(self) -> Any:
         pass
 
+    def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
+        """
+        Attempts to retrieve physical pixel size for the specified scene.
+        If none available, returns `1.0` for each spatial dimension.
+
+        Parameters
+        ----------
+        scene: int
+            The index of the scene for which to return physical pixel sizes.
+
+        Returns
+        -------
+        sizes: Tuple[float]
+            Tuple of floats representing the pixel sizes for X, Y, Z, in that order.
+        """
+        return (1.0, 1.0, 1.0)
+
     @property
     def cluster(self) -> Optional[LocalCluster]:
         return self._cluster

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -331,6 +331,35 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
     assert str(f) not in [f.path for f in proc.open_files()]
 
 
+@pytest.mark.parametrize(
+    "filename, expected_sizes",
+    [
+        (PNG_FILE, (1.0, 1.0, 1.0)),
+        (TIF_FILE, (1.0, 1.0, 1.0)),
+        (CZI_FILE, (1.0833333333333333e-06, 1.0833333333333333e-06, 1.0)),
+        (OME_FILE, (1.0833333333333333, 1.0833333333333333, 1.0)),
+    ],
+)
+def test_physical_pixel_size(resources_dir, filename, expected_sizes):
+    # Get filepath
+    f = resources_dir / filename
+
+    # Check that there are no open file pointers after init
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    # Check basics
+    with Profiler() as prof:
+        img = AICSImage(f)
+        assert img.get_physical_pixel_size() == expected_sizes
+
+        # Check that basic details don't require task computation
+        assert len(prof.results) == 0
+
+    # Check that there are no open file pointers after basics
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+
 @pytest.mark.parametrize("data, rgb, expected_data, expected_visible, expected_ndim, expected_axis_labels", [
     (
         # C Z Y X


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #78 

- [x] Provide context of changes.

Dan wanted something, so I added it.

For real though, this implements the same getter that `get_channel_names` uses to go to the base reader for pixel sizes and return. My one gripe with this is that the values are returned in `X`, `Y`, `Z` order which is the opposite of literally everything else in `aicsimageio` but didn't change that as it would be a breaking change.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
