### PR TITLE
feature/add-aicsimageio-napari-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,25 @@ img.get_channel_names()  # returns a list of string channel names if found in th
 ### Napari Interactive Viewer
 [napari](https://github.com/Napari/napari) is a fast, interactive, multi-dimensional image viewer for python and
 it is pretty useful for imaging data that this package tends to interact with.
+
+#### Installation
+**Stable Release:** `pip install napari`<br>
+**Development Head:** `pip install git+https://github.com/napari/napari.git`
+
+#### CLI
+Launch the GUI then select your the file you want to interact with:
+
+```bash
+napari
+```
+
+You can select between plugins:
+* `aicsimageio` (full in-memory file reading)
+* `aicsimageio_delayed` (large file, on-demand file reading)
+
+#### Python
+In an Python terminal or Jupyter Notebook:
+
 ```python
 from aicsimageio import AICSImage
 

--- a/aicsimageio/plugins/__init__.py
+++ b/aicsimageio/plugins/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/plugins/napari/__init__.py
+++ b/aicsimageio/plugins/napari/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/plugins/napari/delayed.py
+++ b/aicsimageio/plugins/napari/delayed.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+from pluggy import HookimplMarker
+
+from . import utils
+
+###############################################################################
+
+napari_hook_implementation = HookimplMarker("napari")
+
+###############################################################################
+
+
+@napari_hook_implementation
+def napari_get_reader(path: utils.PathLike) -> Optional[utils.ReaderFunction]:
+    return utils.get_reader(path, compute=False)

--- a/aicsimageio/plugins/napari/in_memory.py
+++ b/aicsimageio/plugins/napari/in_memory.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+from pluggy import HookimplMarker
+
+from . import utils
+
+###############################################################################
+
+napari_hook_implementation = HookimplMarker("napari")
+
+###############################################################################
+
+
+@napari_hook_implementation
+def napari_get_reader(path: utils.PathLike) -> Optional[utils.ReaderFunction]:
+    return utils.get_reader(path, compute=True)

--- a/aicsimageio/plugins/napari/utils.py
+++ b/aicsimageio/plugins/napari/utils.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from functools import partial
+from typing import (Any, Callable, Dict, List, NamedTuple, Optional, Tuple,
+                    Union)
+
+import dask.array as da
+import numpy as np
+from pluggy import HookimplMarker
+
+from aicsimageio import AICSImage, dask_utils, exceptions
+from aicsimageio.constants import Dimensions
+from aicsimageio.readers.reader import Reader
+
+###############################################################################
+
+LayerData = Union[Tuple[Any], Tuple[Any, Dict], Tuple[Any, Dict, str]]
+PathLike = Union[str, List[str]]
+ReaderFunction = Callable[[PathLike], List[LayerData]]
+
+napari_hook_implementation = HookimplMarker("napari")
+
+###############################################################################
+
+
+class LoadResult(NamedTuple):
+    data: np.ndarray
+    index: int
+    channel_axis: Optional[int]
+    channel_names: Optional[List[str]]
+
+###############################################################################
+
+
+def _load_image(path: str, ReaderClass: Reader, index: int) -> LoadResult:
+    # Initialize reader
+    reader = ReaderClass(path)
+
+    # Set channel_axis
+    if Dimensions.Channel in reader.dims:
+        channel_axis = reader.dims.index(Dimensions.Channel)
+    else:
+        channel_axis = None
+
+    # Set channel names
+    if channel_axis is not None:
+        channel_names = reader.get_channel_names()
+    else:
+        channel_names = None
+
+    # Finalize data and metadata to send to napari viewer
+    return LoadResult(
+        data=np.squeeze(reader.dask_data.astype(np.float16)),
+        index=index,
+        channel_axis=channel_axis,
+        channel_names=channel_names,
+    )
+
+
+def reader_function(path: PathLike, compute: bool) -> List[LayerData]:
+    """
+    Given a single path return a list of LayerData tuples.
+    """
+    # Alert console of how we are loading the image
+    print(f"Reader will load image in-memory: {compute}")
+
+    # Standardize path to list of paths
+    paths = [path] if isinstance(path, str) else path
+
+    # Determine reader for all
+    ReaderClass = AICSImage.determine_reader(paths[0])
+
+    # Spawn dask cluster for parallel read
+    with dask_utils.cluster_and_client() as (cluster, client):
+        # Map each file read
+        futures = client.map(
+            _load_image,
+            paths,
+            [ReaderClass for i in range(len(paths))],
+            [i for i in range(len(paths))],
+        )
+
+        # Block until done
+        results = client.gather(futures)
+
+        # Sort results by index
+        results = sorted(results, key=lambda result: result.index)
+
+        # Stack all arrays and configure metadata
+        data = da.stack([result.data for result in results])
+
+        # Determine whether or not to read in full first
+        if compute:
+            data = data.compute()
+
+        # Construct metadata using any of the returns as there is an assumption it is all the same
+        meta = {
+            "name": results[0].channel_names,
+            "channel_axis": results[0].channel_axis + 1,  # Add 1 to offset the new axis from the array stack
+            "is_pyramid": False,
+            "visible": False,
+        }
+
+    return [(data, meta)]
+
+
+def get_reader(path: PathLike, compute: bool) -> Optional[ReaderFunction]:
+    """
+    Given a single path or list of paths, return the appropriate aicsimageio reader.
+    """
+    # Standardize path to list of paths
+    paths = [path] if isinstance(path, str) else path
+
+    # See if there is a supported reader for the file(s) provided
+    try:
+        # There is an assumption that the images are stackable and
+        # I think it is also safe to assume that if stackable, they are of the same type
+        # So only determine reader for the first one
+        AICSImage.determine_reader(paths[0])
+
+        # The above line didn't error so we know we have a supported reader
+        # Return a partial function with compute determined
+        return partial(reader_function, compute=compute)
+
+    # No supported reader, return None
+    except exceptions.UnsupportedFileFormatError:
+        return None

--- a/aicsimageio/tests/plugins/__init__.py
+++ b/aicsimageio/tests/plugins/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/tests/plugins/napari/__init__.py
+++ b/aicsimageio/tests/plugins/napari/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/tests/plugins/napari/test_napari.py
+++ b/aicsimageio/tests/plugins/napari/test_napari.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from aicsimageio.plugins.napari import utils
+
+from ...test_aics_image import (BIG_CZI_FILE, BIG_OME_FILE, CZI_FILE, GIF_FILE,
+                                MED_TIF_FILE, OME_FILE, PNG_FILE, TIF_FILE)
+
+
+@pytest.mark.parametrize("filename, compute, expected_dtype, expected_shape, expected_channel_axis", [
+    (PNG_FILE, True, np.ndarray, (1, 1, 1), None),
+    (GIF_FILE, True, np.ndarray, (1, 1, 1), None),
+    (CZI_FILE, True, np.ndarray, (1, 325, 475), None),
+    (CZI_FILE, False, da.core.Array, (1, 325, 475), None),
+    (OME_FILE, True, np.ndarray, (1, 325, 475), None),
+    (OME_FILE, False, da.core.Array, (1, 325, 475), None),
+    (TIF_FILE, True, np.ndarray, (1, 325, 475), None),
+    (TIF_FILE, False, da.core.Array, (1, 325, 475), None),
+    ([CZI_FILE, CZI_FILE], True, np.ndarray, (2, 325, 475), None),
+    ([CZI_FILE, CZI_FILE], False, da.core.Array, (2, 325, 475), None),
+    (MED_TIF_FILE, False, da.core.Array, (1, 10, 3, 325, 475), None),
+    (BIG_CZI_FILE, False, da.core.Array, (1, 3, 3, 5, 325, 475), None),
+    (BIG_OME_FILE, False, da.core.Array, (1, 3, 5, 3, 325, 475), None),
+])
+def test_reader(resources_dir, filename, compute, expected_dtype, expected_shape, expected_channel_axis):
+    # Append filename(s) to resources dir
+    if isinstance(filename, str):
+        path = str(resources_dir / filename)
+    else:
+        path = [str(resources_dir / _path) for _path in filename]
+
+    # Get reader
+    reader = utils.get_reader(path, compute, processes=False)
+
+    # Check callable
+    assert callable(reader)
+
+    # Get data
+    layer_data = reader(path)
+
+    # We only return one layer
+    data, _ = layer_data[0]
+
+    # Check layer data
+    assert isinstance(data, expected_dtype)
+    assert data.shape == expected_shape

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,12 @@ setup(
         "Python library for reading and writing image data with special handlers for bio-formats "
         "from Allen Institute for Cell Science."
     ),
-    entry_points={},
+    entry_points={
+        "napari.plugin": [
+            "aicsimageio = aicsimageio.plugins.napari.in_memory",
+            # "aicsimageio_delayed = aicsimageio.plugins.napari.delayed",
+        ],
+    },
     install_requires=requirements,
     license="BSD-3-Clause",
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     entry_points={
         "napari.plugin": [
             "aicsimageio = aicsimageio.plugins.napari.in_memory",
-            # "aicsimageio_delayed = aicsimageio.plugins.napari.delayed",
+            "aicsimageio_delayed = aicsimageio.plugins.napari.delayed",
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.

[napari](https://github.com/napari) has added custom plugins! Their team is cool, napari is cool, it would be nice to have a plugin for the library. It was pretty easy to setup [after some initial confusions](https://github.com/napari/cookiecutter-napari-plugin/issues/4).

This plugin is instantly exposed to `napari` if the user has `aicsimageio` installed.

There are two planned plugin options:
* `aicsimageio`
* `aicsimageio_delayed`

The reason the `delayed` option is commented out right now is because until the plugin manager has been added to `napari` I think it's best to always use the in-memory option.

There are some details available on why each one is there available on the README changes of this PR.

By default the image channels are turned off so that initial load is fast after the data has loaded (and because seeing 4+ channels at a time can be difficult to comprehend what is going on in the image)

- [x] Provide relevant tests for your feature or bug fix.

All tests pass except for the fact that there are known file formats that don't work until future patches because their readers are missing the `get_channel_names` function. See #86

- [x] Provide or update documentation for any feature added by your pull request.

**To test this out:**
```bash
git fetch
git checkout feature/napari-plugin
pip install -e .
pip install git+https://github.com/napari/napari.git
napari
```

Then load a file from the UI.

**Potential future additions:**
From my understanding, the ["labels" layer](https://github.com/napari/napari/blob/master/napari/layers/labels/labels.py#L16) is something we could _heavily_ utilize. From initial thinking, we could check channel names for `_seg`, or `segmentation` and then assume those channels go on the labels layer. Just a thought, feedback appreciated.
