### PR TITLE
feature/add-get-channel-names-to-base-reader

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -461,7 +461,16 @@ class AICSImage:
         channels_names: List[str]
             List of strings representing the channel names.
         """
-        return self.reader.get_channel_names(scene)
+        # Get channel names from reader
+        channel_names = self.reader.get_channel_names(scene)
+
+        # Unlike the readers, AICSImage objects always have a channel dimension
+        # In the case the base reader returns None, return a list of "0"
+        if channel_names is None:
+            return ["0"]
+
+        # Return the read channel names
+        return channel_names
 
     def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         """

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -467,7 +467,7 @@ class AICSImage:
         # Unlike the readers, AICSImage objects always have a channel dimension
         # In the case the base reader returns None, return a list of "0"
         if channel_names is None:
-            [str(i) for i in range(self.size_c)]
+            return [str(i) for i in range(self.size_c)]
 
         # Return the read channel names
         return channel_names

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -467,7 +467,7 @@ class AICSImage:
         # Unlike the readers, AICSImage objects always have a channel dimension
         # In the case the base reader returns None, return a list of "0"
         if channel_names is None:
-            return ["0"]
+            [str(i) for i in range(self.size_c)]
 
         # Return the read channel names
         return channel_names

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -461,10 +461,7 @@ class AICSImage:
         channels_names: List[str]
             List of strings representing the channel names.
         """
-        try:
-            return self.reader.get_channel_names(scene)
-        except AttributeError:
-            return [str(i) for i in range(self.size_c)]
+        return self.reader.get_channel_names(scene)
 
     def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         """

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -3,7 +3,7 @@
 
 import io
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import dask.array as da
 import imageio
@@ -11,6 +11,7 @@ import numpy as np
 from dask import delayed
 
 from .. import exceptions
+from ..constants import Dimensions
 from .reader import Reader
 
 ###############################################################################
@@ -110,6 +111,22 @@ class DefaultReader(Reader):
                 self._metadata = reader.get_meta_data()
 
         return self._metadata
+
+    def get_channel_names(self, scene: int = 0) -> Optional[List[str]]:
+        # Check for channel in dims
+        if Dimensions.Channel in self.dims:
+            channel_index = self.dims.index(Dimensions.Channel)
+            channel_dim_size = self.dask_data.shape[channel_index]
+
+            # RGB vs RGBA vs other
+            if channel_dim_size == 3:
+                return ["Red", "Green", "Blue"]
+            elif channel_dim_size == 4:
+                return ["Red", "Green", "Blue", "Alpha"]
+            else:
+                return [str(i) for i in range(channel_dim_size)]
+
+        return None
 
     @staticmethod
     def _is_this_type(buffer: io.BytesIO) -> bool:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -163,13 +163,14 @@ class Reader(ABC):
             List of strings representing the channel names.
             If channel dimension not present in file, return None.
         """
-        # Check for channel in dims
-        if Dimensions.Channel in self.dims:
-            channel_index = self.dims.index(Dimensions.Channel)
-            channel_dim_size = self.dask_data.shape[channel_index]
-            return [str(i) for i in range(channel_dim_size)]
+        # Check for channels dimension
+        if Dimensions.Channel not in self.dims:
+            return None
 
-        return None
+        # Channel dimension in reader data, get default channel names
+        channel_index = self.dims.index(Dimensions.Channel)
+        channel_dim_size = self.dask_data.shape[channel_index]
+        return [str(i) for i in range(channel_dim_size)]
 
     @property
     def cluster(self) -> Optional["distributed.LocalCluster"]:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -161,7 +161,7 @@ class Reader(ABC):
         -------
         channels_names: Optional[List[str]]
             List of strings representing the channel names.
-            If channel dimension not present in file, return's None.
+            If channel dimension not present in file, return None.
         """
         # Check for channel in dims
         if Dimensions.Channel in self.dims:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -5,7 +5,7 @@ import io
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -147,6 +147,29 @@ class Reader(ABC):
             Tuple of floats representing the pixel sizes for X, Y, Z, in that order.
         """
         return (1.0, 1.0, 1.0)
+
+    def get_channel_names(self, scene: int = 0) -> Optional[List[str]]:
+        """
+        Attempts to use the image's metadata to get the image's channel names.
+
+        Parameters
+        ----------
+        scene: int
+            The index of the scene for which to return channel names.
+
+        Returns
+        -------
+        channels_names: Optional[List[str]]
+            List of strings representing the channel names.
+            If channel dimension not present in file, return's None.
+        """
+        # Check for channel in dims
+        if Dimensions.Channel in self.dims:
+            channel_index = self.dims.index(Dimensions.Channel)
+            channel_dim_size = self.dask_data.shape[channel_index]
+            return [str(i) for i in range(channel_dim_size)]
+
+        return None
 
     @property
     def cluster(self) -> Optional["distributed.LocalCluster"]:

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -327,6 +327,7 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
     with Profiler() as prof:
         img = AICSImage(f)
         assert img.get_channel_names() == expected_channel_names
+        assert len(img.get_channel_names()) == img.size_c
 
         # Check that basic details don't require task computation
         assert len(prof.results) == 0

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -308,7 +308,7 @@ def test_large_imread_dask(resources_dir, filename, expected_shape, expected_tas
         (PNG_FILE, ["Red", "Green", "Blue", "Alpha"]),
         (GIF_FILE, ["Red", "Green", "Blue", "Alpha"]),
         (JPG_FILE, ["Red", "Green", "Blue"]),
-        (TIF_FILE, None),
+        (TIF_FILE, ["0"]),
         (MED_TIF_FILE, ["0", "1", "2"]),
         (CZI_FILE, ["Bright"]),
         (OME_FILE, ["Bright"]),

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -305,10 +305,14 @@ def test_large_imread_dask(resources_dir, filename, expected_shape, expected_tas
 @pytest.mark.parametrize(
     "filename, expected_channel_names",
     [
-        (PNG_FILE, ["0", "1", "2", "3"]),
-        (TIF_FILE, ["0"]),
+        (PNG_FILE, ["Red", "Green", "Blue", "Alpha"]),
+        (GIF_FILE, ["Red", "Green", "Blue", "Alpha"]),
+        (JPG_FILE, ["Red", "Green", "Blue"]),
+        (TIF_FILE, None),
+        (MED_TIF_FILE, ["0", "1", "2"]),
         (CZI_FILE, ["Bright"]),
         (OME_FILE, ["Bright"]),
+        (BIG_CZI_FILE, ["EGFP", "TaRFP", "Bright"])
     ],
 )
 def test_channel_names(resources_dir, filename, expected_channel_names):


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #86 

- [x] Provide context of changes.

Follow the spec from `get_physical_pixel_size` to expose the function on the base reader then mutate on inheriting readers for `get_channel_names`. All readers will now at a minimum return a `List[str]` for `n` channels they contain or `None` when no channel dimension present.

The one weird case here is that `AICSImage` object always expand to fill dimensions `STCZYX` with `1` dimensions. So while the readers can return `None` the `AICSImage` case returns `["0"]` if the child reader returns `None`.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
