### PR TITLE
feature/deprecate-context-manager-cluster-spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,26 +77,20 @@ either of those are, there are some utility functions to help construct and mana
 ```python
 from aicsimageio import AICSImage, dask_utils
 
-# Create a local dask cluster and client for the duration of the context manager
-with AICSImage("filename.ome.tiff") as img:
-    # do your work like normal
-    print(img.dask_data.shape)
-
-# Specify arguments for the local cluster initialization
-with AICSImage("filename.ome.tiff", dask_kwargs={"nworkers": 4}) as img:
-    # do your work like normal
-    print(img.dask_data.shape)
-
-# Connect to a dask client for the duration of the context manager
-with AICSImage("filename.ome.tiff", dask_kwargs={"address": "tcp://localhost:12345"}) as img:
-    # do your work like normal
-    print(img.dask_data.shape)
-
-# Or spawn a local cluster and / or connect to a client outside of a context manager
-# This uses the same "address" and dask kwargs as above
-# If you pass an address in, it will create and shutdown the client and no cluster will be created.
-# Similar to AICSImage, these objects will be connected and useable for the lifespan of the context manager.
+# Spawn a local cluster
+# These objects will be connected and useable for the lifespan of the context manager.
 with dask_utils.cluster_and_client() as (cluster, client):
+
+    img1 = AICSImage("1.tiff")
+    img2 = AICSImage("2.tiff")
+    img3 = AICSImage("3.tiff")
+
+    # Do your image processing work
+
+# Connect to a remote cluster
+# If you pass an address in, it will create and shutdown the client and no cluster will be created.
+# These objects will be connected and useable for the lifespan of the context manager.
+with dask_utils.cluster_and_client(address="tcp://localhost:1234") as (cluster, client):
 
     img1 = AICSImage("1.tiff")
     img2 = AICSImage("2.tiff")
@@ -105,8 +99,8 @@ with dask_utils.cluster_and_client() as (cluster, client):
     # Do your image processing work
 ```
 
-_**Note:** The `AICSImage` context manager and the `dask_utils` module require that the processing machine or container
-have networking capabilities enabled to function properly._
+_**Note:** The `dask_utils` module requires that the processing machine or container have networking capabilities
+enabled to function properly._
 
 ### Metadata Reading
 ```python

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import warnings
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, List, Optional, Tuple, Type
 
 import dask.array as da
 import numpy as np
@@ -34,7 +33,6 @@ class AICSImage:
         self,
         data: types.ImageLike,
         known_dims: Optional[str] = None,
-        dask_kwargs: Dict[str, Any] = {},
         **kwargs
     ):
         """
@@ -50,11 +48,8 @@ class AICSImage:
             String with path to file, numpy.ndarray, or dask.array.Array with up to six dimensions.
         known_dims: Optional[str]
             Optional string with the known dimension order. If None, the reader will attempt to parse dim order.
-        dask_kwargs: Dict[str, Any] = {}
-            A dictionary of arguments to pass to a dask cluster and or client.
         kwargs: Dict[str, Any]
-            Extra keyword arguments that can be passed down to either the reader subclass or, if using the context
-            manager, the LocalCluster initialization.
+            Extra keyword arguments that can be passed down to either the reader subclass
 
         Examples
         --------
@@ -78,27 +73,8 @@ class AICSImage:
 
         >>> img = AICSImage("my_file.czi", chunk_by_dims=["T", "Y", "X"])
 
-        Create a local dask cluster for the duration of the context manager.
-
-        >>> with AICSImage("filename.ome.tiff") as img:
-        ...     data = img.get_image_data("ZYX", S=0, T=0, C=0)
-
-        Create a local dask cluster with arguments for the duration of the context manager.
-
-        >>> with AICSImage("filename.ome.tiff", dask_kwargs={"nworkers": 4}) as img:
-        ...     data = img.get_image_data("ZYX", S=0, T=0, C=0)
-
-        Connect to a specific dask cluster for the duration of the context manager.
-
-        >>> with AICSImage("filename.ome.tiff", dask_kwargs={"address": "tcp://localhost:1234"}) as img:
-        ...     data = img.get_image_data("ZYX", S=0, T=0, C=0)
-        ```
-
         Notes
         -----
-        When using the AICSImage context manager, the processing machine or container must have networking capabilities
-        enabled to function properly.
-
         Constructor for AICSImage class intended for providing a unified interface for dealing with
         microscopy images. To extend support to a new reader simply add a new reader child class of
         Reader ([readers/reader.py]) and add the class to SUPPORTED_READERS variable.
@@ -124,11 +100,6 @@ class AICSImage:
         # Lazy load data from reader and reformat to standard dimensions
         self._dask_data = None
         self._data = None
-
-        # Store dask client and cluster setup
-        self._dask_kwargs = dask_kwargs
-        self._client = None
-        self._cluster = None
 
     @staticmethod
     def determine_reader(data: types.ImageLike) -> Type[Reader]:
@@ -492,53 +463,11 @@ class AICSImage:
     def __repr__(self) -> str:
         return f"<AICSImage [{type(self.reader).__name__}]>"
 
-    @property
-    def cluster(self) -> Optional["distributed.LocalCluster"]:
-        """
-        If this object created a local Dask cluster, return it.
-        """
-        return self._cluster
-
-    @property
-    def client(self) -> Optional["distributed.Client"]:
-        """
-        If connected to a Dask cluster, return the connected Client.
-        """
-        return self._client
-
-    def close(self):
-        """
-        Close the connection to the Dask distributed Client.
-        If this object created a LocalCluster, close it down as well.
-        """
-        from . import dask_utils
-        self._cluster, self._client = dask_utils.shutdown_cluster_and_client(self.cluster, self.client)
-
     def __enter__(self):
-        """
-        If provided an address, create a Dask Client connection.
-        If not provided an address, create a LocalCluster and Client connection.
-        If not provided an address, other Dask kwargs are accepted and passed down to the LocalCluster object.
-        """
-        # Warn of future changes to API
-        warnings.warn(
-            "In aicsimageio>=3.2.*, the AICSImage context manager will no longer construct and manage a distributed "
-            "local dask cluster for you. If this functionality is desired for your work, please switch to explictly "
-            "calling the `aicsimageio.dask_utils.cluster_and_client` context manager.",
-            FutureWarning
-        )
-
-        from . import dask_utils
-        self._cluster, self._client = dask_utils.spawn_cluster_and_client(**self._dask_kwargs)
-
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        Always close the Dask Client connection.
-        If connected to *strictly* a LocalCluster, close it down as well.
-        """
-        self.close()
+        pass
 
 
 def imread_dask(data: types.ImageLike, **kwargs) -> da.core.Array:

--- a/aicsimageio/tests/test_dask_utils.py
+++ b/aicsimageio/tests/test_dask_utils.py
@@ -4,47 +4,8 @@
 import sys
 
 import pytest
-from distributed import get_client
 
 from .test_aics_image import CZI_FILE, OME_FILE, PNG_FILE, TIF_FILE
-
-
-def test_aicsimage_context_manager(resources_dir):
-    from aicsimageio import AICSImage
-
-    # Ensure that no dask cluster or client is available before
-    with pytest.raises(ValueError):
-        get_client()
-
-    # Load the image in a context manager that spawn and closes a cluster and client
-    # Processes = False informs dask to use threads instead of processes
-    # We must use threads here to make sure we can properly run codecov
-    with AICSImage(resources_dir / "s_3_t_1_c_3_z_5.czi", dask_kwargs={"processes": False}) as image:
-        assert get_client() is not None
-        assert image.data.shape == (3, 1, 3, 5, 325, 475)
-
-    # Ensure that no dask cluster or client is available after
-    with pytest.raises(ValueError):
-        get_client()
-
-
-def test_reader_context_manager(resources_dir):
-    from aicsimageio.readers import CziReader
-
-    # Ensure that no dask cluster or client is available before
-    with pytest.raises(ValueError):
-        get_client()
-
-    # Load the image in a context manager that spawn and closes a cluster and client
-    # Processes = False informs dask to use threads instead of processes
-    # We must use threads here to make sure we can properly run codecov
-    with CziReader(resources_dir / "s_3_t_1_c_3_z_5.czi", dask_kwargs={"processes": False}) as reader:
-        assert get_client() is not None
-        assert reader.data.shape == (1, 3, 3, 5, 325, 475)
-
-    # Ensure that no dask cluster or client is available after
-    with pytest.raises(ValueError):
-        get_client()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #91 

- [x] Provide context of changes.

Keeps the context manager existence so that we simply just have it there in the case we want to add something there in 4.0 but removes the cluster and client spawning during object context and so that it isn't _too_ much of a breaking change. Updates documentation on the README to only use full `dask_utils` examples.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
