### PR TITLE
feature/read-leica-lif-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ ENV/
 .spyderproject
 .spyproject
 
+# Pycharm project stuff
+.idea
 # Rope project settings
 .ropeproject
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Python library for reading and writing image data with specific support for ha
     * `CZI`
     * `OME-TIFF`
     * `TIFF`
+    * `LIF`
     * Any additional format supported by [`imageio`](https://github.com/imageio/imageio)
 * Supports writing metadata and imaging data for:
     * `OME-TIFF`

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -12,8 +12,8 @@ from . import transforms, types
 from .constants import Dimensions
 from .exceptions import (InvalidDimensionOrderingError,
                          UnsupportedFileFormatError)
-from .readers import (ArrayLikeReader, CziReader, DefaultReader, OmeTiffReader,
-                      TiffReader)
+from .readers import (ArrayLikeReader, CziReader, LifReader, DefaultReader,
+                      OmeTiffReader, TiffReader)
 from .readers.reader import Reader
 
 ###############################################################################
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 # The order of the readers in this list is important.
 # Example: if TiffReader was placed before OmeTiffReader, we would never hit the OmeTiffReader.
-SUPPORTED_READERS = [ArrayLikeReader, CziReader, OmeTiffReader, TiffReader, DefaultReader]
+SUPPORTED_READERS = [ArrayLikeReader, CziReader, LifReader, OmeTiffReader, TiffReader, DefaultReader]
 
 ###############################################################################
 

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -42,3 +42,10 @@ class InconsistentShapeError(Exception):
     A general function to use when the shape returned or requested from an array operation is invalid.
     """
     pass
+
+
+class InconsistentPixelType(Exception):
+    """
+    This exception is returned when the metadata has conflicting pixel types.
+    """
+    pass

--- a/aicsimageio/readers/__init__.py
+++ b/aicsimageio/readers/__init__.py
@@ -3,6 +3,7 @@
 
 from .arraylike_reader import ArrayLikeReader  # noqa: F401
 from .czi_reader import CziReader  # noqa: F401
+from .lif_reader import LifReader  # noqa: F401
 from .default_reader import DefaultReader  # noqa: F401
 from .ome_tiff_reader import OmeTiffReader  # noqa: F401
 from .tiff_reader import TiffReader  # noqa: F401

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -731,7 +731,7 @@ class LifReader(Reader):
 
     def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         """
-        Get the (X, Y, Z) pixel size. If the value is not set it returns the 1.0.
+        Get the (X, Y, Z) pixel size. If the value is not set it returns 1.0.
 
         Parameters
         ----------

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -267,12 +267,8 @@ class LifReader(Reader):
             The appropriate data type to construct the matrix with.
 
         """
-        ############################
-        #
         #  Due to the 12 bit values being stored in a uint16 the raw data is a little fussy to get the
         #  contrast correct.
-        #
-        ############################
         p_types = {8: np.uint8,
                    12: np.dtype('<u2'),  # little endian uint16
                    16: np.dtype('<u2'),  # little endian uint16

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -49,9 +49,9 @@ class LifReader(Reader):
 
     ########################################################
     #
-    #  Note LifFile treats scenes as separate images in the lif file.
-    #  So once a Scene/Image is loaded the image data is retrieved
-    #  2D YX plane by 2D YX plane.
+    #  Note LifFile (the underlying library of this Reader) only allows for
+    #  reading a single YX plane at a time, unlike other underlying libraries
+    #  such as tiffffile or aicspylibczi that allow for reading n-dim chunk reading.
     #
     ########################################################
 

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -51,10 +51,7 @@ class LifReader(Reader):
     #
     #  Note the lif treats scenes as separate images in the lif file.
     #  Also once a Scene/Image is loaded the image data is retrieved
-    #  2D XY plane by 2D XY plane meaning that if you have a Z stack.
-    #  concretely if you have loaded an image into img and you then
-    #  attempt to retrieve the XY plane with get_frame(c=0, t=0) and the
-    #  image has 20 z slices get_frame will assume z=0 is the slice you want.
+    #  2D YX plane by 2D YX plane meaning that if you have a Z stack.
     #
     ########################################################
 
@@ -682,7 +679,7 @@ class LifReader(Reader):
         Returns
         -------
         Dict[Dimension: range]
-            These ranges can then be used to iterate through the specified XY images
+            These ranges can then be used to iterate through the specified YX images
 
         """
         if read_dims is None:
@@ -709,8 +706,8 @@ class LifReader(Reader):
     @staticmethod
     def _compute_offsets(lif: LifFile) -> Tuple[List[np.ndarray], np.ndarray]:
         """
-        Compute the offsets for each of the XY planes so that the LifFile object doesn't need
-        to be created for each XY image read.
+        Compute the offsets for each of the YX planes so that the LifFile object doesn't need
+        to be created for each YX image read.
 
         Parameters
         ----------

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import io
+import logging
+import lxml
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import dask.array as da
+import numpy as np
+from readlif.reader import LifFile, LifImage
+from readlif import reader, utilities
+from dask import delayed
+from lxml.etree import _Element
+
+from .. import exceptions, types
+from ..buffer_reader import BufferReader
+from ..constants import Dimensions
+from .reader import Reader
+
+###############################################################################
+
+log = logging.getLogger(__name__)
+
+###############################################################################
+
+
+class LifReader(Reader):
+    """
+    LifReader wraps readlif.reader to provide the same reading capabilities but abstracts the specifics of using the
+    backend library to create a unified interface. This enables higher level functions to duck type the File Readers.
+
+    Parameters
+    ----------
+    data: types.FileLike
+        A string or path to the CZI file to be read.
+    chunk_by_dims: List[str]
+        The dimensions to use as the for mapping the chunks / blocks.
+        Default: [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX]
+        Note: SpatialY and SpatialX will always be added to the list if not present.
+    S: int
+        If the image has different dimensions on any scene from another, the dask array construction will fail.
+        In that case, use this parameter to specify a specific scene to construct a dask array for.
+        Default: 0 (select the first scene)
+    """
+
+    LIF_MAGIC_BYTE = 0x70
+    LIF_MEMORY_BYTE = 0x2a
+
+    ########################################################
+    #
+    #  Note the lif treats scenes as separate images in the lif file.
+    #  Also once a Scene/Image is loaded the image data is retrieved
+    #  2D XY plane by 2D XY plane meaning that if you have a Z stack.
+    #  concretely if you have loaded an image into img and you then
+    #  attempt to retrieve the XY plane with get_frame(c=0, t=0) and the
+    #  image has 20 z slices get_frame will assume z=0 is the slice you want.
+    #
+    ########################################################
+
+    def __init__(
+        self,
+        data: types.FileLike,
+        chunk_by_dims: List[str] = [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX],
+        S: int = 0,
+        **kwargs
+    ):
+        # Run super init to check filepath provided
+        super().__init__(data, **kwargs)
+
+        # Store parameters needed for _daread
+        self.chunk_by_dims = chunk_by_dims
+        self.specific_s_index = S
+        lif = LifFile(filename=self._file)
+        self._chunk_offsets, self._chunk_lengths = LifReader._compute_offsets(lif=lif)
+
+    @staticmethod
+    def _is_this_type(buffer: io.BytesIO) -> bool:
+        with BufferReader(buffer) as buffer_reader:
+            header = buffer_reader.read_bytes(n_bytes=8)
+
+            if len(buffer_reader.endianness) < 2 or len(header) < 8:
+                return False
+            if buffer_reader.endianness[0] != LifReader.LIF_MAGIC_BYTE and header[1] != LifReader.LIF_MAGIC_BYTE:
+                return False
+            if header[6] == LifReader.LIF_MEMORY_BYTE:
+                return True
+        return False
+
+    @staticmethod
+    def _read_image(img: Path, offsets: np.ndarray, r_length: np.ndarray, read_dims: Optional[Dict[str, int]] = None) -> Tuple[np.ndarray, List[Tuple[str, int]]]:
+        """
+        Read and return the squeezed image data requested along with the dimension info that was read.
+
+        Parameters
+        ----------
+        img: Path
+            Path to the LIF file to read.
+        read_dims: Optional[Dict[str, int]]
+            The dimensions to read from the file as a dictionary of string to integer.
+            Default: None (Read all data from the image)
+
+        Returns
+        -------
+        data: np.ndarray
+            The data read for the dimensions provided.
+        read_dimensions: List[Tuple[str, int]]]
+            The dimension sizes that were returned from the read.
+        """
+        # Catch optional read dim
+        if read_dims is None:
+            read_dims = {}
+
+        # Init czi
+        # lif = LifFile(img)
+
+        # Read image
+        log.debug(f"Reading dimensions: {read_dims}")
+        data, dims = LifReader._get_item_as_bitmap(img, offsets, r_length, **read_dims)
+
+        return data, dims  # the data and dims, dimensions with fixed index have been squeezed out
+
+    @staticmethod
+    def _imread(img: Path, offsets: np.ndarray, r_length: np.ndarray, read_dims: Optional[Dict[str, str]] = None) -> np.ndarray:
+        data, dims = LifReader._read_image(img=img,
+                                           offsets=offsets,
+                                           r_length=r_length,
+                                           read_dims=read_dims
+                                           )
+        return data
+
+    @staticmethod
+    def _dims_shape(lif: LifFile):
+        shape_list = [{'T': (0, img.nt),
+                       'C': (0, img.channels),
+                       'Z': (0, img.nz),
+                       'Y': (0, img.dims[1]),
+                       'X': (0, img.dims[0])}
+                      for idx, img in enumerate(lif.get_iter_image())]
+        consistent = all(elem == shape_list[0] for elem in shape_list)
+        if consistent:
+            shape_list[0]['S'] = (0, len(shape_list))
+            shape_list = [shape_list[0]]
+        else:
+            for idx, lst in enumerate(shape_list):
+                lst['S'] = (idx, idx+1)
+        return shape_list
+
+    @staticmethod
+    def _daread(
+        img: Path,
+        lif: LifFile,
+        offsets: np.ndarray,
+        r_length: np.ndarray,
+        chunk_by_dims: List[str] = [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX],
+        S: int = 0
+    ) -> Tuple[da.core.Array, str]:
+        """
+        Read a CZI image file as a delayed dask array where certain dimensions act as the chunk size.
+
+        Parameters
+        ----------
+        img: Path
+            The filepath to read.
+        czi: CziFile
+            The loaded CziFile object created from reading the filepath.
+        chunk_by_dims: List[str]
+            The dimensions to use as the for mapping the chunks / blocks.
+            Default: [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX]
+            Note: SpatialY and SpatialX will always be added to the list if not present.
+        S: int
+            If the image has different dimensions on any scene from another, the dask array construction will fail.
+            In that case, use this parameter to specify a specific scene to construct a dask array for.
+            Default: 0 (select the first scene)
+
+        Returns
+        -------
+        img: dask.array.core.Array
+            The constructed dask array where certain dimensions are chunked.
+        dims: str
+            The dimension order as a string.
+        """
+        # Get image dims indicies
+        image_dim_indices = LifReader._dims_shape(lif=lif)
+
+        # Catch inconsistent scene dimension sizes
+        if len(image_dim_indices) > 1:
+            # Choose the provided scene
+            try:
+                image_dim_indices = image_dim_indices[S]
+                log.info(f"File contains variable dimensions per scene, selected scene: {S} for data retrieval.")
+            except IndexError:
+                raise exceptions.InconsistentShapeError(
+                    f"The LIF image provided has variable dimensions per scene. "
+                    f"Please provide a valid index to the 'S' parameter to create a dask array for the index provided. "
+                    f"Provided scene index: {S}. Scene index range: 0-{len(image_dim_indices)}."
+                )
+        else:
+            # If the list is length one that means that all the scenes in the image have the same dimensions
+            # Just select the first dictionary in the list
+            image_dim_indices = image_dim_indices[0]
+
+        # Uppercase dimensions provided to chunk by dims
+        chunk_by_dims = [d.upper() for d in chunk_by_dims]
+
+        # Always add Y and X dims to chunk by dims because that is how CZI files work
+        if Dimensions.SpatialY not in chunk_by_dims:
+            log.info(f"Adding the Spatial Y dimension to chunk by dimensions as it was not found.")
+            chunk_by_dims.append(Dimensions.SpatialY)
+        if Dimensions.SpatialX not in chunk_by_dims:
+            log.info(f"Adding the Spatial X dimension to chunk by dimensions as it was not found.")
+            chunk_by_dims.append(Dimensions.SpatialX)
+
+        # Setup read dimensions for an example chunk
+        first_chunk_read_dims = {}
+        for dim, (dim_begin_index, dim_end_index) in image_dim_indices.items():
+            # Only add the dimension if the dimension isn't a part of the chunk
+            if dim not in chunk_by_dims:
+                # Add to read dims
+                first_chunk_read_dims[dim] = dim_begin_index
+
+        # Read first chunk for information used by dask.array.from_delayed
+        sample, sample_dims = LifReader._get_item_as_bitmap(img, offsets, r_length, **first_chunk_read_dims)
+        # lif.read_image(**first_chunk_read_dims)
+
+        # Get the shape for the chunk and operating shape for the dask array
+        # We also collect the chunk and non chunk dimension ordering so that we can swap the dimensions after we
+        # block the dask array together.
+        sample_chunk_shape = []
+        operating_shape = []
+        non_chunk_dimension_ordering = []
+        chunk_dimension_ordering = []
+        for i, dim_info in enumerate(sample_dims):
+            # Unpack dim info
+            dim, size = dim_info
+
+            # If the dim is part of the specified chunk dims then append it to the sample, and, append the dimension
+            # to the chunk dimension ordering
+            if dim in chunk_by_dims:
+                sample_chunk_shape.append(size)
+                chunk_dimension_ordering.append(dim)
+
+            # Otherwise, append the dimension to the non chunk dimension ordering, and, append the true size of the
+            # image at that dimension
+            else:
+                non_chunk_dimension_ordering.append(dim)
+                operating_shape.append(image_dim_indices[dim][1] - image_dim_indices[dim][0])
+
+        # Convert shapes to tuples and combine the non and chunked dimension orders as that is the order the data will
+        # actually come out of the read data as
+        sample_chunk_shape = tuple(sample_chunk_shape)
+        blocked_dimension_order = non_chunk_dimension_ordering + chunk_dimension_ordering
+
+        # Fill out the rest of the operating shape with dimension sizes of 1 to match the length of the sample chunk
+        # When dask.block happens it fills the dimensions from inner-most to outer-most with the chunks as long as
+        # the dimension is size 1
+        # Basically, we are adding empty dimensions to the operating shape that will be filled by the chunks from dask
+        operating_shape = tuple(operating_shape) + (1, ) * len(sample_chunk_shape)
+
+        # Create empty numpy array with the operating shape so that we can iter through and use the multi_index to
+        # create the readers.
+        lazy_arrays = np.ndarray(operating_shape, dtype=object)
+
+        # We can enumerate over the multi-indexed array and construct read_dims dictionaries by simply zipping together
+        # the ordered dims list and the current multi-index plus the begin index for that plane. We then set the value
+        # of the array at the same multi-index to the delayed reader using the constructed read_dims dictionary.
+        dims = [d for d in LifReader.static_dims()]
+        begin_indicies = tuple(image_dim_indices[d][0] for d in dims)
+        for i, _ in np.ndenumerate(lazy_arrays):
+            # Add the czi file begin index for each dimension to the array dimension index
+            this_chunk_read_indicies = (
+                current_dim_begin_index + curr_dim_index
+                for current_dim_begin_index, curr_dim_index in zip(begin_indicies, i)
+            )
+
+            # Zip the dims with the read indices
+            this_chunk_read_dims = dict(zip(blocked_dimension_order, this_chunk_read_indicies))
+
+            # Remove the dimensions that we want to chunk by from the read dims
+            for d in chunk_by_dims:
+                if d in this_chunk_read_dims:
+                    this_chunk_read_dims.pop(d)
+
+            # Add delayed array to lazy arrays at index
+            lazy_arrays[i] = da.from_delayed(
+                delayed(LifReader._imread)(img, offsets, r_length, this_chunk_read_dims),
+                shape=sample_chunk_shape,
+                dtype=sample.dtype,
+            )
+
+        # Convert the numpy array of lazy readers into a dask array and fill the inner-most empty dimensions with chunks
+        merged = da.block(lazy_arrays.tolist())
+
+        # Because we have set certain dimensions to be chunked and others not
+        # we will need to transpose back to original dimension ordering
+        # Example being, if the original dimension ordering was "SZYX" and we want to chunk by "S", "Y", and "X"
+        # We created an array with dimensions ordering "ZSYX"
+        transpose_indices = []
+        transpose_required = False
+        for i, d in enumerate(LifReader.static_dims()):
+            new_index = blocked_dimension_order.index(d)
+            if new_index != i:
+                transpose_required = True
+                transpose_indices.append(new_index)
+            else:
+                transpose_indices.append(i)
+
+        # Only run if the transpose is actually required
+        # The default case is "Z", "Y", "X", which _usually_ doesn't need to be transposed because that is _usually_
+        # The normal dimension order of the CZI file anyway
+        if transpose_required:
+            merged = da.transpose(merged, tuple(transpose_indices))
+
+        # Because dimensions outside of Y and X can be in any order and present or not
+        # we also return the dimension order string.
+        return merged, "".join(dims)
+
+    @staticmethod
+    def _daread_safe(
+        img: Union[str, Path],
+        offsets: np.ndarray,
+        r_length: np.ndarray,
+        chunk_by_dims: List[str] = [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX],
+        S: int = 0
+    ) -> Tuple[da.core.Array, str]:
+        """
+        Safely read a LIF image file as a delayed dask array where certain dimensions act as the chunk size.
+
+        Parameters
+        ----------
+        img: Union[str, Path]
+            The filepath to read.
+        chunk_by_dims: List[str]
+            The dimensions to use as the for mapping the chunks / blocks.
+            Default: [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX]
+            Note: SpatialY and SpatialX will always be added to the list if not present.
+        S: int
+            If the image has different dimensions on any scene from another, the dask array construction will fail.
+            In that case, use this parameter to specify a specific scene to construct a dask array for.
+            Default: 0 (select the first scene)
+
+        Returns
+        -------
+        img: dask.array.core.Array
+            The constructed dask array where certain dimensions are chunked.
+        dims: str
+            The dimension order as a string.
+        """
+        # Resolve image path
+        img = LifReader._resolve_image_path(img)
+
+        # Init temp czi
+        lif = LifFile(img)
+
+        # Safely construct the dask array or catch any exception
+        try:
+            return LifReader._daread(img=img,
+                                     lif=lif,
+                                     offsets=offsets,
+                                     r_length=r_length,
+                                     chunk_by_dims=chunk_by_dims,
+                                     S=S
+                                     )
+
+        except Exception as e:
+            # A really bad way to close any connection to the CZI object
+            lif._bytes = None
+            lif.reader = None
+
+            raise e
+
+    @property
+    def dask_data(self) -> da.core.Array:
+        """
+        Returns
+        -------
+        Constructed dask array where each chunk is a delayed read from the CZI file.
+        Places dimensions in the native order (i.e. "TZCYX")
+        """
+        if self._dask_data is None:
+            self._dask_data, self._dims = LifReader._daread_safe(
+                self._file,
+                self._chunk_offsets,
+                self._chunk_lengths,
+                chunk_by_dims=self.chunk_by_dims,
+                S=self.specific_s_index
+            )
+
+        return self._dask_data
+
+    @staticmethod
+    def static_dims():
+        return "STCZYX"
+
+    @property
+    def dims(self) -> str:
+        return LifReader.static_dims()  # forcing 6 D
+
+    def dtype(self) -> np.dtype:
+        return self.dask_data.dtype
+
+    @property
+    def metadata(self) -> _Element:
+        """
+        Load and return the metadata from the CZI file
+
+        Returns
+        -------
+        The lxml Element Tree of the metadata
+        """
+        # We can't serialize lxml element trees so don't save the tree to the object state
+        if self._metadata:
+            return self._metadata
+
+        self._metadata, header = utilities.get_xml(self._file)
+        return self._metadata
+
+    def _size_of_dimension(self, dim: str) -> int:
+        if dim in self.dims:
+            return self.dask_data.shape[self.dims.index(dim)]
+
+        return 1
+
+    def size_s(self) -> int:
+        return self._size_of_dimension(Dimensions.Scene)
+
+    def size_t(self) -> int:
+        return self._size_of_dimension(Dimensions.Time)
+
+    def size_c(self) -> int:
+        return self._size_of_dimension(Dimensions.Channel)
+
+    def size_z(self) -> int:
+        return self._size_of_dimension(Dimensions.SpatialZ)
+
+    def size_y(self) -> int:
+        return self._size_of_dimension(Dimensions.SpatialY)
+
+    def size_x(self) -> int:
+        return self._size_of_dimension(Dimensions.SpatialX)
+
+    @staticmethod
+    def get_pixel_type(meta: _Element, scene: int = 0):
+        p_types = {8: np.uint8, 16: np.uint16, 32: np.uint32, 64: np.uint64}
+        img_sets = meta.findall(".//Image")
+
+        img = img_sets[scene]
+        chs = img.findall(".//ChannelDescription")
+        resolution = set([ch.attrib['Resolution'] for ch in chs])
+        if len(resolution) != 1:
+            raise exceptions.InconsistentPixelType(f"Metadata contains two conflicting "
+                                                   f"Resolution attributes: {resolution}")
+
+        return p_types[int(resolution.pop())]
+
+    def get_channel_names(self, scene: int = 0):
+        # for the remove to work the
+        img_sets = self.metadata.findall(".//Image")
+
+        img = img_sets[scene]
+        scene_channel_list = []
+        chs = img.findall(".//ChannelDescription")
+        chs_details = img.findall(".//WideFieldChannelInfo")
+        for ch in chs:
+            ch_detail = next(x for x in chs_details if x.attrib["LUT"] == ch.attrib["LUTName"])
+            scene_channel_list.append((f"{ch_detail.attrib['LUT']}--{ch_detail.attrib['ContrastingMethodName']}"
+                                       f"--{ch_detail.attrib['FluoCubeName']}"))
+        return scene_channel_list
+
+    # TODO refactor this utility function into a metadata wrapper class
+    def _getmetadataxmltext(self, findpath, default=None):
+        ref = self.metadata.find(findpath)
+        if ref is None:
+            return default
+        return ref.text
+
+    def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
+        # for the remove to work the
+        img_sets = self.metadata.findall(".//Image")
+
+        img = img_sets[scene]
+        scene_pixel_size = [1.0, 1.0, 1.0]
+        dim_list = img.findall(".//DimensionDescription")
+        for idx, dim in enumerate(dim_list):
+            scene_pixel_size[idx] = (abs(1000000.0*float(dim.attrib['Length']))/(float(dim.attrib['NumberOfElements'])-1.0))
+        return tuple(scene_pixel_size)
+
+    #  bitmap reader functions
+
+    @staticmethod
+    def _get_item_as_bitmap(im_path: Path, offsets: np.ndarray, r_length: np.ndarray, **kwargs):
+        """
+        Gets specified item from the image set (private).
+        Args:
+            n (int): what item to retrieve
+
+        Returns:
+            PIL image
+        """
+        lif = LifFile(im_path)
+
+        # data has already been checked for consistency. The dims are either consistent or S is specified
+        selected_ranges = LifReader.kwargs_to_ranges(lif, **kwargs)
+        s_index = kwargs[Dimensions.Scene] if Dimensions.Scene in kwargs.keys() else 0
+        lif_img = lif.get_image(img_n=s_index)
+        x_size = lif_img.dims[0]
+        y_size = lif_img.dims[1]
+        lir = LifReader(im_path)
+        pixel_type = lir.get_pixel_type(lir.metadata, s_index)
+
+        ranged_dims = [(dim, len(selected_ranges[dim])) for dim in [Dimensions.Scene,
+                                                                    Dimensions.Time,
+                                                                    Dimensions.Channel,
+                                                                    Dimensions.SpatialZ]
+                       ]
+
+        img_stack = []
+        with open(str(im_path), "rb") as image:
+            for s_index in selected_ranges[Dimensions.Scene]:
+                for t_index in selected_ranges[Dimensions.Time]:
+                    for c_index in selected_ranges[Dimensions.Channel]:
+                        for z_index in selected_ranges[Dimensions.SpatialZ]:
+                            image.seek(offsets[s_index, t_index, c_index, z_index])
+                            byte_array = image.read(r_length[s_index])
+                            img_stack.append(
+                                np.frombuffer(byte_array, dtype=pixel_type).reshape(x_size, y_size).transpose()
+                            )
+
+        shape = [len(selected_ranges[dim[0]]) for dim in ranged_dims]
+        shape.append(y_size)
+        shape.append(x_size)
+        ranged_dims.append((Dimensions.SpatialY, y_size))
+        ranged_dims.append((Dimensions.SpatialX, x_size))
+        return np.array(img_stack).reshape(*shape), ranged_dims  # in some subset of STCZYX order
+
+    @staticmethod
+    def kwargs_to_ranges(lif: LifFile, **kwargs):
+
+        data_shape = LifReader._dims_shape(lif=lif)
+
+        if Dimensions.Scene in kwargs:
+            s_range = range(kwargs[Dimensions.Scene], kwargs[Dimensions.Scene] + 1)
+            s_dict = data_shape[s_range[0]]
+        else:
+            s_range = range(*data_shape[0][Dimensions.Scene])
+            s_dict = data_shape[0]
+
+        ans = {Dimensions.Scene: s_range}
+        for ky in [Dimensions.Time, Dimensions.Channel, Dimensions.SpatialZ]:
+            if ky in kwargs.keys():
+                ans[ky] = range(kwargs[ky], kwargs[ky]+1)
+            else:
+                ans[ky] = range(*s_dict[ky])
+
+        return ans
+
+    @staticmethod
+    def get_frame(img: LifImage, z: int = 0, t: int = 0, c: int = 0):
+        """
+        Gets the specified frame (z, t, c) from image.
+
+        Args:
+            img (LifImage): the Scene/Image within the LifFile
+            z (int): z position
+            t (int): time point
+            c (int): channel
+
+        Returns:
+            Image as a numpy.ndarray (XY) object
+        """
+        t = int(t)
+        c = int(c)
+        z = int(z)
+        if z >= img.nz:
+            raise ValueError("Requested Z frame doesn't exist.")
+        elif t >= img.nt:
+            raise ValueError("Requested T frame doesn't exist.")
+        elif c >= img.channels:
+            raise ValueError("Requested channel doesn't exist.")
+
+        total_items = img.channels * img.nz * img.nt
+
+        t_offset = img.channels * img.nz
+        t_requested = t_offset * t
+
+        z_offset = img.channels
+        z_requested = z_offset * z
+
+        c_requested = c
+
+        item_requested = t_requested + z_requested + c_requested
+        if item_requested > total_items:
+            raise ValueError("The requested item is after the end of the image")
+
+        return LifReader._get_item_as_bitmap(img=img, n=item_requested)
+
+    @staticmethod
+    def _compute_offsets(lif: LifFile) -> Tuple[np.ndarray, np.ndarray]:
+        """
+
+        Parameters
+        ----------
+        lif : LifFile
+            The LifFile object with an open file pointer to the file.
+
+        Returns
+        -------
+        (numpy.ndarray, numpy.ndarray)
+            The first numpy array holds the offsets and it's indexes are in STCZ order.
+            The second numpy array holds the image read length per Scene.
+
+        """
+        s_list = []
+        s_img_length_list = []
+        for img in lif.get_iter_image():
+            offsets = np.zeros(shape=(img.nt, img.channels, img.nz), dtype=np.uint64)
+            t_offset = img.channels * img.nz
+            z_offset = img.channels
+            seek_distance = img.channels * img.dims[2] * img.dims[3]
+            # self.offsets[1] is the length of the image
+            if img.offsets[1] == 0:
+                # In the case of a blank image, we can calculate the length from
+                # the metadata in the LIF. When this is read by the parser,
+                # it is set to zero initially.
+                image_len = seek_distance * img.dims[0] * img.dims[1]
+            else:
+                image_len = int(img.offsets[1] / seek_distance)
+
+            for t_index in range(img.nt):
+                t_requested = t_offset * t_index
+                for c_index in range(img.channels):
+                    c_requested = c_index
+                    for z_index in range(img.nz):
+                        z_requested = z_offset * z_index
+                        item_requested = t_requested + z_requested + c_requested
+                        # self.offsets[0] is the offset in the file
+                        offsets[t_index, c_index, z_index] = img.offsets[0] + image_len * item_requested
+
+            s_list.append(offsets)
+            s_img_length_list.append(image_len)
+
+        return np.asarray(s_list, dtype=np.uint64), np.asarray(s_img_length_list, dtype=np.uint64)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -384,6 +384,8 @@ class LifReader(Reader):
             A List of numpy ndarrays offsets, see _compute_offsets for more details.
         read_lengths: numpy.ndarray
             A 1D numpy array of read lengths, the index is the scene index
+        meta: lxml.etree.Element
+            The root element of the metadata etree from the file.
         read_dims: Optional[Dict[str, int]]
             The dimensions to read from the file as a dictionary of string to integer.
             Default: None (Read all data from the image)
@@ -439,6 +441,8 @@ class LifReader(Reader):
             A List of numpy ndarrays offsets, see _compute_offsets for more details.
         read_lengths: numpy.ndarray
             A 1D numpy array of read lengths, the index is the scene index
+        meta: lxml.etree.Element
+            The root element of the metadata etree from the file.
         read_dims: Optional[Dict[str, int]]
             The dimensions to read from the file as a dictionary of string to integer.
             Default: None (Read all data from the image)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -527,7 +527,11 @@ class LifReader(Reader):
                 first_chunk_read_dims[dim] = dim_begin_index
 
         # Read first chunk for information used by dask.array.from_delayed
-        sample, sample_dims = LifReader._get_item_as_bitmap(img, offsets, read_length, lif.xml_root, first_chunk_read_dims)
+        sample, sample_dims = LifReader._get_item_as_bitmap(im_path=img,
+                                                            offsets=offsets,
+                                                            read_length=read_length,
+                                                            meta=lif.xml_root,
+                                                            read_dims=first_chunk_read_dims)
         # lif.read_image(**first_chunk_read_dims)
 
         # Get the shape for the chunk and operating shape for the dask array

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -110,7 +110,7 @@ class LifReader(Reader):
                         z_requested = z_offset * z_index
                         item_requested = t_requested + z_requested + c_requested
                         # self.offsets[0] is the offset in the file
-                        offsets[t_index, c_index, z_index] = img.offsets[0] + image_len * item_requested
+                        offsets[t_index, c_index, z_index] = np.uint64(img.offsets[0] + image_len * item_requested)
 
             s_list.append(offsets)
             s_img_length_list.append(image_len)
@@ -265,15 +265,12 @@ class LifReader(Reader):
         """
         ############################
         #
-        #  This is super weird to me that resolution=12 and resolution=16 would have different
-        #  byte order meaning given 2 uint8s/chars => AB from the byte array one method combines them
-        #  with ( A << 8 | B ) and the other combines them with ( B << 8 | A ).
-        #  This could be wrong but I haven't found any documentation on the image byte order etc so it's
-        #  currently my best guess.
+        #  Due to the 12 bit values being stored in a uint16 the raw data is a little fussy to get the
+        #  contrast correct.
         #
         ############################
         p_types = {8: np.uint8,
-                   12: np.dtype('>u2'),  # big endian uint16
+                   12: np.dtype('<u2'),  # little endian uint16
                    16: np.dtype('<u2'),  # little endian uint16
                    32: np.dtype('<u4'),  # little endian uint32 ** untested
                    64: np.dtype('<u8')   # little endian uint64 ** untested

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Tuple
 import dask.array as da
 import numpy as np
 from dask import delayed
-from lxml.etree import Element
+from xml.etree.ElementTree import Element
 from readlif import utilities
 from readlif.reader import LifFile
 
@@ -261,7 +261,7 @@ class LifReader(Reader):
 
         Parameters
         ----------
-        meta: lxml.etree.Element
+        meta: xml.etree.ElementTree.Element
             The root Element of the metadata etree
         scene: int
             The index of the scene, scenes could have different storage data types.
@@ -384,7 +384,7 @@ class LifReader(Reader):
             A List of numpy ndarrays offsets, see _compute_offsets for more details.
         read_lengths: numpy.ndarray
             A 1D numpy array of read lengths, the index is the scene index
-        meta: lxml.etree.Element
+        meta: xml.etree.ElementTree.Element
             The root element of the metadata etree from the file.
         read_dims: Optional[Dict[str, int]]
             The dimensions to read from the file as a dictionary of string to integer.
@@ -441,7 +441,7 @@ class LifReader(Reader):
             A List of numpy ndarrays offsets, see _compute_offsets for more details.
         read_lengths: numpy.ndarray
             A 1D numpy array of read lengths, the index is the scene index
-        meta: lxml.etree.Element
+        meta: xml.etree.ElementTree.Element
             The root element of the metadata etree from the file.
         read_dims: Optional[Dict[str, int]]
             The dimensions to read from the file as a dictionary of string to integer.
@@ -672,9 +672,9 @@ class LifReader(Reader):
 
         Returns
         -------
-        The lxml Element Tree of the metadata
+        The xml Element Tree of the metadata
         """
-        # We can't serialize lxml element trees so don't save the tree to the object state
+        # We can't serialize xml element trees so don't save the tree to the object state
         meta_xml, header = utilities.get_xml(self._file)
         return meta_xml
 
@@ -729,16 +729,9 @@ class LifReader(Reader):
                                        f"--{ch_detail.attrib['FluoCubeName']}"))
         return scene_channel_list
 
-    # TODO refactor this utility function into a metadata wrapper class
-    def _getmetadataxmltext(self, findpath, default=None):
-        ref = self.metadata.find(findpath)
-        if ref is None:
-            return default
-        return ref.text
-
     def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
         """
-        Get the (X, Y, Z) pixel size. If the value isn't set it returns the 1.0.
+        Get the (X, Y, Z) pixel size. If the value is not set it returns the 1.0.
 
         Parameters
         ----------
@@ -747,7 +740,7 @@ class LifReader(Reader):
 
         Returns
         -------
-        (X, Y, Z) in µm.
+        (X, Y, Z) in m.
 
         """
         # find all the Image nodes in the xml tree. They correspond to the individual scenes
@@ -767,7 +760,7 @@ class LifReader(Reader):
         for idx, dim in enumerate(dim_list):
             # the formula for the pixel size is
             # pixel_size = Length/(NumberOfElements - 1) from Leica & ImageJ
-            scene_pixel_size[idx] = (abs(1000000.0*float(dim.attrib['Length']))/(
+            scene_pixel_size[idx] = (abs(float(dim.attrib['Length']))/(
                                         float(dim.attrib['NumberOfElements'])-1.0)
                                      )
         return tuple(scene_pixel_size)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -3,21 +3,20 @@
 
 import io
 import logging
-import lxml
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import dask.array as da
 import numpy as np
-from readlif.reader import LifFile, LifImage
-from readlif import reader, utilities
 from dask import delayed
 from lxml.etree import _Element
+from readlif import utilities
+from readlif.reader import LifFile, LifImage
 
+from .reader import Reader
 from .. import exceptions, types
 from ..buffer_reader import BufferReader
 from ..constants import Dimensions
-from .reader import Reader
 
 ###############################################################################
 
@@ -73,23 +72,41 @@ class LifReader(Reader):
         self.chunk_by_dims = chunk_by_dims
         self.specific_s_index = S
         lif = LifFile(filename=self._file)
+        #  _chunk_offsets is a list of ndarrays (only way I could deal with inconsistent scene shape)
         self._chunk_offsets, self._chunk_lengths = LifReader._compute_offsets(lif=lif)
 
     @staticmethod
     def _is_this_type(buffer: io.BytesIO) -> bool:
+        """
+        Test the file that was provided to check that the header is consistent with this reader.
+
+        Parameters
+        ----------
+        buffer: io.BytesIO
+            This is the contents of the file path the LifReader was initialized with.
+
+        Returns
+        -------
+        True / False
+            True if it has the right header byte structure False if it does not.
+
+        """
         with BufferReader(buffer) as buffer_reader:
             header = buffer_reader.read_bytes(n_bytes=8)
 
+            # if the buffer is to short return false
             if len(buffer_reader.endianness) < 2 or len(header) < 8:
                 return False
+            # check for the magic byte
             if buffer_reader.endianness[0] != LifReader.LIF_MAGIC_BYTE and header[1] != LifReader.LIF_MAGIC_BYTE:
                 return False
+            # check for the memory byte, if magic byte and memory byte are present return true
             if header[6] == LifReader.LIF_MEMORY_BYTE:
                 return True
         return False
 
     @staticmethod
-    def _read_image(img: Path, offsets: np.ndarray, r_length: np.ndarray, read_dims: Optional[Dict[str, int]] = None) -> Tuple[np.ndarray, List[Tuple[str, int]]]:
+    def _read_image(img: Path, offsets: List[np.ndarray], r_length: np.ndarray, read_dims: Optional[Dict[str, int]] = None) -> Tuple[np.ndarray, List[Tuple[str, int]]]:
         """
         Read and return the squeezed image data requested along with the dimension info that was read.
 
@@ -97,6 +114,10 @@ class LifReader(Reader):
         ----------
         img: Path
             Path to the LIF file to read.
+        offsets: List[numpy.ndarray]
+            A List of numpy ndarrays offsets, see _compute_offsets for more details.
+        r_length: numpy.ndarray
+            A 1D numpy array of read lengths, the index is the scene index
         read_dims: Optional[Dict[str, int]]
             The dimensions to read from the file as a dictionary of string to integer.
             Default: None (Read all data from the image)
@@ -112,17 +133,51 @@ class LifReader(Reader):
         if read_dims is None:
             read_dims = {}
 
-        # Init czi
-        # lif = LifFile(img)
-
         # Read image
         log.debug(f"Reading dimensions: {read_dims}")
-        data, dims = LifReader._get_item_as_bitmap(img, offsets, r_length, **read_dims)
+        data, dims = LifReader._get_item_as_bitmap(img, offsets, r_length, read_dims)
 
-        return data, dims  # the data and dims, dimensions with fixed index have been squeezed out
+        # Drop dims so that the data dims match the chunk_dims for dask
+        ops = []
+        real_dims = []
+        for i, dim_info in enumerate(dims):
+            # Expand dimension info
+            dim, size = dim_info
+
+            # If the dim was provided in the read dims we know a single plane for that
+            # dimension was requested so remove it
+            if dim in read_dims:
+                ops.append(0)
+            # Otherwise just read the full slice
+            else:
+                ops.append(slice(None, None, None))
+                real_dims.append(dim_info)
+
+        # Convert ops and run getitem
+        return data[tuple(ops)], real_dims
 
     @staticmethod
-    def _imread(img: Path, offsets: np.ndarray, r_length: np.ndarray, read_dims: Optional[Dict[str, str]] = None) -> np.ndarray:
+    def _imread(img: Path, offsets: List[np.ndarray], r_length: np.ndarray, read_dims: Optional[Dict[str, str]] = None) -> np.ndarray:
+        """
+        This function is a pass through to _read_image above
+        the difference is it returns the data without the dims structure.
+        Parameters
+        ----------
+        img: Path
+            Path to the LIF file to read.
+        offsets: List[numpy.ndarray]
+            A List of numpy ndarrays offsets, see _compute_offsets for more details.
+        r_length: numpy.ndarray
+            A 1D numpy array of read lengths, the index is the scene index
+        read_dims: Optional[Dict[str, int]]
+            The dimensions to read from the file as a dictionary of string to integer.
+            Default: None (Read all data from the image)
+
+        Returns
+        -------
+        data: np.ndarray
+            The data read for the dimensions provided.
+        """
         data, dims = LifReader._read_image(img=img,
                                            offsets=offsets,
                                            r_length=r_length,
@@ -132,6 +187,31 @@ class LifReader(Reader):
 
     @staticmethod
     def _dims_shape(lif: LifFile):
+        """
+        Get the dimensions for the opened file from the binary data (not the metadata)
+
+        Parameters
+        ----------
+        lif: LifFile
+
+        Returns
+        -------
+        list[dict]
+            A list of dictionaries containing Dimension / depth. If the shape is consistent across Scenes then
+            the list will have only one Dictionary. If the shape is inconsistent the the list will have a dictionary
+             for each Scene. A consistently shaped file with 3 scenes, 7 time-points
+            and 4 Z slices containing images of (h,w) = (325, 475) would return
+            [
+             {'S': (0, 3), 'T': (0,7), 'X': (0, 475), 'Y': (0, 325), 'Z': (0, 4)}
+            ].
+            The result for a similarly shaped file but with different number of time-points per scene would yield
+            [
+             {'S': (0, 1), 'T': (0,8), 'X': (0, 475), 'Y': (0, 325), 'Z': (0, 4)},
+             {'S': (1, 2), 'T': (0,6), 'X': (0, 475), 'Y': (0, 325), 'Z': (0, 4)},
+             {'S': (2, 3), 'T': (0,7), 'X': (0, 475), 'Y': (0, 325), 'Z': (0, 4)}
+            ]
+
+        """
         shape_list = [{'T': (0, img.nt),
                        'C': (0, img.channels),
                        'Z': (0, img.nz),
@@ -150,21 +230,22 @@ class LifReader(Reader):
     @staticmethod
     def _daread(
         img: Path,
-        lif: LifFile,
-        offsets: np.ndarray,
+        offsets: List[type(np.ndarray)],
         r_length: np.ndarray,
         chunk_by_dims: List[str] = [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX],
         S: int = 0
     ) -> Tuple[da.core.Array, str]:
         """
-        Read a CZI image file as a delayed dask array where certain dimensions act as the chunk size.
+        Read a LIF image file as a delayed dask array where certain dimensions act as the chunk size.
 
         Parameters
         ----------
         img: Path
             The filepath to read.
-        czi: CziFile
-            The loaded CziFile object created from reading the filepath.
+        offsets: List[numpy.ndarray]
+            A List of numpy ndarrays offsets, see _compute_offsets for more details.
+        r_length: numpy.ndarray
+            A 1D numpy array of read lengths, the index is the scene index
         chunk_by_dims: List[str]
             The dimensions to use as the for mapping the chunks / blocks.
             Default: [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX]
@@ -182,6 +263,7 @@ class LifReader(Reader):
             The dimension order as a string.
         """
         # Get image dims indicies
+        lif = LifFile(filename=img)
         image_dim_indices = LifReader._dims_shape(lif=lif)
 
         # Catch inconsistent scene dimension sizes
@@ -221,7 +303,7 @@ class LifReader(Reader):
                 first_chunk_read_dims[dim] = dim_begin_index
 
         # Read first chunk for information used by dask.array.from_delayed
-        sample, sample_dims = LifReader._get_item_as_bitmap(img, offsets, r_length, **first_chunk_read_dims)
+        sample, sample_dims = LifReader._get_item_as_bitmap(img, offsets, r_length, first_chunk_read_dims)
         # lif.read_image(**first_chunk_read_dims)
 
         # Get the shape for the chunk and operating shape for the dask array
@@ -265,7 +347,7 @@ class LifReader(Reader):
         # We can enumerate over the multi-indexed array and construct read_dims dictionaries by simply zipping together
         # the ordered dims list and the current multi-index plus the begin index for that plane. We then set the value
         # of the array at the same multi-index to the delayed reader using the constructed read_dims dictionary.
-        dims = [d for d in LifReader.static_dims()]
+        dims = [d for d in Dimensions.DefaultOrder]
         begin_indicies = tuple(image_dim_indices[d][0] for d in dims)
         for i, _ in np.ndenumerate(lazy_arrays):
             # Add the czi file begin index for each dimension to the array dimension index
@@ -298,7 +380,7 @@ class LifReader(Reader):
         # We created an array with dimensions ordering "ZSYX"
         transpose_indices = []
         transpose_required = False
-        for i, d in enumerate(LifReader.static_dims()):
+        for i, d in enumerate(Dimensions.DefaultOrder):
             new_index = blocked_dimension_order.index(d)
             if new_index != i:
                 transpose_required = True
@@ -316,60 +398,6 @@ class LifReader(Reader):
         # we also return the dimension order string.
         return merged, "".join(dims)
 
-    @staticmethod
-    def _daread_safe(
-        img: Union[str, Path],
-        offsets: np.ndarray,
-        r_length: np.ndarray,
-        chunk_by_dims: List[str] = [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX],
-        S: int = 0
-    ) -> Tuple[da.core.Array, str]:
-        """
-        Safely read a LIF image file as a delayed dask array where certain dimensions act as the chunk size.
-
-        Parameters
-        ----------
-        img: Union[str, Path]
-            The filepath to read.
-        chunk_by_dims: List[str]
-            The dimensions to use as the for mapping the chunks / blocks.
-            Default: [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX]
-            Note: SpatialY and SpatialX will always be added to the list if not present.
-        S: int
-            If the image has different dimensions on any scene from another, the dask array construction will fail.
-            In that case, use this parameter to specify a specific scene to construct a dask array for.
-            Default: 0 (select the first scene)
-
-        Returns
-        -------
-        img: dask.array.core.Array
-            The constructed dask array where certain dimensions are chunked.
-        dims: str
-            The dimension order as a string.
-        """
-        # Resolve image path
-        img = LifReader._resolve_image_path(img)
-
-        # Init temp czi
-        lif = LifFile(img)
-
-        # Safely construct the dask array or catch any exception
-        try:
-            return LifReader._daread(img=img,
-                                     lif=lif,
-                                     offsets=offsets,
-                                     r_length=r_length,
-                                     chunk_by_dims=chunk_by_dims,
-                                     S=S
-                                     )
-
-        except Exception as e:
-            # A really bad way to close any connection to the CZI object
-            lif._bytes = None
-            lif.reader = None
-
-            raise e
-
     @property
     def dask_data(self) -> da.core.Array:
         """
@@ -379,7 +407,7 @@ class LifReader(Reader):
         Places dimensions in the native order (i.e. "TZCYX")
         """
         if self._dask_data is None:
-            self._dask_data, self._dims = LifReader._daread_safe(
+            self._dask_data, self._dims = LifReader._daread(
                 self._file,
                 self._chunk_offsets,
                 self._chunk_lengths,
@@ -389,21 +417,33 @@ class LifReader(Reader):
 
         return self._dask_data
 
-    @staticmethod
-    def static_dims():
-        return "STCZYX"
-
     @property
     def dims(self) -> str:
-        return LifReader.static_dims()  # forcing 6 D
+        """
+        The dimensions for a lif file.
+
+        Returns
+        -------
+        str
+            "STCZYX"
+        """
+        return Dimensions.DefaultOrder  # forcing 6 D
 
     def dtype(self) -> np.dtype:
+        """
+        The data type of the underlying numpy ndarray, ie uint8, uint16, uint32 etc.
+
+        Returns
+        -------
+        numpy.dtype
+            The data format used to store the data in the Leica lif file and the read numpy.ndarray.
+        """
         return self.dask_data.dtype
 
     @property
     def metadata(self) -> _Element:
         """
-        Load and return the metadata from the CZI file
+        Load and return the metadata from the LIF file
 
         Returns
         -------
@@ -441,8 +481,38 @@ class LifReader(Reader):
         return self._size_of_dimension(Dimensions.SpatialX)
 
     @staticmethod
-    def get_pixel_type(meta: _Element, scene: int = 0):
-        p_types = {8: np.uint8, 16: np.uint16, 32: np.uint32, 64: np.uint64}
+    def get_pixel_type(meta: _Element, scene: int = 0) -> np.dtype:
+        """
+        This function parses the metadata to assign the appropriate numpy.dtype
+
+        Parameters
+        ----------
+        meta: lxml.etree.Element
+            The root Element of the metadata etree
+        scene: int
+            The index of the scene, scenes could have different storage data types.
+
+        Returns
+        -------
+        numpy.dtype
+            The appropriate data type to construct the matrix with.
+
+        """
+        ############################
+        #
+        #  This is super weird to me that resolution=12 and resolution=16 would have different
+        #  byte order meaning given 2 uint8s/chars => AB from the byte array one method combines them
+        #  with ( A << 8 | B ) and the other combines them with ( B << 8 | A ).
+        #  This could be wrong but I haven't found any documentation on the image byte order etc so it's
+        #  currently my best guess.
+        #
+        ############################
+        p_types = {8: np.uint8,
+                   12: np.dtype('>u2'),  # big endian uint16
+                   16: np.dtype('<u2'),  # little endian uint16
+                   32: np.dtype('<u4'),  # little endian uint32 ** untested
+                   64: np.dtype('<u8')   # little endian uint64 ** untested
+                   }
         img_sets = meta.findall(".//Image")
 
         img = img_sets[scene]
@@ -454,7 +524,20 @@ class LifReader(Reader):
 
         return p_types[int(resolution.pop())]
 
-    def get_channel_names(self, scene: int = 0):
+    def get_channel_names(self, scene: int = 0) -> List[str]:
+        """
+        Get the channel names for the scene
+
+        Parameters
+        ----------
+        scene: int
+            The index of the scene from which to retrieve the channel names
+
+        Returns
+        -------
+        List[str]
+            A list of descriptive names of the channels of the form "Gray--TL-BF--EMP_BF" and "Green--FLUO--GFP"
+        """
         # for the remove to work the
         img_sets = self.metadata.findall(".//Image")
 
@@ -476,33 +559,77 @@ class LifReader(Reader):
         return ref.text
 
     def get_physical_pixel_size(self, scene: int = 0) -> Tuple[float]:
-        # for the remove to work the
+        """
+        Get the (X, Y, Z) pixel size. If the value isn't set it returns the 1.0.
+
+        Parameters
+        ----------
+        scene: int
+            The scene to retrieve the dimensions from
+
+        Returns
+        -------
+        (X, Y, Z) in µm.
+
+        """
+        # find all the Image nodes in the xml tree. They correspond to the individual scenes
         img_sets = self.metadata.findall(".//Image")
 
+        # select the specified scene
         img = img_sets[scene]
         scene_pixel_size = [1.0, 1.0, 1.0]
-        dim_list = img.findall(".//DimensionDescription")
+        dim_list = []
+        dim_list.append(img.findall(".//DimensionDescription[@DimID='1']")[0])
+        dim_list.append(img.findall(".//DimensionDescription[@DimID='2']")[0])
+        z_dim = img.findall(".//DimensionDescription[@DimID='3']")
+        if len(z_dim) > 0:
+            dim_list.append(z_dim[0])
+
+        # calculate and overwrite the pixel size for each X, Y, Z dim if present
         for idx, dim in enumerate(dim_list):
-            scene_pixel_size[idx] = (abs(1000000.0*float(dim.attrib['Length']))/(float(dim.attrib['NumberOfElements'])-1.0))
+            # the formula for the pixel size is
+            # pixel_size = Length/(NumberOfElements - 1) from Leica & ImageJ
+            scene_pixel_size[idx] = (abs(1000000.0*float(dim.attrib['Length']))/(
+                                        float(dim.attrib['NumberOfElements'])-1.0)
+                                     )
         return tuple(scene_pixel_size)
 
     #  bitmap reader functions
 
     @staticmethod
-    def _get_item_as_bitmap(im_path: Path, offsets: np.ndarray, r_length: np.ndarray, **kwargs):
+    def _get_item_as_bitmap(im_path: Path, offsets: List[type(np.ndarray)], r_length: np.ndarray,
+                            read_dims: Optional[Dict[str, int]] = None) -> Tuple[List[type(np.ndarray)],
+                                                                                 List[Tuple[str, int]]]:
         """
-        Gets specified item from the image set (private).
-        Args:
-            n (int): what item to retrieve
+        Gets specified bitmap data from the lif file (private).
 
-        Returns:
-            PIL image
+        Parameters
+        ----------
+        im_path: Path
+            Path to the LIF file to read.
+        offsets: List[numpy.ndarray]
+            A List of numpy ndarrays offsets, see _compute_offsets for more details.
+        r_length: numpy.ndarray
+            A 1D numpy array of read lengths, the index is the scene index
+        read_dims: Optional[Dict[str, int]]
+            The dimensions to read from the file as a dictionary of string to integer.
+            Default: None (Read all data from the image)
+
+        Returns
+        -------
+        numpy.ndarray
+            a stack of images as a numpy.ndarray
+        List[Tuple[str, int]]
+            The shape of the data being returned
         """
+        if read_dims is None:
+            read_dims = {}
+
         lif = LifFile(im_path)
 
         # data has already been checked for consistency. The dims are either consistent or S is specified
-        selected_ranges = LifReader.kwargs_to_ranges(lif, **kwargs)
-        s_index = kwargs[Dimensions.Scene] if Dimensions.Scene in kwargs.keys() else 0
+        selected_ranges = LifReader.read_dims_to_ranges(lif, read_dims)
+        s_index = read_dims[Dimensions.Scene] if Dimensions.Scene in read_dims.keys() else 0
         lif_img = lif.get_image(img_n=s_index)
         x_size = lif_img.dims[0]
         y_size = lif_img.dims[1]
@@ -521,11 +648,11 @@ class LifReader(Reader):
                 for t_index in selected_ranges[Dimensions.Time]:
                     for c_index in selected_ranges[Dimensions.Channel]:
                         for z_index in selected_ranges[Dimensions.SpatialZ]:
-                            image.seek(offsets[s_index, t_index, c_index, z_index])
+                            image.seek(offsets[s_index][t_index, c_index, z_index])
                             byte_array = image.read(r_length[s_index])
-                            img_stack.append(
-                                np.frombuffer(byte_array, dtype=pixel_type).reshape(x_size, y_size).transpose()
-                            )
+                            typed_array = np.frombuffer(byte_array, dtype=pixel_type).reshape(x_size, y_size)
+                            typed_array = typed_array.transpose()
+                            img_stack.append(typed_array)
 
         shape = [len(selected_ranges[dim[0]]) for dim in ranged_dims]
         shape.append(y_size)
@@ -535,69 +662,49 @@ class LifReader(Reader):
         return np.array(img_stack).reshape(*shape), ranged_dims  # in some subset of STCZYX order
 
     @staticmethod
-    def kwargs_to_ranges(lif: LifFile, **kwargs):
+    def read_dims_to_ranges(lif: LifFile, read_dims: Optional[Dict[str, int]] = None):
+        """
+        Convert the provided read_dims and file structure into ranges to iterate over
+
+        Parameters
+        ----------
+        lif: LifFile
+            The LifFile to get the ranges from
+        read_dims: Dict[str: int]
+            The list of locked dimensions
+
+        Returns
+        -------
+        Dict[Dimension: range]
+            These ranges can then be used to iterate through the specified XY images
+
+        """
+        if read_dims is None:
+            read_dims = {}
 
         data_shape = LifReader._dims_shape(lif=lif)
 
-        if Dimensions.Scene in kwargs:
-            s_range = range(kwargs[Dimensions.Scene], kwargs[Dimensions.Scene] + 1)
+        if Dimensions.Scene in read_dims:
+            s_range = range(read_dims[Dimensions.Scene], read_dims[Dimensions.Scene] + 1)
             s_dict = data_shape[s_range[0]]
         else:
             s_range = range(*data_shape[0][Dimensions.Scene])
             s_dict = data_shape[0]
 
         ans = {Dimensions.Scene: s_range}
-        for ky in [Dimensions.Time, Dimensions.Channel, Dimensions.SpatialZ]:
-            if ky in kwargs.keys():
-                ans[ky] = range(kwargs[ky], kwargs[ky]+1)
+        for key in [Dimensions.Time, Dimensions.Channel, Dimensions.SpatialZ]:
+            if key in read_dims.keys():
+                ans[key] = range(read_dims[key], read_dims[key]+1)
             else:
-                ans[ky] = range(*s_dict[ky])
+                ans[key] = range(*s_dict[key])
 
         return ans
 
     @staticmethod
-    def get_frame(img: LifImage, z: int = 0, t: int = 0, c: int = 0):
+    def _compute_offsets(lif: LifFile) -> Tuple[List[np.ndarray], np.ndarray]:
         """
-        Gets the specified frame (z, t, c) from image.
-
-        Args:
-            img (LifImage): the Scene/Image within the LifFile
-            z (int): z position
-            t (int): time point
-            c (int): channel
-
-        Returns:
-            Image as a numpy.ndarray (XY) object
-        """
-        t = int(t)
-        c = int(c)
-        z = int(z)
-        if z >= img.nz:
-            raise ValueError("Requested Z frame doesn't exist.")
-        elif t >= img.nt:
-            raise ValueError("Requested T frame doesn't exist.")
-        elif c >= img.channels:
-            raise ValueError("Requested channel doesn't exist.")
-
-        total_items = img.channels * img.nz * img.nt
-
-        t_offset = img.channels * img.nz
-        t_requested = t_offset * t
-
-        z_offset = img.channels
-        z_requested = z_offset * z
-
-        c_requested = c
-
-        item_requested = t_requested + z_requested + c_requested
-        if item_requested > total_items:
-            raise ValueError("The requested item is after the end of the image")
-
-        return LifReader._get_item_as_bitmap(img=img, n=item_requested)
-
-    @staticmethod
-    def _compute_offsets(lif: LifFile) -> Tuple[np.ndarray, np.ndarray]:
-        """
+        Compute the offsets for each of the XY planes so that the LifFile object doesn't need
+        to be created for each XY image read.
 
         Parameters
         ----------
@@ -606,8 +713,9 @@ class LifReader(Reader):
 
         Returns
         -------
-        (numpy.ndarray, numpy.ndarray)
-            The first numpy array holds the offsets and it's indexes are in STCZ order.
+        List[numpy.ndarray]
+            The list of numpy arrays holds the offsets and it should be accessed as [S][T,C,Z].
+        numpy.ndarray
             The second numpy array holds the image read length per Scene.
 
         """
@@ -640,4 +748,4 @@ class LifReader(Reader):
             s_list.append(offsets)
             s_img_length_list.append(image_len)
 
-        return np.asarray(s_list, dtype=np.uint64), np.asarray(s_img_length_list, dtype=np.uint64)
+        return s_list, np.asarray(s_img_length_list, dtype=np.uint64)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -11,7 +11,7 @@ import numpy as np
 from dask import delayed
 from lxml.etree import _Element
 from readlif import utilities
-from readlif.reader import LifFile, LifImage
+from readlif.reader import LifFile
 
 from .reader import Reader
 from .. import exceptions, types
@@ -106,7 +106,10 @@ class LifReader(Reader):
         return False
 
     @staticmethod
-    def _read_image(img: Path, offsets: List[np.ndarray], r_length: np.ndarray, read_dims: Optional[Dict[str, int]] = None) -> Tuple[np.ndarray, List[Tuple[str, int]]]:
+    def _read_image(img: Path, offsets: List[np.ndarray],
+                    r_length: np.ndarray,
+                    read_dims: Optional[Dict[str, int]] = None
+                    ) -> Tuple[np.ndarray, List[Tuple[str, int]]]:
         """
         Read and return the squeezed image data requested along with the dimension info that was read.
 
@@ -157,7 +160,10 @@ class LifReader(Reader):
         return data[tuple(ops)], real_dims
 
     @staticmethod
-    def _imread(img: Path, offsets: List[np.ndarray], r_length: np.ndarray, read_dims: Optional[Dict[str, str]] = None) -> np.ndarray:
+    def _imread(img: Path, offsets: List[np.ndarray],
+                r_length: np.ndarray,
+                read_dims: Optional[Dict[str, str]] = None
+                ) -> np.ndarray:
         """
         This function is a pass through to _read_image above
         the difference is it returns the data without the dims structure.

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -33,7 +33,7 @@ class LifReader(Reader):
     Parameters
     ----------
     data: types.FileLike
-        A string or path to the CZI file to be read.
+        A string or path to the LIF file to be read.
     chunk_by_dims: List[str]
         The dimensions to use as the for mapping the chunks / blocks.
         Default: [Dimensions.SpatialZ, Dimensions.SpatialY, Dimensions.SpatialX]
@@ -510,7 +510,7 @@ class LifReader(Reader):
         # Uppercase dimensions provided to chunk by dims
         chunk_by_dims = [d.upper() for d in chunk_by_dims]
 
-        # Always add Y and X dims to chunk by dims because that is how CZI files work
+        # Always add Y and X dims to chunk by dims because that is how LIF files work
         if Dimensions.SpatialY not in chunk_by_dims:
             log.info(f"Adding the Spatial Y dimension to chunk by dimensions as it was not found.")
             chunk_by_dims.append(Dimensions.SpatialY)
@@ -618,7 +618,7 @@ class LifReader(Reader):
 
         # Only run if the transpose is actually required
         # The default case is "Z", "Y", "X", which _usually_ doesn't need to be transposed because that is _usually_
-        # The normal dimension order of the CZI file anyway
+        # The normal dimension order of the LIF file anyway
         if transpose_required:
             merged = da.transpose(merged, tuple(transpose_indices))
 
@@ -631,7 +631,7 @@ class LifReader(Reader):
         """
         Returns
         -------
-        Constructed dask array where each chunk is a delayed read from the CZI file.
+        Constructed dask array where each chunk is a delayed read from the LIF file.
         Places dimensions in the native order (i.e. "TZCYX")
         """
         if self._dask_data is None:

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -541,7 +541,6 @@ class LifReader(Reader):
                                                                read_lengths=read_lengths,
                                                                meta=lif.xml_root,
                                                                read_dims=first_chunk_read_dims)
-        # lif.read_image(**first_chunk_read_dims)
 
         # Get the shape for the chunk and operating shape for the dask array
         # We also collect the chunk and non chunk dimension ordering so that we can swap the dimensions after we

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -8,7 +8,6 @@ import pytest
 from dask.diagnostics import Profiler
 from psutil import Process
 
-from aicsimageio import exceptions
 from aicsimageio.readers.lif_reader import LifReader
 
 
@@ -187,4 +186,3 @@ def test_lif_image_data_two(resources_dir, filename, scene, expected):
 
     img = LifReader(f)
     assert img._chunk_offsets[0][0, 0, 0] == expected
-

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -173,7 +173,6 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     proc = Process()
     assert str(f) not in [f.path for f in proc.open_files()]
 
-
     # Init reader
     img = LifReader(f)
 

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -28,7 +28,7 @@ from aicsimageio.readers.lif_reader import LifReader
             "STCZYX",
             np.uint16,
             0,
-            ("Z", "Y", "X"),
+            ["Z", "Y", "X"],
             (1, 1, 1, 1, 2048, 2048),
             4  # 1 * 1 * 2 * 2 = 4
         ),
@@ -38,31 +38,31 @@ from aicsimageio.readers.lif_reader import LifReader
             "STCZYX",
             np.uint16,
             0,
-            ("Z", "Y", "X"),
+            ["Z", "Y", "X"],
             (1, 1, 1, 1, 614, 614),
             16  # 1 * 4 * 2 * 2 = 16
         ),
         #  To be added back in when rebased off jackson's S3 pr
-        # (
-        #     "s14_t1_c2_z52_inconsistent.lif",
-        #     (1, 1, 2, 38, 2048, 2048),
-        #     "STCZYX",
-        #     np.uint16,
-        #     0,
-        #     ("Z", "Y", "X"),
-        #     (1, 1, 1, 38, 2048, 2048),
-        #     4  # 1 * 1 * 2 * 2 = 4
-        # ),
-        # (
-        #     "s14_t1_c2_z52_inconsistent.lif",
-        #     (1, 1, 2, 52, 2048, 2048),
-        #     "STCZYX",
-        #     np.uint16,
-        #     1,
-        #     ("C", "Y", "X"),
-        #     (1, 1, 2, 1, 2048, 2048),
-        #     104  # 1 * 1 * 52 * 2 = 104
-        # ),
+        (
+            "s_14_t_1_c_2_variable_dims.lif",
+            (1, 1, 2, 38, 2048, 2048),
+            "STCZYX",
+            np.uint16,
+            0,
+            ["Z", "Y", "X"],
+            (1, 1, 1, 38, 2048, 2048),
+            4  # 1 * 1 * 2 * 2 = 4
+        ),
+        (
+            "s_14_t_1_c_2_variable_dims.lif",
+            (1, 1, 2, 52, 2048, 2048),
+            "STCZYX",
+            np.uint16,
+            1,
+            ["C", "Y", "X"],
+            (1, 1, 2, 1, 2048, 2048),
+            104  # 1 * 1 * 52 * 2 = 104
+        ),
     ]
 )
 def test_lif_reader(
@@ -125,7 +125,7 @@ def test_is_this_type(raw_bytes, expected):
 @pytest.mark.parametrize("filename, scene, expected", [
     ("s_1_t_1_c_2_z_1.lif", 0, ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"]),
     ("s_1_t_4_c_2_z_1.lif", 0, ["Gray--TL-PH--EMP_BF", "Green--FLUO--GFP"]),
-    #  ("s14_t1_c2_z52_inconsistent.lif", 0, ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"])
+    ("s_14_t_1_c_2_variable_dims.lif", 0, ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"]),
     pytest.param("s_1_t_1_c_2_z_1.lif", 2, None, marks=pytest.mark.raises(exception=IndexError))
 ])
 def test_get_channel_names(resources_dir, filename, scene, expected):
@@ -135,7 +135,7 @@ def test_get_channel_names(resources_dir, filename, scene, expected):
 @pytest.mark.parametrize("filename, scene, expected", [
     ("s_1_t_1_c_2_z_1.lif", 0, (0.325, 0.325, 1.0)),
     ("s_1_t_4_c_2_z_1.lif", 0, (0.33915, 0.33915, 1.0)),
-    #  ("s14_t1_c2_z52_inconsistent.lif", 0, (0.1625, 0.1625, 1.000715))
+    ("s_14_t_1_c_2_variable_dims.lif", 0, (0.1625, 0.1625, 1.000715))
 ])
 def test_get_physical_pixel_size(resources_dir, filename, scene, expected):
     assert LifReader(resources_dir / filename).get_physical_pixel_size(scene) == pytest.approx(expected, rel=0.001)
@@ -165,25 +165,8 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     assert img.size_x() == x
 
 
-# This test doesn't work currently => I'm trying to figure out why but no good guesses yet
-
-# @pytest.mark.parametrize("filename, scene, expected", [
-#     ("s1_t4_c2_z1.lif", 0, (25575, 25009, 25239, 25014, 25288, 25912, 25545, 25067, 25322, 25211, 25204)),
-#     #  ("s14_t1_c2_z52_inconsistent.lif", 0, (0.1625, 0.1625, 1.000715))
-# ])
-# def test_lif_image_data_one(resources_dir, filename, scene, expected):
-#     f = resources_dir / filename
-#
-#     img = LifReader(f)
-#     data_y = img.data[0, 0, 0, 0, 0:10, 0]
-#     data_x = img.data[0, 0, 0, 0, 0, 0:10]
-#     assert np.array_equal(data_y, expected)
-#     assert np.array_equal(data_x, expected)
-
-
 @pytest.mark.parametrize("filename, scene, expected", [
     ("s_1_t_4_c_2_z_1.lif", 0, 51221),
-    #  ("s14_t1_c2_z52_inconsistent.lif", 0, (0.1625, 0.1625, 1.000715))
 ])
 def test_lif_image_data_two(resources_dir, filename, scene, expected):
     f = resources_dir / filename

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -42,7 +42,7 @@ from aicsimageio.readers.lif_reader import LifReader
             (1, 1, 1, 1, 614, 614),
             16  # 1 * 4 * 2 * 2 = 16
         ),
-        #  To be added back in when rebased off jackson's S3 pr
+        # To be added back in when rebased off jackson's S3 pr
         (
             "s_14_t_1_c_2_variable_dims.lif",
             (1, 1, 2, 38, 2048, 2048),
@@ -78,12 +78,14 @@ def test_lif_reader(
 ):
     # Get file
     f = resources_dir / filename
+    # Check that there are no open file pointers
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
 
     # Read file
     img = LifReader(f, chunk_by_dims=chunk_dims, S=select_scene)
 
     # Check that there are no open file pointers after init
-    proc = Process()
     assert str(f) not in [f.path for f in proc.open_files()]
 
     # Check basics
@@ -129,7 +131,16 @@ def test_is_this_type(raw_bytes, expected):
     pytest.param("s_1_t_1_c_2_z_1.lif", 2, None, marks=pytest.mark.raises(exception=IndexError))
 ])
 def test_get_channel_names(resources_dir, filename, scene, expected):
+    f = resources_dir / filename
+
+    # Check that there are no open file pointers
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
+
     assert LifReader(resources_dir / filename).get_channel_names(scene) == expected
+
+    # Check that there are no open file pointers
+    assert str(f) not in [f.path for f in proc.open_files()]
 
 
 @pytest.mark.parametrize("filename, scene, expected", [
@@ -138,7 +149,16 @@ def test_get_channel_names(resources_dir, filename, scene, expected):
     ("s_14_t_1_c_2_variable_dims.lif", 0, (0.1625, 0.1625, 1.000715))
 ])
 def test_get_physical_pixel_size(resources_dir, filename, scene, expected):
+    f = resources_dir / filename
+
+    # Check that there are no open file pointers
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
+
     assert LifReader(resources_dir / filename).get_physical_pixel_size(scene) == pytest.approx(expected, rel=0.001)
+
+    # Check that there are no open file pointers
+    assert str(f) not in [f.path for f in proc.open_files()]
 
 
 @pytest.mark.parametrize("filename, s, t, c, z, y, x", [
@@ -148,6 +168,11 @@ def test_get_physical_pixel_size(resources_dir, filename, scene, expected):
 def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     # Get file
     f = resources_dir / filename
+
+    # Check that there are no open file pointers
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
+
 
     # Init reader
     img = LifReader(f)
@@ -164,6 +189,9 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     assert img.size_y() == y
     assert img.size_x() == x
 
+    # Check that there are no open file pointers
+    assert str(f) not in [f.path for f in proc.open_files()]
+
 
 @pytest.mark.parametrize("filename, scene, expected", [
     ("s_1_t_4_c_2_z_1.lif", 0, 51221),
@@ -171,10 +199,12 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
 def test_lif_image_data_two(resources_dir, filename, scene, expected):
     f = resources_dir / filename
 
-    img = LifReader(f)
-
-    # Check that there are no open file pointers after init
+    # Check that there are no open file pointers
     proc = Process()
     assert str(f) not in [f.path for f in proc.open_files()]
+    img = LifReader(f)
 
     assert img._chunk_offsets[0][0, 0, 0] == expected
+
+    # Check that there are no open file pointers
+    assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -145,8 +145,8 @@ def test_get_channel_names(resources_dir, filename, scene, expected):
 
 @pytest.mark.parametrize("filename, scene, expected", [
     ("s_1_t_1_c_2_z_1.lif", 0, (0.325, 0.325, 1.0)),
-    ("s_1_t_4_c_2_z_1.lif", 0, (0.33915, 0.33915, 1.0)),
-    ("s_14_t_1_c_2_variable_dims.lif", 0, (0.1625, 0.1625, 1.000715))
+    ("s_1_t_4_c_2_z_1.lif", 0, (0.33914910277324634, 0.33914910277324634, 1.0)),
+    ("s_14_t_1_c_2_variable_dims.lif", 0, (0.1625, 0.1625, 1.000715)),
 ])
 def test_get_physical_pixel_size(resources_dir, filename, scene, expected):
     f = resources_dir / filename

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -144,9 +144,9 @@ def test_get_channel_names(resources_dir, filename, scene, expected):
 
 
 @pytest.mark.parametrize("filename, scene, expected", [
-    ("s_1_t_1_c_2_z_1.lif", 0, (0.325, 0.325, 1.0)),
-    ("s_1_t_4_c_2_z_1.lif", 0, (0.33914910277324634, 0.33914910277324634, 1.0)),
-    ("s_14_t_1_c_2_variable_dims.lif", 0, (0.1625, 0.1625, 1.000715)),
+    ("s_1_t_1_c_2_z_1.lif", 0, (3.25e-07, 3.25e-07, 1.0)),
+    ("s_1_t_4_c_2_z_1.lif", 0, (3.3914910277324634e-07, 3.3914910277324634e-07, 1.0)),
+    ("s_14_t_1_c_2_variable_dims.lif", 0, (1.625e-07, 1.625e-07, 1.000715e-06)),
 ])
 def test_get_physical_pixel_size(resources_dir, filename, scene, expected):
     f = resources_dir / filename

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from io import BytesIO
+
+import numpy as np
+import pytest
+from dask.diagnostics import Profiler
+from psutil import Process
+
+from aicsimageio import exceptions
+from aicsimageio.readers.lif_reader import LifReader
+
+
+@pytest.mark.parametrize(
+    "filename, "
+    "expected_shape, "
+    "expected_dims, "
+    "expected_dtype, "
+    "select_scene, "
+    "chunk_dims, "
+    "expected_chunksize, "
+    "expected_task_count",
+    [
+        # Expected task counts should be each non chunk dimension size multiplied againest each other * 2
+        (
+            "s1_t1_c2_z1.lif",
+            (1, 1, 2, 1, 2048, 2048),
+            "STCZYX",
+            np.uint16,
+            0,
+            ("Z", "Y", "X"),
+            (1, 1, 1, 1, 2048, 2048),
+            2  # 1 * 1 * 2 = 2
+        ),
+        (
+            "s1_t4_c2_z1.lif",
+            (1, 4, 2, 1, 614, 614),
+            "SCZYX",
+            np.uint16,
+            0,
+            ("Z", "Y", "X"),
+            (1, 1, 1, 5, 325, 475),
+            18  # 1 * 3 * 3 * 2 = 18
+        ),
+        (
+            "s14_t1_c2_z52_inconsistent.lif",
+            (1, 3, 3, 5, 2048, 2048),
+            "STCZYX",
+            np.uint16,
+            0,
+            ("Z", "Y", "X"),
+            (1, 1, 1, 38, 2048, 2048),
+            90  # 1 * 3 * 3 * 5 * 2 = 90
+        ),
+        (
+            "s14_t1_c2_z52_inconsistent.lif",
+            (14, 1, 2, 52, 2048, 2048),
+            "STCZYX",
+            np.uint16,
+            1,
+            ("C", "Y", "X"),
+            (1, 1, 3, 1, 2048, 2048),
+            30  # 1 * 3 * 5 * 2 = 30
+        ),
+    ]
+)
+def test_lif_reader(
+    resources_dir,
+    filename,
+    expected_shape,
+    expected_dims,
+    expected_dtype,
+    select_scene,
+    chunk_dims,
+    expected_chunksize,
+    expected_task_count
+):
+    # Get file
+    f = resources_dir / filename
+
+    # Read file
+    img = LifReader(f, chunk_by_dims=chunk_dims, S=select_scene)
+
+    # Check that there are no open file pointers after init
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    # Check basics
+    with Profiler() as prof:
+        assert img.dims == expected_dims
+        assert img.metadata
+        shp = img.dask_data.shape
+        assert img.dask_data.shape == expected_shape
+        assert img.dask_data.chunksize == expected_chunksize
+        assert img.dtype() == expected_dtype
+        # Check that basic details don't require task computation
+        assert len(prof.results) == 0
+
+    # Check that there are no open file pointers after basics
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    # Check computed type is numpy array, computed shape is expected shape, and task count is expected
+    with Profiler() as prof:
+        assert isinstance(img.data, np.ndarray)
+        assert img.data.shape == expected_shape
+        assert len(prof.results) == expected_task_count
+
+    # Check that there are no open file pointers after retrieval
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+
+@pytest.mark.parametrize("raw_bytes, expected", [
+    (BytesIO(b"ZInotalifnope"), False),
+    (BytesIO(b"ZISRAWFILE"), False),
+    (BytesIO(bytearray.fromhex('70000000759c07002a38')), True),
+    (BytesIO(b""), False),
+    (BytesIO(bytearray.fromhex('700000009f7500002acd3a00003c004c004d0053')), True),
+    (BytesIO(bytearray.fromhex('70000000b1c700002ad66300003c004c004d0053')), True),
+])
+def test_is_this_type(raw_bytes, expected):
+    res = LifReader._is_this_type(raw_bytes)
+    assert res == expected
+
+
+@pytest.mark.parametrize("filename, scene, expected", [
+    ("s1_t1_c2_z1.lif", 0, ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"]),
+    ("temp_example.lif", 0, ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"])
+    # Our current get channel names doesn't take scene into account
+    # pytest.param("s_3_t_1_c_3_z_5.czi", 3, None, marks=pytest.mark.raises(exception=IndexError))
+])
+def test_get_channel_names(resources_dir, filename, scene, expected):
+    assert LifReader(resources_dir / filename).get_channel_names(scene) == expected
+
+
+@pytest.mark.parametrize("filename, scene, expected", [
+    ("s1_t1_c2_z1.lif", 0, (0.325, 0.325, 1.0)),
+    ("temp_example.lif", 0, (0.1625, 0.1625, 1.000715))
+])
+def test_get_physical_pixel_size(resources_dir, filename, scene, expected):
+    assert pytest.approx(expected, 0.00001) == LifReader(resources_dir / filename).get_physical_pixel_size(scene)
+
+
+@pytest.mark.parametrize("filename, s, t, c, z, y, x", [
+    ("s_1_t_1_c_1_z_1.czi", 1, 1, 1, 1, 325, 475),
+    ("s_3_t_1_c_3_z_5.czi", 3, 1, 3, 5, 325, 475)
+])
+def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
+    # Get file
+    f = resources_dir / filename
+
+    # Init reader
+    img = LifReader(f)
+
+    # Check sizes
+    assert img.size_s() == s
+    assert img.size_t() == t
+    assert img.size_c() == c
+    assert img.size_z() == z
+    assert img.size_y() == y
+    assert img.size_x() == x

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -4,7 +4,6 @@
 from io import BytesIO
 
 import numpy as np
-from psutil import Process
 import pytest
 from dask.diagnostics import Profiler
 from psutil import Process

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -353,8 +353,8 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
         (TIF_FILE, (1.0, 1.0, 1.0)),
         (CZI_FILE, (1.0833333333333333e-06, 1.0833333333333333e-06, 1.0)),
         (OME_FILE, (1.0833333333333333, 1.0833333333333333, 1.0)),
-        (LIF_FILE, (0.325, 0.325, 1.0)),
-        (BIG_LIF_FILE, (0.33914910277324634, 0.33914910277324634, 1.0)),
+        (LIF_FILE, (3.25e-07, 3.25e-07, 1.0)),
+        (BIG_LIF_FILE, (3.3914910277324634e-07, 3.3914910277324634e-07, 1.0)),
     ],
 )
 def test_physical_pixel_size(resources_dir, filename, expected_sizes):

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from dask.diagnostics import Profiler
 from lxml.etree import _Element
+from xml.etree.ElementTree import Element
 from psutil import Process
 
 from aicsimageio import AICSImage, exceptions, imread, imread_dask, readers
@@ -21,10 +22,12 @@ PNG_FILE = "example.png"
 GIF_FILE = "example.gif"
 TIF_FILE = "s_1_t_1_c_1_z_1.tiff"
 CZI_FILE = "s_1_t_1_c_1_z_1.czi"
+LIF_FILE = "s_1_t_1_c_2_z_1.lif"
 OME_FILE = "s_1_t_1_c_1_z_1.ome.tiff"
 MED_TIF_FILE = "s_1_t_10_c_3_z_1.tiff"
 BIG_OME_FILE = "s_3_t_1_c_3_z_5.ome.tiff"
 BIG_CZI_FILE = "s_3_t_1_c_3_z_5.czi"
+BIG_LIF_FILE = "s_1_t_4_c_2_z_1.lif"
 TXT_FILE = "example.txt"
 
 
@@ -38,6 +41,7 @@ TXT_FILE = "example.txt"
         (TIF_FILE, readers.TiffReader),
         (OME_FILE, readers.OmeTiffReader),
         (CZI_FILE, readers.CziReader),
+        (LIF_FILE, readers.LifReader),
         pytest.param(
             TXT_FILE,
             None,
@@ -203,6 +207,7 @@ def test_force_dims(data_shape, dims, expected):
         (TIF_FILE, str),
         (OME_FILE, omexml.OMEXML),
         (CZI_FILE, _Element),
+        (LIF_FILE, Element),
     ],
 )
 def test_metadata(resources_dir, filename, expected_metadata_type):
@@ -216,6 +221,7 @@ def test_metadata(resources_dir, filename, expected_metadata_type):
     # Check basics
     with Profiler() as prof:
         img = AICSImage(f)
+        print(type(img.metadata))
         assert isinstance(img.metadata, expected_metadata_type)
 
         # Check that basic details don't require task computation
@@ -226,15 +232,16 @@ def test_metadata(resources_dir, filename, expected_metadata_type):
 
 
 @pytest.mark.parametrize(
-    "filename, expected_shape",
+    "filename, expected_shape, expected_tasks",
     [
-        (PNG_FILE, (1, 1, 4, 1, 800, 537)),
-        (TIF_FILE, (1, 1, 1, 1, 325, 475)),
-        (OME_FILE, (1, 1, 1, 1, 325, 475)),
-        (CZI_FILE, (1, 1, 1, 1, 325, 475)),
+        (PNG_FILE, (1, 1, 4, 1, 800, 537), 2),
+        (TIF_FILE, (1, 1, 1, 1, 325, 475), 2),
+        (OME_FILE, (1, 1, 1, 1, 325, 475), 2),
+        (CZI_FILE, (1, 1, 1, 1, 325, 475), 2),
+        (LIF_FILE, (1, 1, 2, 1, 2048, 2048), 4),
     ],
 )
-def test_imread(resources_dir, filename, expected_shape):
+def test_imread(resources_dir, filename, expected_shape, expected_tasks):
     # Get filepath
     f = resources_dir / filename
 
@@ -248,7 +255,7 @@ def test_imread(resources_dir, filename, expected_shape):
         assert img.shape == expected_shape
 
         # Reshape and transpose are required so there should be two tasks in the graph
-        assert len(prof.results) == 2
+        assert len(prof.results) == expected_tasks
 
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]
@@ -258,7 +265,8 @@ def test_imread(resources_dir, filename, expected_shape):
     # Because we are directly requesting the data, the transpose and reshape calls get reduced
     (MED_TIF_FILE, (1, 10, 3, 1, 325, 475), 60),
     (BIG_OME_FILE, (3, 1, 3, 5, 325, 475), 90),
-    (BIG_CZI_FILE, (3, 1, 3, 5, 325, 475), 18)
+    (BIG_CZI_FILE, (3, 1, 3, 5, 325, 475), 18),
+    (BIG_LIF_FILE, (1, 4, 2, 1, 614, 614), 16),
 ])
 def test_large_imread(resources_dir, filename, expected_shape, expected_task_count):
     # Get filepath
@@ -282,7 +290,8 @@ def test_large_imread(resources_dir, filename, expected_shape, expected_task_cou
     # Because we are directly returning the dask array nothing has been computed
     (MED_TIF_FILE, (1, 10, 3, 1, 325, 475), 0),
     (BIG_OME_FILE, (3, 1, 3, 5, 325, 475), 0),
-    (BIG_CZI_FILE, (3, 1, 3, 5, 325, 475), 0)
+    (BIG_CZI_FILE, (3, 1, 3, 5, 325, 475), 0),
+    (BIG_LIF_FILE, (1, 4, 2, 1, 614, 614), 0),
 ])
 def test_large_imread_dask(resources_dir, filename, expected_shape, expected_task_count):
     # Get filepath
@@ -311,8 +320,10 @@ def test_large_imread_dask(resources_dir, filename, expected_shape, expected_tas
         (TIF_FILE, ["0"]),
         (MED_TIF_FILE, ["0", "1", "2"]),
         (CZI_FILE, ["Bright"]),
+        (LIF_FILE, ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"]),
         (OME_FILE, ["Bright"]),
-        (BIG_CZI_FILE, ["EGFP", "TaRFP", "Bright"])
+        (BIG_CZI_FILE, ["EGFP", "TaRFP", "Bright"]),
+        (BIG_LIF_FILE, ["Gray--TL-PH--EMP_BF", "Green--FLUO--GFP"]),
     ],
 )
 def test_channel_names(resources_dir, filename, expected_channel_names):
@@ -343,6 +354,8 @@ def test_channel_names(resources_dir, filename, expected_channel_names):
         (TIF_FILE, (1.0, 1.0, 1.0)),
         (CZI_FILE, (1.0833333333333333e-06, 1.0833333333333333e-06, 1.0)),
         (OME_FILE, (1.0833333333333333, 1.0833333333333333, 1.0)),
+        (LIF_FILE, (0.325, 0.325, 1.0)),
+        (BIG_LIF_FILE, (0.33914910277324634, 0.33914910277324634, 1.0)),
     ],
 )
 def test_physical_pixel_size(resources_dir, filename, expected_sizes):
@@ -484,6 +497,7 @@ def test_view_napari(data, rgb, expected_data, expected_visible, expected_ndim, 
     (TIF_FILE, (1, 1, 1, 1, 325, 475), str, 2),
     (OME_FILE, (1, 1, 1, 1, 325, 475), omexml.OMEXML, 2),
     (CZI_FILE, (1, 1, 1, 1, 325, 475), _Element, 2),
+    (LIF_FILE, (1, 1, 2, 1, 2048, 2048), Element, 4),  # not entirely sure why this is 4 not 2
     (MED_TIF_FILE, (1, 10, 3, 1, 325, 475), str, 60),
     (BIG_OME_FILE, (3, 1, 3, 5, 325, 475), omexml.OMEXML, 90),
     (BIG_CZI_FILE, (3, 1, 3, 5, 325, 475), _Element, 18),

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -221,7 +221,6 @@ def test_metadata(resources_dir, filename, expected_metadata_type):
     # Check basics
     with Profiler() as prof:
         img = AICSImage(f)
-        print(type(img.metadata))
         assert isinstance(img.metadata, expected_metadata_type)
 
         # Check that basic details don't require task computation

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -253,7 +253,7 @@ def test_imread(resources_dir, filename, expected_shape, expected_tasks):
         img = imread(f)
         assert img.shape == expected_shape
 
-        # Reshape and transpose are required so there should be two tasks in the graph
+        # Reshape and transpose are required so there should be (2 * chunks) tasks in the graph
         assert len(prof.results) == expected_tasks
 
     # Check that there are no open file pointers after basics

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="89b6219c95f10b3a0c55935792e8da84af4d07080d05a73f65e5feb1896c3c29",
+            default="fb3aa3dccf08aab89031b63d84fc466e4a7c25a54ef80da21797302360ab3c6c",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(

--- a/scripts/upload_test_resources.py
+++ b/scripts/upload_test_resources.py
@@ -51,7 +51,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "-y", "--yes",
             action="store_true",
-            dest="preappoved",
+            dest="preapproved",
             help="Auto-accept upload of files."
         )
         p.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ requirements = [
     "distributed>=2.9.3",
     "numpy>=1.16",
     "imageio>=2.3.0",
+    "readlif>=0.2.1",
     "lxml>=4.4.2",
     "tifffile>=2019.7.26.2",
     "toolz>=0.10.0",


### PR DESCRIPTION
This PR adds some functionality to read Leica-LIF files. Other python-based readers seem to fail on at least one of the two test files as they have different endianness. The solution here is based on the data we have so it is more of a starting point than a completed all-encompassing solution. 

- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
closes #90  

- [x] Provide context of changes.

LIF files are one of the core institute file formats. Enabling Dask based reading enables us to capture the data more directly. 

We used the `readlif` package as a starting point to enable lif file reading. Currently, we are using it simply to get the file offset, metadata, and parse some of the metadata

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

