### PR TITLE
bugfix/update-ome-spec

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -569,9 +569,9 @@ class AICSImage:
 
         except ModuleNotFoundError:
             raise ModuleNotFoundError(
-                f"'napari' has not been installed. To use this function install napari "
-                f"with either: pip install napari' or "
-                f"'pip install aicsimageio[interactive]'"
+                "'napari' has not been installed. To use this function install napari "
+                "with either: pip install napari' or "
+                "'pip install aicsimageio[interactive]'"
             )
 
     def get_channel_names(self, scene: int = 0) -> List[str]:
@@ -620,14 +620,14 @@ class AICSImage:
         return f"<AICSImage [{type(self.reader).__name__}]>"
 
     @property
-    def cluster(self) -> Optional["distributed.LocalCluster"]:
+    def cluster(self) -> Optional["distributed.LocalCluster"]:  # noqa: F821
         """
         If this object created a local Dask cluster, return it.
         """
         return self._cluster
 
     @property
-    def client(self) -> Optional["distributed.Client"]:
+    def client(self) -> Optional["distributed.Client"]:  # noqa: F821
         """
         If connected to a Dask cluster, return the connected Client.
         """
@@ -654,9 +654,9 @@ class AICSImage:
         # Warn of future changes to API
         warnings.warn(
             "In aicsimageio>=4.*, the AICSImage context manager will no longer "
-            f"construct and manage a distributed local dask cluster for you. If this "
-            f"functionality is desired for your work, please switch to explictly "
-            f"calling the `aicsimageio.dask_utils.cluster_and_client` context manager.",
+            "construct and manage a distributed local dask cluster for you. If this "
+            "functionality is desired for your work, please switch to explictly "
+            "calling the `aicsimageio.dask_utils.cluster_and_client` context manager.",
             FutureWarning,
         )
 

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -202,14 +202,14 @@ class CziReader(Reader):
         # Always add Y and X dims to chunk by dims because that is how CZI files work
         if Dimensions.SpatialY not in chunk_by_dims:
             log.info(
-                f"Adding the Spatial Y dimension to chunk by dimensions as it was not "
-                f"found."
+                "Adding the Spatial Y dimension to chunk by dimensions as it was not "
+                "found."
             )
             chunk_by_dims.append(Dimensions.SpatialY)
         if Dimensions.SpatialX not in chunk_by_dims:
             log.info(
-                f"Adding the Spatial X dimension to chunk by dimensions as it was not "
-                f"found."
+                "Adding the Spatial X dimension to chunk by dimensions as it was not "
+                "found."
             )
             chunk_by_dims.append(Dimensions.SpatialX)
 

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -112,7 +112,7 @@ class LifReader(Reader):
                 # the metadata in the LIF. When this is read by the parser,
                 # it is set to zero initially.
                 log.debug(
-                    f"guessing image length: LifFile assumes 1byte per pixel,"
+                    "guessing image length: LifFile assumes 1byte per pixel,"
                     " but I think this is wrong!"
                 )
                 image_len = seek_distance * x_size * y_size * pixel_type.itemsize
@@ -596,14 +596,14 @@ class LifReader(Reader):
         # Always add Y and X dims to chunk by dims because that is how LIF files work
         if Dimensions.SpatialY not in chunk_by_dims:
             log.info(
-                f"Adding the Spatial Y dimension to chunk by dimensions as it was not "
-                f"found."
+                "Adding the Spatial Y dimension to chunk by dimensions as it was not "
+                "found."
             )
             chunk_by_dims.append(Dimensions.SpatialY)
         if Dimensions.SpatialX not in chunk_by_dims:
             log.info(
-                f"Adding the Spatial X dimension to chunk by dimensions as it was not "
-                f"found."
+                "Adding the Spatial X dimension to chunk by dimensions as it was not "
+                "found."
             )
             chunk_by_dims.append(Dimensions.SpatialX)
 

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -205,11 +205,11 @@ class Reader(ABC):
         return [str(i) for i in range(channel_dim_size)]
 
     @property
-    def cluster(self) -> Optional["distributed.LocalCluster"]:
+    def cluster(self) -> Optional["distributed.LocalCluster"]:  # noqa: F821
         return self._cluster
 
     @property
-    def client(self) -> Optional["distributed.Client"]:
+    def client(self) -> Optional["distributed.Client"]:  # noqa: F821
         return self._client
 
     def close(self):

--- a/aicsimageio/vendor/omexml.py
+++ b/aicsimageio/vendor/omexml.py
@@ -11,16 +11,15 @@ omexml.py read and write OME xml
 
 from __future__ import absolute_import, unicode_literals
 
-import sys
-import xml.etree.ElementTree as ElementTree
-
-from io import BytesIO
-
 import datetime
 import logging
-from functools import reduce
 import re
+import sys
 import uuid
+import xml.etree.ElementTree as ElementTree
+from functools import reduce
+from io import BytesIO
+
 import numpy as np  # for ometypedict
 
 logger = logging.getLogger(__file__)
@@ -35,16 +34,16 @@ DEFAULT_NOW = xsd_now()
 #
 # The namespaces
 #
-NS_BINARY_FILE = "http://www.openmicroscopy.org/Schemas/BinaryFile/2013-06"
+NS_BINARY_FILE = "http://www.openmicroscopy.org/Schemas/BinaryFile/2016-06"
 NS_ORIGINAL_METADATA = "openmicroscopy.org/OriginalMetadata"
-NS_DEFAULT = "http://www.openmicroscopy.org/Schemas/{ns_key}/2013-06"
+NS_DEFAULT = "http://www.openmicroscopy.org/Schemas/{ns_key}/2016-06"
 NS_RE = r"http://www.openmicroscopy.org/Schemas/(?P<ns_key>.*)/[0-9/-]"
 
 default_xml = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Warning: this comment is an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://ome-xml.org/wiki/OmeTiff. -->
 <OME xmlns="{ns_ome_default}"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2013-06 http://www.openmicroscopy.org/Schemas/OME/2012-03/ome.xsd">
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
   <Image ID="Image:0" Name="default.png">
     <AcquisitionDate>{timestamp}</AcquisitionDate>
     <Pixels DimensionOrder="XYCTZ"
@@ -60,7 +59,7 @@ default_xml = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
       </Channel>
     </Pixels>
   </Image>
-</OME>""".format(ns_ome_default=NS_DEFAULT.format(ns_key='ome'), timestamp=xsd_now())
+</OME>""".format(ns_ome_default=NS_DEFAULT.format(ns_key='OME'), timestamp=xsd_now())
 
 #
 # These are the OME-XML pixel types - not all supported by subimager
@@ -385,7 +384,7 @@ class OMEXML(object):
                                                       encoding='utf-8',
                                                       method="xml",
                                                       xml_declaration=True
-                                                      # default_namespace = 'http://www.openmicroscopy.org/Schemas/ome/2013-06'
+                                                      # default_namespace = 'http://www.openmicroscopy.org/Schemas/ome/2016-06'
                                                       )
         return result.getvalue().decode()
 


### PR DESCRIPTION
## Description
ZEN viewer fails to load our OME-TIFFs due to incorrect xmlns pointers and out of date schema. Following discussion on #115, the minimal changes of simply updating the xmlns pointers and schema version simply works. Tested in both ZEN and FIJI in addition to our normal OmeTiffWriter tests. This is very much a temporary patch until 4.0 writers release.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #115 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
