### PR TITLE
bugfix/add-imagecodecs-dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ requirements = [
     "dask>=2.9.0",
     "distributed>=2.9.3",
     "numpy>=1.16",
+    "imagecodecs>=2020.2.18",
     "imageio>=2.3.0",
     "readlif>=0.2.1",
     "lxml>=4.4.2",


### PR DESCRIPTION
## Description
Most recent master builds are failing since yesterday morning (when the CRON is scheduled), after some investigation it looks likes it was due to a new `tifffile` release which removed `imagecodecs` as a dependency. `tifffile` doesn't follow semantic versioning so :shrug: 
