### PR TITLE
admin/switch-log-warning-to-warnings-warn

### DIFF
--- a/aicsimageio/transforms.py
+++ b/aicsimageio/transforms.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import warnings
 from collections import Counter
 
 from . import types
@@ -173,7 +174,7 @@ def reshape_data(
                 check_selection_max = dim_spec
             else:
                 # Dimension wasn't included in kwargs, default to zero
-                log.warning(
+                warnings.warn(
                     f"Data has dimension {dim} with depth {data.shape[dim_index]}, "
                     f"assuming {dim}=0 is the desired value, "
                     f"if not the case specify {dim}=x where "


### PR DESCRIPTION
## Description
Switch from `log.warning` to `warnings.warn` to allow warnings to be ignored so that they don't take up as much logging space when the user knows what they are doing.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #121 

- [x] Provide relevant tests for your feature or bug fix.

No changes really...

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
