### PR TITLE
feature/reader-additions

### DIFF
--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -158,6 +158,31 @@ class Reader(ABC):
     def dims(self) -> str:
         pass
 
+    def size(self, dims: str = Dimensions.DefaultOrder) -> Tuple[int]:
+        """
+        Parameters
+        ----------
+        dims: str
+            A string containing a list of dimensions being requested. The default is to
+            return the six standard dims.
+
+        Returns
+        -------
+        size: Tuple[int]
+            A tuple with the requested dimensions filled in.
+        """
+        # Ensure dims is an uppercase string
+        dims = dims.upper()
+
+        # Check that the dims requested are in the image dims
+        if not (all(d in self.dims for d in dims)):
+            raise exceptions.InvalidDimensionOrderingError(
+                f"Invalid dimensions requested: {dims}"
+            )
+
+        # Return the shape of the data for the dimensions requested
+        return tuple([self.dask_data.shape[self.dims.index(dim)] for dim in dims])
+
     @property
     @abstractmethod
     def metadata(self) -> Any:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -366,7 +366,13 @@ class Reader(ABC):
         return tuple([self.dask_data.shape[self.dims.index(dim)] for dim in dims])
 
     @property
-    def shape(self):
+    def shape(self) -> Tuple[int]:
+        """
+        Returns
+        -------
+        shape: Tuple[int]
+            A tuple with the size of all dimensions.
+        """
         return self.dask_data.shape
 
     @property

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import dask.array as da
 import numpy as np
 
-from .. import exceptions, types
+from .. import exceptions, transforms, types
 from ..constants import Dimensions
 
 ###############################################################################
@@ -186,6 +186,154 @@ class Reader(ABC):
                 self._dask_data = da.from_array(self._data)
 
         return self._data
+
+    def get_image_dask_data(
+        self, out_orientation: Optional[str] = None, **kwargs
+    ) -> da.core.Array:
+        """
+        Get specific dimension image data out of an image as a dask array.
+
+        Parameters
+        ----------
+        out_orientation: Optional[str]
+            A string containing the dimension ordering desired for the returned ndarray.
+            Default: The current image dimensions. i.e. `self.dims`
+
+        kwargs:
+            * C=1: specifies Channel 1
+            * T=3: specifies the fourth index in T
+            * D=n: D is Dimension letter and n is the index desired. D should not be
+              present in the out_orientation.
+            * D=[a, b, c]: D is Dimension letter and a, b, c is the list of indicies
+              desired. D should be present in the out_orientation.
+            * D=(a, b, c): D is Dimension letter and a, b, c is the tuple of indicies
+              desired. D should be present in the out_orientation.
+            * D=range(...): D is Dimension letter and range is the standard Python
+              range function. D should be present in the out_orientation.
+            * D=slice(...): D is Dimension letter and slice is the standard Python
+              slice function. D should be present in the out_orientation.
+
+        Returns
+        -------
+        data: dask array
+            The read data with the dimension ordering that was specified with
+            out_orientation.
+
+        Examples
+        --------
+        Specific index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... c1 = img.get_image_dask_data("ZYX", C=1)
+
+        List of index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... first_and_second = img.get_image_dask_data("CZYX", C=[0, 1])
+
+        Tuple of index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... first_and_last = img.get_image_dask_data("CZYX", C=(0, -1))
+
+        Range of index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... first_three = img.get_image_dask_data("CZYX", C=range(3))
+
+        Slice selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... every_other = img.get_image_dask_data("CZYX", C=slice(0, -1, 2))
+
+        Notes
+        -----
+        * If a requested dimension is not present in the data the dimension is
+          added with a depth of 1.
+
+        See `aicsimageio.transforms.reshape_data` for more details.
+        """
+        # If no out orientation, simply return current data as dask array
+        if out_orientation is None:
+            return self.dask_data
+
+        # Transform and return
+        return transforms.reshape_data(
+            data=self.dask_data,
+            given_dims=self.dims,
+            return_dims=out_orientation,
+            **kwargs,
+        )
+
+    def get_image_data(
+        self, out_orientation: Optional[str] = None, **kwargs
+    ) -> np.ndarray:
+        """
+        Get specific dimension image data out of an image as a numpy array.
+
+        Parameters
+        ----------
+        out_orientation: Optional[str]
+            A string containing the dimension ordering desired for the returned ndarray.
+            Default: The current image dimensions. i.e. `self.dims`
+
+        kwargs:
+            * C=1: specifies Channel 1
+            * T=3: specifies the fourth index in T
+            * D=n: D is Dimension letter and n is the index desired. D should not be
+              present in the out_orientation.
+            * D=[a, b, c]: D is Dimension letter and a, b, c is the list of indicies
+              desired. D should be present in the out_orientation.
+            * D=(a, b, c): D is Dimension letter and a, b, c is the tuple of indicies
+              desired. D should be present in the out_orientation.
+            * D=range(...): D is Dimension letter and range is the standard Python
+              range function. D should be present in the out_orientation.
+            * D=slice(...): D is Dimension letter and slice is the standard Python
+              slice function. D should be present in the out_orientation.
+
+        Examples
+        --------
+        Specific index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... c1 = img.get_image_data("ZYX", C=1)
+
+        List of index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... first_and_second = img.get_image_data("CZYX", C=[0, 1])
+
+        Tuple of index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... first_and_last = img.get_image_data("CZYX", C=(0, -1))
+
+        Range of index selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... first_three = img.get_image_data("CZYX", C=range(3))
+
+        Slice selection
+
+        >>> img = Reader("s_1_t_1_c_10_z_20.ome.tiff")
+        ... every_other = img.get_image_data("CZYX", C=slice(0, -1, 2))
+
+        Returns
+        -------
+        data: np.ndarray
+            The read data with the dimension ordering that was specified with
+            out_orientation.
+
+        Notes
+        -----
+        * If a requested dimension is not present in the data the dimension is
+          added with a depth of 1.
+
+        See `aicsimageio.transforms.reshape_data` for more details.
+        """
+        return self.get_image_dask_data(
+            out_orientation=out_orientation, **kwargs
+        ).compute()
 
     @property
     @abstractmethod

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -365,6 +365,7 @@ class Reader(ABC):
         # Return the shape of the data for the dimensions requested
         return tuple([self.dask_data.shape[self.dims.index(dim)] for dim in dims])
 
+    @property
     def shape(self):
         return self.dask_data.shape
 

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -365,6 +365,10 @@ class Reader(ABC):
         # Return the shape of the data for the dimensions requested
         return tuple([self.dask_data.shape[self.dims.index(dim)] for dim in dims])
 
+    @abstractmethod
+    def shape(self):
+        return self.dask_data.shape
+
     @property
     @abstractmethod
     def metadata(self) -> Any:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -365,7 +365,6 @@ class Reader(ABC):
         # Return the shape of the data for the dimensions requested
         return tuple([self.dask_data.shape[self.dims.index(dim)] for dim in dims])
 
-    @abstractmethod
     def shape(self):
         return self.dask_data.shape
 

--- a/aicsimageio/tests/readers/test_arraylike_reader.py
+++ b/aicsimageio/tests/readers/test_arraylike_reader.py
@@ -30,6 +30,7 @@ def test_arraylike_reader(arr, expected_shape, expected_dims):
     # Check basics
     assert reader.dims == expected_dims
     assert reader.metadata is None
+    assert reader.shape == expected_shape
     assert reader.dask_data.shape == expected_shape
     assert reader.size(expected_dims) == expected_shape
 

--- a/aicsimageio/tests/readers/test_arraylike_reader.py
+++ b/aicsimageio/tests/readers/test_arraylike_reader.py
@@ -31,6 +31,11 @@ def test_arraylike_reader(arr, expected_shape, expected_dims):
     assert reader.dims == expected_dims
     assert reader.metadata is None
     assert reader.dask_data.shape == expected_shape
+    assert reader.size(expected_dims) == expected_shape
+
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert reader.size("ABCDEFG") == expected_shape
 
     # Check array
     assert isinstance(reader.data, np.ndarray)

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -120,6 +120,7 @@ def test_czi_reader(
     assert img.dims == expected_dims
     assert img.metadata is not None
     assert img.dask_data.shape == expected_shape
+    assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype
 
     # Check that there are no open file pointers after basics

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -119,7 +119,7 @@ def test_czi_reader(
     # Check basics
     assert img.dims == expected_dims
     assert img.metadata is not None
-    assert reader.shape == expected_shape
+    assert img.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -123,6 +123,10 @@ def test_czi_reader(
     assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype
 
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert img.size("ABCDEFG") == expected_shape
+
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]
 

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -119,6 +119,7 @@ def test_czi_reader(
     # Check basics
     assert img.dims == expected_dims
     assert img.metadata is not None
+    assert reader.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -41,6 +41,7 @@ def test_default_reader(
     assert img.dims == expected_dims
     assert img.metadata
     assert img.dask_data.shape == expected_shape
+    assert img.size(expected_dims) == expected_shape
 
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -43,6 +43,10 @@ def test_default_reader(
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert img.size("ABCDEFG") == expected_shape
+
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]
 

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -40,6 +40,7 @@ def test_default_reader(
     # Check basics
     assert img.dims == expected_dims
     assert img.metadata
+    assert reader.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -40,7 +40,7 @@ def test_default_reader(
     # Check basics
     assert img.dims == expected_dims
     assert img.metadata
-    assert reader.shape == expected_shape
+    assert img.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -77,7 +77,7 @@ def test_lif_reader(
     # Check basics
     assert img.dims == expected_dims
     assert img.metadata
-    assert reader.shape == expected_shape
+    assert img.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -81,6 +81,10 @@ def test_lif_reader(
     assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype
 
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert img.size("ABCDEFG") == expected_shape
+
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]
 

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -77,6 +77,7 @@ def test_lif_reader(
     # Check basics
     assert img.dims == expected_dims
     assert img.metadata
+    assert reader.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from psutil import Process
 
+from aicsimageio import exceptions
 from aicsimageio.readers.lif_reader import LifReader
 
 

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -78,6 +78,7 @@ def test_lif_reader(
     assert img.dims == expected_dims
     assert img.metadata
     assert img.dask_data.shape == expected_shape
+    assert img.size(expected_dims) == expected_shape
     assert img.dtype() == expected_dtype
 
     # Check that there are no open file pointers after basics

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -62,7 +62,7 @@ def test_ome_tiff_reader(
     assert img.dims == expected_dims
     assert img.is_ome()
     assert img.metadata
-    assert reader.shape == expected_shape
+    assert img.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -62,6 +62,7 @@ def test_ome_tiff_reader(
     assert img.dims == expected_dims
     assert img.is_ome()
     assert img.metadata
+    assert reader.shape == expected_shape
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -65,6 +65,10 @@ def test_ome_tiff_reader(
     assert img.dask_data.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert img.size("ABCDEFG") == expected_shape
+
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]
 

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -63,6 +63,7 @@ def test_ome_tiff_reader(
     assert img.is_ome()
     assert img.metadata
     assert img.dask_data.shape == expected_shape
+    assert img.size(expected_dims) == expected_shape
 
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -49,6 +49,7 @@ def test_tiff_reader(
     assert img.dims == expected_dims
     assert img.dtype() == expected_dtype
     assert img.metadata
+    assert reader.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 
     # Will error because those dimensions don't exist in the file

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -49,6 +49,11 @@ def test_tiff_reader(
     assert img.dims == expected_dims
     assert img.dtype() == expected_dtype
     assert img.metadata
+    assert img.size(expected_dims) == expected_shape
+
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert img.size("ABCDEFG") == expected_shape
 
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -49,7 +49,7 @@ def test_tiff_reader(
     assert img.dims == expected_dims
     assert img.dtype() == expected_dtype
     assert img.metadata
-    assert reader.shape == expected_shape
+    assert img.shape == expected_shape
     assert img.size(expected_dims) == expected_shape
 
     # Will error because those dimensions don't exist in the file


### PR DESCRIPTION
## Description
We have a bunch of utility functions exposed on the `AICSImage` object but not exposed on the base reader. This adds those.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #119 
Resolves #118 

- [x] Provide relevant tests for your feature or bug fix.

Note: I do not test `Reader.get_image_data` and `Reader.get_image_dask_data` because, like `AICSImage`, it is simply a passthrough to `transforms.reshape_data`

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
