### PR TITLE
feature/centralize-reader-tests

### DIFF
--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -368,6 +368,15 @@ class Reader(ABC):
         """
         return self.dask_data.shape
 
+    def dtype(self) -> np.dtype:
+        """
+        Returns
+        -------
+        dtype: np.dtype
+            The pixel numpy data type.
+        """
+        return self.dask_data.dtype
+
     @property
     @abstractmethod
     def metadata(self) -> Any:

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -5,10 +5,11 @@ from io import BytesIO
 
 import numpy as np
 import pytest
-from psutil import Process
 
 from aicsimageio import exceptions
 from aicsimageio.readers.czi_reader import CziReader
+
+from .utils import run_image_read_checks
 
 
 @pytest.mark.parametrize(
@@ -106,37 +107,16 @@ def test_czi_reader(
     select_scene,
     chunk_dims,
 ):
-    # Get file
-    f = resources_dir / filename
-
-    # Read file
-    img = CziReader(f, chunk_by_dims=chunk_dims, S=select_scene)
-
-    # Check that there are no open file pointers after init
-    proc = Process()
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check basics
-    assert img.dims == expected_dims
-    assert img.metadata is not None
-    assert img.shape == expected_shape
-    assert img.dask_data.shape == expected_shape
-    assert img.size(expected_dims) == expected_shape
-    assert img.dtype() == expected_dtype
-
-    # Will error because those dimensions don't exist in the file
-    with pytest.raises(exceptions.InvalidDimensionOrderingError):
-        assert img.size("ABCDEFG") == expected_shape
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check array
-    assert isinstance(img.data, np.ndarray)
-    assert img.data.shape == expected_shape
-
-    # Check that there are no open file pointers after retrieval
-    assert str(f) not in [f.path for f in proc.open_files()]
+    run_image_read_checks(
+        ReaderClass=CziReader,
+        resources_dir=resources_dir,
+        filename=filename,
+        chunk_dims=chunk_dims,
+        select_scene=select_scene,
+        expected_shape=expected_shape,
+        expected_dims=expected_dims,
+        expected_dtype=expected_dtype,
+    )
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -8,6 +8,8 @@ from psutil import Process
 from aicsimageio import exceptions
 from aicsimageio.readers.default_reader import DefaultReader
 
+from .utils import run_image_read_checks
+
 
 @pytest.mark.parametrize(
     "filename, expected_shape, expected_dims",
@@ -27,36 +29,16 @@ from aicsimageio.readers.default_reader import DefaultReader
 def test_default_reader(
     resources_dir, filename, expected_shape, expected_dims,
 ):
-    # Get file
-    f = resources_dir / filename
-
-    # Read file
-    img = DefaultReader(f)
-
-    # Check that there are no open file pointers after init
-    proc = Process()
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check basics
-    assert img.dims == expected_dims
-    assert img.metadata
-    assert img.shape == expected_shape
-    assert img.dask_data.shape == expected_shape
-    assert img.size(expected_dims) == expected_shape
-
-    # Will error because those dimensions don't exist in the file
-    with pytest.raises(exceptions.InvalidDimensionOrderingError):
-        assert img.size("ABCDEFG") == expected_shape
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check array
-    assert isinstance(img.data, np.ndarray)
-    assert img.data.shape == expected_shape
-
-    # Check that there are no open file pointers after retrieval
-    assert str(f) not in [f.path for f in proc.open_files()]
+    run_image_read_checks(
+        ReaderClass=DefaultReader,
+        resources_dir=resources_dir,
+        filename=filename,
+        chunk_dims=None,
+        select_scene=None,
+        expected_shape=expected_shape,
+        expected_dims=expected_dims,
+        expected_dtype=np.uint8,
+    )
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -7,8 +7,9 @@ import numpy as np
 import pytest
 from psutil import Process
 
-from aicsimageio import exceptions
 from aicsimageio.readers.lif_reader import LifReader
+
+from .utils import run_image_read_checks
 
 
 @pytest.mark.parametrize(
@@ -63,39 +64,16 @@ def test_lif_reader(
     select_scene,
     chunk_dims,
 ):
-    # Get file
-    f = resources_dir / filename
-    # Check that there are no open file pointers
-    proc = Process()
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Read file
-    img = LifReader(f, chunk_by_dims=chunk_dims, S=select_scene)
-
-    # Check that there are no open file pointers after init
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check basics
-    assert img.dims == expected_dims
-    assert img.metadata
-    assert img.shape == expected_shape
-    assert img.dask_data.shape == expected_shape
-    assert img.size(expected_dims) == expected_shape
-    assert img.dtype() == expected_dtype
-
-    # Will error because those dimensions don't exist in the file
-    with pytest.raises(exceptions.InvalidDimensionOrderingError):
-        assert img.size("ABCDEFG") == expected_shape
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check array
-    assert isinstance(img.data, np.ndarray)
-    assert img.data.shape == expected_shape
-
-    # Check that there are no open file pointers after retrieval
-    assert str(f) not in [f.path for f in proc.open_files()]
+    run_image_read_checks(
+        ReaderClass=LifReader,
+        resources_dir=resources_dir,
+        filename=filename,
+        chunk_dims=chunk_dims,
+        select_scene=select_scene,
+        expected_shape=expected_shape,
+        expected_dims=expected_dims,
+        expected_dtype=expected_dtype,
+    )
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -8,6 +8,8 @@ from psutil import Process
 from aicsimageio import exceptions
 from aicsimageio.readers.tiff_reader import TiffReader
 
+from .utils import run_image_read_checks
+
 
 @pytest.mark.parametrize(
     "filename, " "expected_shape, " "expected_dims, " "expected_dtype, " "select_scene",
@@ -35,36 +37,16 @@ def test_tiff_reader(
     expected_dtype,
     select_scene,
 ):
-    # Get file
-    f = resources_dir / filename
-
-    # Read file
-    img = TiffReader(f, S=select_scene)
-
-    # Check that there are no open file pointers after init
-    proc = Process()
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check basics
-    assert img.dims == expected_dims
-    assert img.dtype() == expected_dtype
-    assert img.metadata
-    assert img.shape == expected_shape
-    assert img.size(expected_dims) == expected_shape
-
-    # Will error because those dimensions don't exist in the file
-    with pytest.raises(exceptions.InvalidDimensionOrderingError):
-        assert img.size("ABCDEFG") == expected_shape
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check arrays
-    assert isinstance(img.data, np.ndarray)
-    assert img.data.shape == expected_shape
-
-    # Check that there are no open file pointers after retrieval
-    assert str(f) not in [f.path for f in proc.open_files()]
+    run_image_read_checks(
+        ReaderClass=TiffReader,
+        resources_dir=resources_dir,
+        filename=filename,
+        chunk_dims=None,
+        select_scene=select_scene,
+        expected_shape=expected_shape,
+        expected_dims=expected_dims,
+        expected_dtype=expected_dtype,
+    )
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/utils.py
+++ b/aicsimageio/tests/readers/utils.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+from psutil import Process
+
+from aicsimageio import exceptions
+from aicsimageio.readers.reader import Reader
+
+###############################################################################
+
+
+def run_image_read_checks(
+    ReaderClass: Reader,
+    resources_dir: Path,
+    filename: str,
+    chunk_dims: List[str],
+    select_scene: int,
+    expected_shape: Tuple[int],
+    expected_dims: str,
+    expected_dtype: np.dtype,
+):
+    # Get file
+    f = resources_dir / filename
+
+    # Check that there are no open file pointers
+    proc = Process()
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    # Read file
+    reader = ReaderClass(f, chunk_by_dims=chunk_dims, S=select_scene)
+
+    # Check that there are no open file pointers after init
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    # Check basics
+    assert reader.dims == expected_dims
+    assert reader.metadata
+    assert reader.shape == expected_shape
+    assert reader.dask_data.shape == expected_shape
+    assert reader.size(expected_dims) == expected_shape
+    assert reader.dtype() == expected_dtype
+
+    # Will error because those dimensions don't exist in the file
+    with pytest.raises(exceptions.InvalidDimensionOrderingError):
+        assert reader.size("ABCDEFG") == expected_shape
+
+    # Check that there are no open file pointers after basics
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    # Check array
+    assert reader.data.shape == expected_shape
+
+    # Check that there are no open file pointers after retrieval
+    assert str(f) not in [f.path for f in proc.open_files()]
+
+    return reader


### PR DESCRIPTION
**This PR is pointed at branch `release-4.0`**

## Description
@AetherUnbound noticed on a previous PR that basically all the reader tests followed the same pattern and recommended I centralize them to a single function. This does just that.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #133 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

## Notes
To make the tests generalize for all readers I added the `dtype` function to the base `Reader` class. In release 4.0 I would prefer to change this to a property to follow the `numpy` / `dask.array` / our own patterns but that would add yet another breaking change. Thoughts?

Thanks for contributing!
