### PR TITLE
admin/update-from-cookiecutter

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Generate Docs
       run: |
         gitchangelog
-        make docs
+        make gen-docs
         touch docs/_build/html/.nojekyll
     - name: Publish Docs
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.8

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,20 +8,21 @@ Ready to contribute? Here's how to set up `aicsimageio` for local development.
 
 1. Fork the `aicsimageio` repo on GitHub.
 
-1. Clone your fork locally:
+2. Clone your fork locally:
 
     ```bash
     git clone git@github.com:{your_name_here}/aicsimageio.git
     ```
 
-1. Install the project in editable mode. (It is also recommended to work in a virtualenv or anaconda environment):
+3. Install the project in editable mode.
+(It is also recommended to work in a virtualenv or anaconda environment):
 
     ```bash
     cd aicsimageio/
     pip install -e .[dev]
     ```
 
-1. Download the test resources:
+4. Download the test resources:
 
     ```bash
     python scripts/download_test_resources.py
@@ -29,7 +30,7 @@ Ready to contribute? Here's how to set up `aicsimageio` for local development.
 
     If you need to upload new resources please let a core maintainer know.
 
-1. Create a branch for local development:
+5. Create a branch for local development:
 
     ```bash
     git checkout -b {your_development_type}/short-description
@@ -38,14 +39,14 @@ Ready to contribute? Here's how to set up `aicsimageio` for local development.
     Ex: feature/read-tiff-files or bugfix/handle-file-not-found<br>
     Now you can make your changes locally.
 
-1. When you're done making changes, check that your changes pass linting and
+6. When you're done making changes, check that your changes pass linting and
    tests, including testing other Python versions with make:
 
     ```bash
     make build
     ```
 
-1. Commit your changes and push your branch to GitHub:
+7. Commit your changes and push your branch to GitHub:
 
     ```bash
     git add .
@@ -53,7 +54,7 @@ Ready to contribute? Here's how to set up `aicsimageio` for local development.
     git push origin {your_development_type}/short-description
     ```
 
-1. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
 
 ## Deploying
 

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,14 @@ clean:  ## clean all build, python, and testing files
 build: ## run tox / run tests and lint
 	tox
 
-docs: ## generate Sphinx HTML documentation, including API docs
+gen-docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/aicsimageio*.rst
 	rm -f docs/modules.rst
 	sphinx-apidoc -o docs/ aicsimageio **/tests/
 	$(MAKE) -C docs html
 
-serve-docs: ## generate Sphinx HTML documentation, including API docs
-	make docs
+docs: ## generate Sphinx HTML documentation, including API docs, and serve to browser
+	make gen-docs
 	$(BROWSER) docs/_build/html/index.html
 
 prepare-release: ## Checkout master, generate new section of changelog

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,21 +14,22 @@ replace = {new_version}
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = 
-	docs/
-	aicsimageio/vendor/
-ignore = 
-	E203
-	W291
-	W503
-max-line-length = 88
-
 [aliases]
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-filterwarnings = 
+filterwarnings =
 	ignore::UserWarning
 	ignore::FutureWarning
+
+[flake8]
+exclude =
+	docs/
+	aicsimageio/vendor/
+ignore =
+	E203
+	E402
+	W291
+	W503
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -21,50 +21,37 @@ requirements = [
     "toolz>=0.10.0",
 ]
 
+setup_requirements = [
+    "pytest-runner>=5.2",
+]
+
 test_requirements = [
     "black>=19.10b0",
-    "codecov>=2.0.22",
+    "codecov>=2.1.4",
     "docutils>=0.10,<0.16",
-    "flake8>=3.7.7",
+    "flake8>=3.8.3",
+    "flake8-debugger>=3.2.1",
     "psutil>=5.7.0",
-    "pytest>=4.3.0",
-    "pytest-cov==2.6.1",
-    "pytest-raises>=0.10",
+    "pytest>=5.4.3",
+    "pytest-cov>=2.9.0",
+    "pytest-raises>=0.11",
     "quilt3>=3.1.12",
 ]
 
 dev_requirements = [
-    "black>=19.10b0",
-    "bumpversion>=0.5.3",
-    "coverage>=5.0a4",
-    "docutils>=0.10,<0.16",
-    "flake8>=3.7.7",
+    *setup_requirements,
+    *test_requirements,
+    "bumpversion>=0.6.0",
+    "coverage>=5.1",
     "gitchangelog>=3.0.4",
-    "ipython>=7.5.0",
+    "ipython>=7.15.0",
     "m2r>=0.2.1",
-    "pytest>=4.3.0",
-    "pytest-cov==2.6.1",
-    "pytest-raises>=0.10",
-    "pytest-runner>=4.4",
-    "quilt3>=3.1.12",
+    "pytest-runner>=5.2",
     "Sphinx>=2.0.0b1,<3",
-    "sphinx_rtd_theme>=0.1.2",
-    "tox>=3.5.2",
-    "twine>=1.13.0",
-    "wheel>=0.33.1",
-]
-
-setup_requirements = [
-    "pytest-runner",
-]
-
-interactive_requirements = [
-    "altair",
-    "bokeh",
-    "jupyterlab",
-    "matplotlib",
-    "napari[pyqt5]>=0.2.10",
-    "pillow",
+    "sphinx_rtd_theme>=0.4.3",
+    "tox>=3.15.2",
+    "twine>=3.1.1",
+    "wheel>=0.34.2",
 ]
 
 benchmark_requirements = [
@@ -79,17 +66,13 @@ benchmark_requirements = [
 ]
 
 extra_requirements = {
+    "setup": setup_requirements,
     "test": test_requirements,
     "dev": dev_requirements,
-    "setup": setup_requirements,
-    "interactive": interactive_requirements,
     "benchmark": benchmark_requirements,
     "all": [
         *requirements,
-        *test_requirements,
-        *setup_requirements,
         *dev_requirements,
-        *interactive_requirements
     ]
 }
 


### PR DESCRIPTION
**This PR points to branch `release-4.0`**

Update from cookiecutter, primarily consists of shuffling test and dev dependencies to be more centralized and manageable. With minor changes to other package admin files.

Notably this removes the `interactive` deps entirely. So `pip install -e .[all]` no longer provides `ipython`, `jupyterlab`, etc.