### PR TITLE
feature/standardize-reader-api

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -9,10 +9,15 @@ import numpy as np
 
 from . import transforms, types
 from .constants import Dimensions
-from .exceptions import (InvalidDimensionOrderingError,
-                         UnsupportedFileFormatError)
-from .readers import (ArrayLikeReader, CziReader, DefaultReader, LifReader,
-                      OmeTiffReader, TiffReader)
+from .exceptions import InvalidDimensionOrderingError, UnsupportedFileFormatError
+from .readers import (
+    ArrayLikeReader,
+    CziReader,
+    DefaultReader,
+    LifReader,
+    OmeTiffReader,
+    TiffReader,
+)
 from .readers.reader import Reader
 
 ###############################################################################

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -9,15 +9,10 @@ import numpy as np
 
 from . import transforms, types
 from .constants import Dimensions
-from .exceptions import InvalidDimensionOrderingError, UnsupportedFileFormatError
-from .readers import (
-    ArrayLikeReader,
-    CziReader,
-    DefaultReader,
-    LifReader,
-    OmeTiffReader,
-    TiffReader,
-)
+from .exceptions import (InvalidDimensionOrderingError,
+                         UnsupportedFileFormatError)
+from .readers import (ArrayLikeReader, CziReader, DefaultReader, LifReader,
+                      OmeTiffReader, TiffReader)
 from .readers.reader import Reader
 
 ###############################################################################
@@ -166,7 +161,7 @@ class AICSImage:
 
         return self._data
 
-    def size(self, dims: str = Dimensions.DefaultOrder) -> Tuple[int]:
+    def get_size(self, dims: str = Dimensions.DefaultOrder) -> Tuple[int]:
         """
         Parameters
         ----------
@@ -201,7 +196,7 @@ class AICSImage:
         shape: Tuple[int]
             A tuple with the size of all dimensions.
         """
-        return self.size()
+        return self.get_size()
 
     @property
     def size_x(self) -> int:
@@ -211,7 +206,7 @@ class AICSImage:
         size: int
             The size of the Spatial X dimension.
         """
-        return self.size(Dimensions.SpatialX)[0]
+        return self.get_size(Dimensions.SpatialX)[0]
 
     @property
     def size_y(self) -> int:
@@ -221,7 +216,7 @@ class AICSImage:
         size: int
             The size of the Spatial Y dimension.
         """
-        return self.size(Dimensions.SpatialY)[0]
+        return self.get_size(Dimensions.SpatialY)[0]
 
     @property
     def size_z(self) -> int:
@@ -231,7 +226,7 @@ class AICSImage:
         size: int
             The size of the Spatial Z dimension.
         """
-        return self.size(Dimensions.SpatialZ)[0]
+        return self.get_size(Dimensions.SpatialZ)[0]
 
     @property
     def size_c(self) -> int:
@@ -241,7 +236,7 @@ class AICSImage:
         size: int
             The size of the Channel dimension.
         """
-        return self.size(Dimensions.Channel)[0]
+        return self.get_size(Dimensions.Channel)[0]
 
     @property
     def size_t(self) -> int:
@@ -251,7 +246,7 @@ class AICSImage:
         size: int
             The size of the Time dimension.
         """
-        return self.size(Dimensions.Time)[0]
+        return self.get_size(Dimensions.Time)[0]
 
     @property
     def size_s(self) -> int:
@@ -261,7 +256,7 @@ class AICSImage:
         size: int
             The size of the Scene dimension.
         """
-        return self.size(Dimensions.Scene)[0]
+        return self.get_size(Dimensions.Scene)[0]
 
     @property
     def metadata(self) -> Any:

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -22,12 +22,7 @@ class InvalidDimensionOrderingError(Exception):
     validation. Should be provided a message for the user to be given more context.
     """
 
-    def __init__(self, message: str, **kwargs):
-        super().__init__(**kwargs)
-        self.message = message
-
-    def __str__(self):
-        return self.message
+    pass
 
 
 class ConflictingArgumentsError(Exception):

--- a/aicsimageio/readers/arraylike_reader.py
+++ b/aicsimageio/readers/arraylike_reader.py
@@ -48,7 +48,7 @@ class ArrayLikeReader(Reader):
     def _read_immediate(self):
         return self._dask_data.compute()
 
-    @Reader.dims.getter
+    @property
     def dims(self) -> str:
         return self._dims
 

--- a/aicsimageio/readers/arraylike_reader.py
+++ b/aicsimageio/readers/arraylike_reader.py
@@ -48,23 +48,9 @@ class ArrayLikeReader(Reader):
     def _read_immediate(self):
         return self._dask_data.compute()
 
-    @property
+    @Reader.dims.getter
     def dims(self) -> str:
         return self._dims
-
-    @dims.setter
-    def dims(self, dims: str):
-        # Check amount of provided dims against data shape
-        if len(dims) != len(self.dask_data.shape):
-            raise exceptions.InvalidDimensionOrderingError(
-                f"Provided too many dimensions for the associated file. "
-                f"Received {len(dims)} dimensions [dims: {dims}] "
-                f"for image with {len(self.data.shape)} dimensions "
-                f"[shape: {self.data.shape}]."
-            )
-
-        # Set the dims
-        self._dims = dims
 
     @property
     def metadata(self) -> None:

--- a/aicsimageio/readers/arraylike_reader.py
+++ b/aicsimageio/readers/arraylike_reader.py
@@ -4,7 +4,7 @@
 import dask.array as da
 import numpy as np
 
-from .. import exceptions, types
+from .. import types
 from .reader import Reader
 
 ###############################################################################

--- a/aicsimageio/readers/arraylike_reader.py
+++ b/aicsimageio/readers/arraylike_reader.py
@@ -40,7 +40,7 @@ class ArrayLikeReader(Reader):
             raise TypeError(data)
 
         # Guess dims
-        self._dims = self.guess_dim_order(self.dask_data.shape)
+        self._dims = self.guess_dim_order(self.shape)
 
     def _read_delayed(self):
         return self._dask_data

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -448,14 +448,11 @@ class CziReader(Reader):
 
         return data
 
-    @property
+    @Reader.dims.getter
     def dims(self) -> str:
         if self._dims is None:
             self._dims = CziFile(self._file).dims
         return self._dims
-
-    def dtype(self) -> np.dtype:
-        return self.dask_data.dtype
 
     @property
     def metadata(self) -> _Element:
@@ -470,29 +467,29 @@ class CziReader(Reader):
         # state
         return CziFile(self._file).meta
 
-    def _size_of_dimension(self, dim: str) -> int:
-        if dim in self.dims:
-            return self.dask_data.shape[self.dims.index(dim)]
-
-        return 1
-
+    @property
     def size_s(self) -> int:
-        return self._size_of_dimension(Dimensions.Scene)
+        return self.get_size_of_dimension(Dimensions.Scene)
 
+    @property
     def size_t(self) -> int:
-        return self._size_of_dimension(Dimensions.Time)
+        return self.get_size_of_dimension(Dimensions.Time)
 
+    @property
     def size_c(self) -> int:
-        return self._size_of_dimension(Dimensions.Channel)
+        return self.get_size_of_dimension(Dimensions.Channel)
 
+    @property
     def size_z(self) -> int:
-        return self._size_of_dimension(Dimensions.SpatialZ)
+        return self.get_size_of_dimension(Dimensions.SpatialZ)
 
+    @property
     def size_y(self) -> int:
-        return self._size_of_dimension(Dimensions.SpatialY)
+        return self.get_size_of_dimension(Dimensions.SpatialY)
 
+    @property
     def size_x(self) -> int:
-        return self._size_of_dimension(Dimensions.SpatialX)
+        return self.get_size_of_dimension(Dimensions.SpatialX)
 
     def get_channel_names(self, scene: int = 0):
         chelem = self.metadata.findall(

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -448,7 +448,7 @@ class CziReader(Reader):
 
         return data
 
-    @Reader.dims.getter
+    @property
     def dims(self) -> str:
         if self._dims is None:
             self._dims = CziFile(self._file).dims

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -104,7 +104,7 @@ class DefaultReader(Reader):
         except exceptions.UnsupportedFileFormatError:
             raise exceptions.UnsupportedFileFormatError(self._file)
 
-    @Reader.dims.getter
+    @property
     def dims(self) -> str:
         # Set dims if not set
         if self._dims is None:

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -108,14 +108,14 @@ class DefaultReader(Reader):
     def dims(self) -> str:
         # Set dims if not set
         if self._dims is None:
-            if len(self.dask_data.shape) == 2:
+            if len(self.shape) == 2:
                 self._dims = "YX"
-            elif len(self.dask_data.shape) == 3:
+            elif len(self.shape) == 3:
                 self._dims = "YXC"
-            elif len(self.dask_data.shape) == 4:
+            elif len(self.shape) == 4:
                 self._dims = "TYXC"
             else:
-                self._dims = self.guess_dim_order(self.dask_data.shape)
+                self._dims = self.guess_dim_order(self.shape)
 
         return self._dims
 
@@ -131,7 +131,7 @@ class DefaultReader(Reader):
         # Check for channel in dims
         if Dimensions.Channel in self.dims:
             channel_index = self.dims.index(Dimensions.Channel)
-            channel_dim_size = self.dask_data.shape[channel_index]
+            channel_dim_size = self.shape[channel_index]
 
             # RGB vs RGBA vs other
             if channel_dim_size == 3:

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -58,15 +58,15 @@ class LifReader(Reader):
     #
     ########################################################
 
-    @property
+    @Reader.dims.getter
     def dims(self) -> str:
         """
         The dimensions for a lif file.
 
         Returns
         -------
-        str
-            "STCZYX"
+        dims: str
+            Always returns: "STCZYX"
         """
         return Dimensions.DefaultOrder  # forcing 6 D
 
@@ -776,18 +776,6 @@ class LifReader(Reader):
 
         return data
 
-    def dtype(self) -> np.dtype:
-        """
-        The data type of the underlying numpy ndarray, ie uint8, uint16, uint32 etc.
-
-        Returns
-        -------
-        numpy.dtype
-            The data format used to store the data in the Leica lif file and the read
-            numpy.ndarray.
-        """
-        return self.dask_data.dtype
-
     @property
     def metadata(self) -> Element:
         """
@@ -802,29 +790,29 @@ class LifReader(Reader):
         meta_xml, header = utilities.get_xml(self._file)
         return meta_xml
 
-    def _size_of_dimension(self, dim: str) -> int:
-        if dim in self.dims:
-            return self.dask_data.shape[self.dims.index(dim)]
-
-        return 1
-
+    @property
     def size_s(self) -> int:
-        return self._size_of_dimension(Dimensions.Scene)
+        return self.get_size_of_dimension(Dimensions.Scene)
 
+    @property
     def size_t(self) -> int:
-        return self._size_of_dimension(Dimensions.Time)
+        return self.get_size_of_dimension(Dimensions.Time)
 
+    @property
     def size_c(self) -> int:
-        return self._size_of_dimension(Dimensions.Channel)
+        return self.get_size_of_dimension(Dimensions.Channel)
 
+    @property
     def size_z(self) -> int:
-        return self._size_of_dimension(Dimensions.SpatialZ)
+        return self.get_size_of_dimension(Dimensions.SpatialZ)
 
+    @property
     def size_y(self) -> int:
-        return self._size_of_dimension(Dimensions.SpatialY)
+        return self.get_size_of_dimension(Dimensions.SpatialY)
 
+    @property
     def size_x(self) -> int:
-        return self._size_of_dimension(Dimensions.SpatialX)
+        return self.get_size_of_dimension(Dimensions.SpatialX)
 
     def get_channel_names(self, scene: int = 0) -> List[str]:
         """

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -58,7 +58,7 @@ class LifReader(Reader):
     #
     ########################################################
 
-    @Reader.dims.getter
+    @property
     def dims(self) -> str:
         """
         The dimensions for a lif file.

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -73,21 +73,27 @@ class OmeTiffReader(TiffReader):
 
         return self._metadata
 
+    @property
     def size_s(self) -> int:
         return self.metadata.image_count
 
+    @property
     def size_t(self) -> int:
         return self.metadata.image().Pixels.SizeT
 
+    @property
     def size_c(self) -> int:
         return self.metadata.image().Pixels.SizeC
 
+    @property
     def size_z(self) -> int:
         return self.metadata.image().Pixels.SizeZ
 
+    @property
     def size_y(self) -> int:
         return self.metadata.image().Pixels.SizeY
 
+    @property
     def size_x(self) -> int:
         return self.metadata.image().Pixels.SizeX
 

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -352,12 +352,12 @@ class Reader(ABC):
             available image data.
         """
         # Check amount of provided dims against data shape
-        if len(dims) != len(self.dask_data.shape):
+        if len(dims) != len(self.shape):
             raise exceptions.InvalidDimensionOrderingError(
                 f"Provided too many dimensions for the associated file. "
                 f"Received {len(dims)} dimensions [dims: {dims}] "
-                f"for image with {len(self.data.shape)} dimensions "
-                f"[shape: {self.data.shape}]."
+                f"for image with {len(self.shape)} dimensions "
+                f"[shape: {self.shape}]."
             )
 
         # Set the dims
@@ -386,7 +386,7 @@ class Reader(ABC):
             )
 
         # Return the shape of the data for the dimensions requested
-        return tuple([self.dask_data.shape[self.dims.index(dim)] for dim in dims])
+        return tuple([self.shape[self.dims.index(dim)] for dim in dims])
 
     def get_size_of_dimension(self, dim: str) -> int:
         """
@@ -402,7 +402,7 @@ class Reader(ABC):
         """
         dim = dim.upper()
         if dim in self.dims:
-            return self.dask_data.shape[self.dims.index(dim)]
+            return self.get_size(dim)[0]
 
         return 1
 
@@ -469,7 +469,7 @@ class Reader(ABC):
 
         # Channel dimension in reader data, get default channel names
         channel_index = self.dims.index(Dimensions.Channel)
-        channel_dim_size = self.dask_data.shape[channel_index]
+        channel_dim_size = self.shape[channel_index]
         return [str(i) for i in range(channel_dim_size)]
 
     def __enter__(self):

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -337,32 +337,6 @@ class Reader(ABC):
         # https://stackoverflow.com/questions/15785982/python-overriding-getter-without-setter/15786149#15786149
         pass
 
-    @dims.setter
-    def dims(self, dims: str):
-        """
-        Parameters
-        ----------
-        dims: str
-            The dimensions of the image.
-
-        Raises
-        ------
-        exceptions.InvalidDimensionOrderingError:
-            If too many or too few dimensions were provided in comparison to the
-            available image data.
-        """
-        # Check amount of provided dims against data shape
-        if len(dims) != len(self.shape):
-            raise exceptions.InvalidDimensionOrderingError(
-                f"Provided too many dimensions for the associated file. "
-                f"Received {len(dims)} dimensions [dims: {dims}] "
-                f"for image with {len(self.shape)} dimensions "
-                f"[shape: {self.shape}]."
-            )
-
-        # Set the dims
-        self._dims = dims
-
     def get_size(self, dims: str = Dimensions.DefaultOrder) -> Tuple[int]:
         """
         Parameters

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -333,7 +333,8 @@ class Reader(ABC):
     def dims(self) -> str:
         # When implementing a new reader you must use
         # @Reader.dims.getter instead of simply @property
-        # See: https://stackoverflow.com/questions/15785982/python-overriding-getter-without-setter/15786149#15786149
+        # See:
+        # https://stackoverflow.com/questions/15785982/python-overriding-getter-without-setter/15786149#15786149
         pass
 
     @dims.setter

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 
 ###############################################################################
 
+
 class TiffProperties(NamedTuple):
     dims: str
     shape: Tuple[int]
@@ -185,8 +186,8 @@ class TiffReader(Reader):
             return tiff.asarray()
 
     @staticmethod
-    def _guess_tiff_dims(tiff: TiffFile, S: int) -> str:
-        guess = self.guess_dim_order(tiff.series[S].pages.shape)
+    def _guess_tiff_dims(single_scene_dims: str) -> str:
+        guess = TiffReader.guess_dim_order(single_scene_dims)
         best_guess = []
         for dim_from_meta in single_scene_dims:
             if dim_from_meta in Dimensions.DefaultOrder:
@@ -222,9 +223,8 @@ class TiffReader(Reader):
             # We can sometimes trust the dimension info in the image
             if all([d in Dimensions.DefaultOrder for d in single_scene_dims]):
                 # Add scene dimension only if there are multiple scenes
-                if (
-                    len(tiff.series) > 1
-                    and TiffReader._scene_shape_is_consistent(tiff, S)
+                if len(tiff.series) > 1 and TiffReader._scene_shape_is_consistent(
+                    tiff, S
                 ):
                     dims = f"{Dimensions.Scene}{single_scene_dims}"
                     shape = (len(tiff.series), *single_scene_shape)
@@ -235,13 +235,12 @@ class TiffReader(Reader):
             # Sometimes the dimension info is wrong in certain dimensions, so guess
             # that dimension
             else:
-                dims_best_guess = TiffReader._guess_tiff_dims(tiff, S)
+                dims_best_guess = TiffReader._guess_tiff_dims(single_scene_dims)
 
                 # Add scene dimension only if there are multiple scenes
                 # and only when scene dimensions are consistent shape
-                if (
-                    len(tiff.series) > 1
-                    and TiffReader._scene_shape_is_consistent(tiff, S)
+                if len(tiff.series) > 1 and TiffReader._scene_shape_is_consistent(
+                    tiff, S
                 ):
                     dims = f"{Dimensions.Scene}{dims_best_guess}"
                     shape = (len(tiff.series), *single_scene_shape)

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -178,10 +178,7 @@ class TiffReader(Reader):
             # Else, return single scene
             return tiff.asarray()
 
-    def load_slice(self, slice_index: int = 0) -> np.ndarray:
-        with TiffFile(self._file) as tiff:
-            return tiff.asarray(key=slice_index)
-
+    @property
     def dtype(self):
         if self._dtype is None:
             with TiffFile(self._file) as tiff:
@@ -189,7 +186,7 @@ class TiffReader(Reader):
 
         return self._dtype
 
-    @property
+    @Reader.dims.getter
     def dims(self) -> str:
         if self._dims is None:
             # Get a single scenes dimensions in order
@@ -238,20 +235,6 @@ class TiffReader(Reader):
                         self._dims = f"{Dimensions.Scene}{best_guess}"
 
         return self._dims
-
-    @dims.setter
-    def dims(self, dims: str):
-        # Check amount of provided dims against data shape
-        if len(dims) != len(self.dask_data.shape):
-            raise exceptions.InvalidDimensionOrderingError(
-                f"Provided too many dimensions for the associated file. "
-                f"Received {len(dims)} dimensions [dims: {dims}] "
-                f"for image with {len(self.data.shape)} dimensions "
-                f"[shape: {self.data.shape}]."
-            )
-
-        # Set the dims
-        self._dims = dims
 
     @staticmethod
     def get_image_description(buffer: io.BufferedIOBase) -> Optional[bytearray]:

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -250,7 +250,7 @@ class TiffReader(Reader):
 
         return TiffProperties(dims, shape, dtype)
 
-    @Reader.dims.getter
+    @property
     def dims(self) -> str:
         if self._dims is None:
             props = self._get_tiff_properties(self._file, self.specific_s_index)

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -11,7 +11,7 @@ import numpy as np
 from dask import delayed
 from tifffile import TiffFile
 
-from .. import exceptions, types
+from .. import types
 from ..buffer_reader import BufferReader
 from ..constants import Dimensions
 from .reader import Reader

--- a/aicsimageio/tests/readers/test_arraylike_reader.py
+++ b/aicsimageio/tests/readers/test_arraylike_reader.py
@@ -41,33 +41,3 @@ def test_arraylike_reader(arr, expected_shape, expected_dims):
     # Check array
     assert isinstance(reader.data, np.ndarray)
     assert reader.data.shape == expected_shape
-
-
-@pytest.mark.parametrize(
-    "expected_starting_dims, set_dims, expected_ending_dims",
-    [
-        ("ZYX", "YXC", "YXC"),
-        ("ZYX", "TYX", "TYX"),
-        ("ZYX", "ABC", "ABC"),
-        pytest.param(
-            "ZYX",
-            "ABCDE",
-            None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
-        ),
-    ],
-)
-def test_dims_setting(expected_starting_dims, set_dims, expected_ending_dims):
-    # Read file
-    img = ArrayLikeReader(da.ones((2, 2, 2)))
-
-    # Check basics
-    assert img.dims == expected_starting_dims
-
-    # Set dims
-    img.dims = set_dims
-
-    # Check dims after update
-    assert img.dims == expected_ending_dims

--- a/aicsimageio/tests/readers/test_arraylike_reader.py
+++ b/aicsimageio/tests/readers/test_arraylike_reader.py
@@ -32,11 +32,11 @@ def test_arraylike_reader(arr, expected_shape, expected_dims):
     assert reader.metadata is None
     assert reader.shape == expected_shape
     assert reader.dask_data.shape == expected_shape
-    assert reader.size(expected_dims) == expected_shape
+    assert reader.get_size(expected_dims) == expected_shape
 
     # Will error because those dimensions don't exist in the file
     with pytest.raises(exceptions.InvalidDimensionOrderingError):
-        assert reader.size("ABCDEFG") == expected_shape
+        assert reader.get_size("ABCDEFG") == expected_shape
 
     # Check array
     assert isinstance(reader.data, np.ndarray)

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -182,9 +182,9 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     img = CziReader(f)
 
     # Check sizes
-    assert img.size_s() == s
-    assert img.size_t() == t
-    assert img.size_c() == c
-    assert img.size_z() == z
-    assert img.size_y() == y
-    assert img.size_x() == x
+    assert img.size_s == s
+    assert img.size_t == t
+    assert img.size_c == c
+    assert img.size_z == z
+    assert img.size_y == y
+    assert img.size_x == x

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-from psutil import Process
 
 from aicsimageio import exceptions
 from aicsimageio.readers.default_reader import DefaultReader
@@ -39,51 +38,3 @@ def test_default_reader(
         expected_dims=expected_dims,
         expected_dtype=np.uint8,
     )
-
-
-@pytest.mark.parametrize(
-    "expected_starting_dims, set_dims, expected_ending_dims",
-    [
-        ("YXC", "ZXC", "ZXC"),
-        ("YXC", "YXZ", "YXZ"),
-        ("YXC", "ABC", "ABC"),
-        pytest.param(
-            "YXC",
-            "ABCDE",
-            None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
-        ),
-    ],
-)
-def test_dims_setting(
-    resources_dir, expected_starting_dims, set_dims, expected_ending_dims
-):
-    # Get file
-    f = resources_dir / "example.png"
-
-    # Read file
-    img = DefaultReader(f)
-
-    # Check that there are no open file pointers after init
-    proc = Process()
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check basics
-    assert img.dims == expected_starting_dims
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Update dims
-    img.dims = set_dims
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check expected
-    assert img.dims == expected_ending_dims
-
-    # Check that there are no open file pointers after retrieval
-    assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -173,12 +173,12 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     assert str(f) not in [f.path for f in proc.open_files()]
 
     # Check sizes
-    assert img.size_s() == s
-    assert img.size_t() == t
-    assert img.size_c() == c
-    assert img.size_z() == z
-    assert img.size_y() == y
-    assert img.size_x() == x
+    assert img.size_s == s
+    assert img.size_t == t
+    assert img.size_c == c
+    assert img.size_z == z
+    assert img.size_y == y
+    assert img.size_x == x
 
     # Check that there are no open file pointers
     assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -49,7 +49,7 @@ def test_ome_tiff_reader(
     )
 
     # Check that OME Metadata matches the dask data array shape and dims order
-    dim_size_getters = {
+    dim_sizes = {
         Dimensions.Scene: reader.size_s,
         Dimensions.Time: reader.size_t,
         Dimensions.Channel: reader.size_c,
@@ -57,9 +57,9 @@ def test_ome_tiff_reader(
         Dimensions.SpatialY: reader.size_y,
         Dimensions.SpatialX: reader.size_x,
     }
-    for d, getter in dim_size_getters.items():
+    for d, val in dim_sizes.items():
         if d in expected_dims:
-            assert getter() == reader.dask_data.shape[reader.dims.index(d)]
+            assert val == reader.dask_data.shape[reader.dims.index(d)]
 
     assert reader.is_ome()
 
@@ -148,9 +148,9 @@ def test_size_functions(resources_dir, filename, s, t, c, z, y, x):
     img = OmeTiffReader(f)
 
     # Check sizes
-    assert img.size_s() == s
-    assert img.size_t() == t
-    assert img.size_c() == c
-    assert img.size_z() == z
-    assert img.size_y() == y
-    assert img.size_x() == x
+    assert img.size_s == s
+    assert img.size_t == t
+    assert img.size_c == c
+    assert img.size_z == z
+    assert img.size_y == y
+    assert img.size_x == x

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-from psutil import Process
 
 from aicsimageio import exceptions
 from aicsimageio.readers.tiff_reader import TiffReader
@@ -47,49 +46,3 @@ def test_tiff_reader(
         expected_dims=expected_dims,
         expected_dtype=expected_dtype,
     )
-
-
-@pytest.mark.parametrize(
-    "expected_starting_dims, set_dims, expected_ending_dims",
-    [
-        ("YX", "XY", "XY"),
-        pytest.param(
-            "YX",
-            "ABCDE",
-            None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
-        ),
-    ],
-)
-def test_dims_setting(
-    resources_dir, expected_starting_dims, set_dims, expected_ending_dims
-):
-    # Get file
-    f = resources_dir / "s_1_t_1_c_1_z_1.tiff"
-
-    # Read file
-    img = TiffReader(f)
-
-    # Check that there are no open file pointers after init
-    proc = Process()
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check basics
-    assert img.dims == expected_starting_dims
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Update dims
-    img.dims = set_dims
-
-    # Check that there are no open file pointers after basics
-    assert str(f) not in [f.path for f in proc.open_files()]
-
-    # Check expected dims
-    assert img.dims == expected_ending_dims
-
-    # Check that there are no open file pointers after retrieval
-    assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/readers/utils.py
+++ b/aicsimageio/tests/readers/utils.py
@@ -42,12 +42,12 @@ def run_image_read_checks(
     assert reader.metadata
     assert reader.shape == expected_shape
     assert reader.dask_data.shape == expected_shape
-    assert reader.size(expected_dims) == expected_shape
-    assert reader.dtype() == expected_dtype
+    assert reader.get_size(expected_dims) == expected_shape
+    assert reader.dtype == expected_dtype
 
     # Will error because those dimensions don't exist in the file
     with pytest.raises(exceptions.InvalidDimensionOrderingError):
-        assert reader.size("ABCDEFG") == expected_shape
+        assert reader.get_size("ABCDEFG") == expected_shape
 
     # Check that there are no open file pointers after basics
     assert str(f) not in [f.path for f in proc.open_files()]

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -155,7 +155,7 @@ def test_known_dims(data, dims, expected_shape):
     assert img.size_c == expected_shape[2]
     assert img.size_t == expected_shape[1]
     assert img.size_s == expected_shape[0]
-    assert img.size(dims) == data.shape
+    assert img.get_size(dims) == data.shape
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_force_dims(data_shape, dims, expected):
     assert img.size_c == expected[2]
     assert img.size_t == expected[1]
     assert img.size_s == expected[0]
-    assert img.size(dims) == data_shape
+    assert img.get_size(dims) == data_shape
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/writers/test_ome_tiff_writer.py
+++ b/aicsimageio/tests/writers/test_ome_tiff_writer.py
@@ -127,11 +127,11 @@ def test_dimensionOrder(
 
     reader = OmeTiffReader(resources_dir / filename)
     output = reader.data
-    t = reader.size_t()
-    c = reader.size_c()
-    z = reader.size_z()
-    y = reader.size_y()
-    x = reader.size_x()
+    t = reader.size_t
+    c = reader.size_c
+    z = reader.size_z
+    y = reader.size_y
+    x = reader.size_x
 
     os.remove(resources_dir / filename)
 


### PR DESCRIPTION
**This PR is pointed at branch `release-4.0` meaning: this will not be released to public until release 4.**

## Description

While we are making changes to APIs for `release-4.0` it seems like now would be a good time to stabilize our reader API as well.

So, as much as I would love there to be a `flake8` plugin to do this:
* function names must begin with a verb
* property names must be nouns

Changes:
* `dtype` on `AICSImage` and `Reader` subclasses is now a property (was a function)
* renamed function `size` to `get_size` on Reader subclasses
* added function `get_size_of_dimension` to Reader as many children had already implemented an undocumented version of it
* removed `load_slice` function from `TiffReader` and `OmeTiffReader` (duplicated work now that `dask_data` is available)
* `size_{dimension}` functions on `Reader` subclasses that implemented them is now a property (was a function, additionally now matches the `AICSImage` API which already was a property)
* removed all custom dimension dims setting from base readers

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
