### PR TITLE
feature/use-in-memory-data-for-non-dask-calls

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Allen Institute for Cell Science
+Copyright 2020 Allen Institute for Cell Science
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ s0t0 = lazy_s0t0.compute()
 In short, if the word "dask" appears in the function or property name, the function
 utilizes delayed reading, if not, the underlying operation is backed by the image fully
 read into memory. I.E. `AICSImage.data` and `AICSImage.get_image_data` load the entire
-image into memory, and `AICSImage.dask_data` and `AICSImage.get_image_dask_data` do not
-load any image data until the user calls `compute` on the `dask.Array` object and only
-the requested chunk will be loaded into memory instead of the entire image.
+image into memory before performing their operation, and `AICSImage.dask_data` and
+`AICSImage.get_image_dask_data` do not load any image data until the user calls
+`compute` on the `dask.Array` object and only the requested chunk will be loaded into
+memory instead of the entire image.
 
 ### Speed up IO and Processing with Dask Clients and Clusters
 If you have already spun up a `distributed.Client` object in your Python process or

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ img = AICSImage("my_file.tiff")
 img.data  # returns 6D STCZYX numpy array
 img.dims  # returns string "STCZYX"
 img.shape  # returns tuple of dimension sizes in STCZYX order
+img.get_image_data("CZYX", S=0, T=0)  # returns 4D CZYX numpy array
 
 # Get 6D STCZYX numpy array
 data = imread("my_file.tiff")
 ```
 
-### Delayed Image Slice Reading
+### Delayed Image Reading
 ```python
 from aicsimageio import AICSImage, imread_dask
 
@@ -52,7 +53,6 @@ img.dask_data  # returns 6D STCZYX dask array
 img.dims  # returns string "STCZYX"
 img.shape  # returns tuple of dimension sizes in STCZYX order
 img.size("STC")  # returns tuple of dimensions sizes for just STC
-img.get_image_data("CZYX", S=0, T=0)  # returns 4D CZYX numpy array
 img.get_image_dask_data("CZYX", S=0, T=0)  # returns 4D CZYX dask array
 
 # Read specified portion of dask array
@@ -65,6 +65,13 @@ lazy_s0t0 = lazy_data[0, 0, :]
 s0t0 = lazy_s0t0.compute()
 ```
 
+#### Quick Start Notes
+In short, if the word "dask" appears in the function or property name, the function
+utilizes delayed reading, if not, the underlying operation is backed by the image fully
+read into memory. I.E. `AICSImage.data` and `AICSImage.get_image_data` load the entire
+image into memory, and `AICSImage.dask_data` and `AICSImage.get_image_dask_data` do not
+load any image data until the user calls `compute` on the `dask.Array` object and only
+the requested chunk will be loaded into memory instead of the entire image.
 
 ### Speed up IO and Processing with Dask Clients and Clusters
 If you have already spun up a `distributed.Client` object in your Python process or

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -10,15 +10,10 @@ import numpy as np
 
 from . import transforms, types
 from .constants import Dimensions
-from .exceptions import InvalidDimensionOrderingError, UnsupportedFileFormatError
-from .readers import (
-    ArrayLikeReader,
-    CziReader,
-    DefaultReader,
-    LifReader,
-    OmeTiffReader,
-    TiffReader,
-)
+from .exceptions import (InvalidDimensionOrderingError,
+                         UnsupportedFileFormatError)
+from .readers import (ArrayLikeReader, CziReader, DefaultReader, LifReader,
+                      OmeTiffReader, TiffReader)
 from .readers.reader import Reader
 
 ###############################################################################
@@ -76,13 +71,14 @@ class AICSImage:
 
         Examples
         --------
-        Initialize an image and read the slices specified as a numpy array.
+        Initialize an image then read the file and return specified slices as a numpy
+        array.
 
         >>> img = AICSImage("my_file.tiff")
         ... zstack_t8 = img.get_image_data("ZYX", S=0, T=8, C=0)
 
         Initialize an image, construct a delayed dask array for certain slices, then
-        read the data.
+        read just that data.
 
         >>> img = AICSImage("my_file.czi")
         ... zstack_t8 = img.get_image_dask_data("ZYX", S=0, T=8, C=0)
@@ -405,7 +401,7 @@ class AICSImage:
         self, out_orientation: Optional[str] = None, **kwargs
     ) -> np.ndarray:
         """
-        Get specific dimension image data out of an image as a numpy array.
+        Read the image as a numpy array then return specific dimension image data.
 
         Parameters
         ----------
@@ -464,12 +460,21 @@ class AICSImage:
         -----
         * If a requested dimension is not present in the data the dimension is
           added with a depth of 1.
+        * This will preload the entire image before returning the requested data.
 
         See `aicsimageio.transforms.reshape_data` for more details.
         """
-        return self.get_image_dask_data(
-            out_orientation=out_orientation, **kwargs
-        ).compute()
+        # If no out orientation, simply return current data as dask array
+        if out_orientation is None:
+            return self.data
+
+        # Transform and return
+        return transforms.reshape_data(
+            data=self.data,
+            given_dims=self.dims,
+            return_dims=out_orientation,
+            **kwargs,
+        )
 
     def view_napari(self, rgb: bool = False, **kwargs):
         """

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -10,15 +10,10 @@ import numpy as np
 
 from . import transforms, types
 from .constants import Dimensions
-from .exceptions import InvalidDimensionOrderingError, UnsupportedFileFormatError
-from .readers import (
-    ArrayLikeReader,
-    CziReader,
-    DefaultReader,
-    LifReader,
-    OmeTiffReader,
-    TiffReader,
-)
+from .exceptions import (InvalidDimensionOrderingError,
+                         UnsupportedFileFormatError)
+from .readers import (ArrayLikeReader, CziReader, DefaultReader, LifReader,
+                      OmeTiffReader, TiffReader)
 from .readers.reader import Reader
 
 ###############################################################################
@@ -83,7 +78,7 @@ class AICSImage:
         ... zstack_t8 = img.get_image_data("ZYX", S=0, T=8, C=0)
 
         Initialize an image, construct a delayed dask array for certain slices, then
-        read just that data.
+        read only that data.
 
         >>> img = AICSImage("my_file.czi")
         ... zstack_t8 = img.get_image_dask_data("ZYX", S=0, T=8, C=0)

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -10,10 +10,15 @@ import numpy as np
 
 from . import transforms, types
 from .constants import Dimensions
-from .exceptions import (InvalidDimensionOrderingError,
-                         UnsupportedFileFormatError)
-from .readers import (ArrayLikeReader, CziReader, DefaultReader, LifReader,
-                      OmeTiffReader, TiffReader)
+from .exceptions import InvalidDimensionOrderingError, UnsupportedFileFormatError
+from .readers import (
+    ArrayLikeReader,
+    CziReader,
+    DefaultReader,
+    LifReader,
+    OmeTiffReader,
+    TiffReader,
+)
 from .readers.reader import Reader
 
 ###############################################################################

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -771,7 +771,10 @@ class LifReader(Reader):
             # have the same dimensions
             # Read all data in the image
             data, _ = LifReader._get_array_from_offset(
-                self._file, self._chunk_offsets, self._chunk_lengths, self.metadata,
+                self._file,
+                self._chunk_offsets,
+                self._chunk_lengths,
+                self.metadata,
             )
 
         return data

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -269,7 +269,7 @@ class Reader(ABC):
         self, out_orientation: Optional[str] = None, **kwargs
     ) -> np.ndarray:
         """
-        Get specific dimension image data out of an image as a numpy array.
+        Read the image as a numpy array then return specific dimension image data.
 
         Parameters
         ----------
@@ -328,12 +328,21 @@ class Reader(ABC):
         -----
         * If a requested dimension is not present in the data the dimension is
           added with a depth of 1.
+        * This will preload the entire image before returning the requested data.
 
         See `aicsimageio.transforms.reshape_data` for more details.
         """
-        return self.get_image_dask_data(
-            out_orientation=out_orientation, **kwargs
-        ).compute()
+        # If no out orientation, simply return current data as dask array
+        if out_orientation is None:
+            return self.data
+
+        # Transform and return
+        return transforms.reshape_data(
+            data=self.data,
+            given_dims=self.dims,
+            return_dims=out_orientation,
+            **kwargs,
+        )
 
     @property
     @abstractmethod

--- a/aicsimageio/tests/readers/test_arraylike_reader.py
+++ b/aicsimageio/tests/readers/test_arraylike_reader.py
@@ -19,7 +19,10 @@ from aicsimageio.readers import ArrayLikeReader
         (da.ones((1, 1, 1)), (1, 1, 1), "ZYX"),
         (da.ones((1, 1, 1, 1)), (1, 1, 1, 1), "CZYX"),
         pytest.param(
-            "hello_word", None, None, marks=pytest.mark.raises(exceptions=TypeError),
+            "hello_word",
+            None,
+            None,
+            marks=pytest.mark.raises(exceptions=TypeError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -60,7 +60,14 @@ from aicsimageio.readers.czi_reader import CziReader
             ("S", "Y", "X"),
         ),
         # Check that Spatial Y and Spatial X dims are always added to chunk dims
-        ("s_3_t_1_c_3_z_5.czi", (1, 3, 3, 5, 325, 475), "BSCZYX", np.uint16, 0, ("S"),),
+        (
+            "s_3_t_1_c_3_z_5.czi",
+            (1, 3, 3, 5, 325, 475),
+            "BSCZYX",
+            np.uint16,
+            0,
+            ("S"),
+        ),
         (
             "variable_per_scene_dims.czi",
             (1, 1, 2, 1, 2, 1248, 1848),

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -25,7 +25,10 @@ from aicsimageio.readers.default_reader import DefaultReader
     ],
 )
 def test_default_reader(
-    resources_dir, filename, expected_shape, expected_dims,
+    resources_dir,
+    filename,
+    expected_shape,
+    expected_dims,
 ):
     # Get file
     f = resources_dir / filename

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -14,8 +14,18 @@ from aicsimageio.readers.ome_tiff_reader import OmeTiffReader
     "filename, " "expected_shape, " "expected_dims, " "select_scene",
     [
         ("s_1_t_1_c_1_z_1.ome.tiff", (325, 475), "YX", 0),
-        ("s_1_t_1_c_10_z_1.ome.tiff", (10, 1736, 1776), "CYX", 0,),
-        ("s_3_t_1_c_3_z_5.ome.tiff", (3, 5, 3, 325, 475), "SZCYX", 0,),
+        (
+            "s_1_t_1_c_10_z_1.ome.tiff",
+            (10, 1736, 1776),
+            "CYX",
+            0,
+        ),
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            (3, 5, 3, 325, 475),
+            "SZCYX",
+            0,
+        ),
         pytest.param(
             "example.txt",
             None,
@@ -33,7 +43,11 @@ from aicsimageio.readers.ome_tiff_reader import OmeTiffReader
     ],
 )
 def test_ome_tiff_reader(
-    resources_dir, filename, expected_shape, expected_dims, select_scene,
+    resources_dir,
+    filename,
+    expected_shape,
+    expected_dims,
+    select_scene,
 ):
     # Get file
     f = resources_dir / filename

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -12,11 +12,41 @@ from aicsimageio.readers.tiff_reader import TiffReader
 @pytest.mark.parametrize(
     "filename, " "expected_shape, " "expected_dims, " "expected_dtype, " "select_scene",
     [
-        ("s_1_t_1_c_1_z_1.ome.tiff", (325, 475), "YX", np.uint16, 0,),
-        ("s_1_t_1_c_1_z_1.tiff", (325, 475), "YX", np.uint16, 0,),
-        ("s_1_t_1_c_10_z_1.ome.tiff", (10, 1736, 1776), "CYX", np.uint16, 0,),
-        ("s_1_t_10_c_3_z_1.tiff", (10, 3, 325, 475), "TCYX", np.uint16, 0,),
-        ("s_3_t_1_c_3_z_5.ome.tiff", (3, 5, 3, 325, 475), "SZCYX", np.uint16, 0,),
+        (
+            "s_1_t_1_c_1_z_1.ome.tiff",
+            (325, 475),
+            "YX",
+            np.uint16,
+            0,
+        ),
+        (
+            "s_1_t_1_c_1_z_1.tiff",
+            (325, 475),
+            "YX",
+            np.uint16,
+            0,
+        ),
+        (
+            "s_1_t_1_c_10_z_1.ome.tiff",
+            (10, 1736, 1776),
+            "CYX",
+            np.uint16,
+            0,
+        ),
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            (10, 3, 325, 475),
+            "TCYX",
+            np.uint16,
+            0,
+        ),
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            (3, 5, 3, 325, 475),
+            "SZCYX",
+            np.uint16,
+            0,
+        ),
         pytest.param(
             "example.txt",
             None,

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -423,14 +423,22 @@ def test_view_napari(
         (TIF_FILE, (1, 1, 1, 1, 325, 475), str),
         (OME_FILE, (1, 1, 1, 1, 325, 475), omexml.OMEXML),
         (CZI_FILE, (1, 1, 1, 1, 325, 475), _Element),
-        (LIF_FILE, (1, 1, 2, 1, 2048, 2048), Element,),
+        (
+            LIF_FILE,
+            (1, 1, 2, 1, 2048, 2048),
+            Element,
+        ),
         (MED_TIF_FILE, (1, 10, 3, 1, 325, 475), str),
         (BIG_OME_FILE, (3, 1, 3, 5, 325, 475), omexml.OMEXML),
         (BIG_CZI_FILE, (3, 1, 3, 5, 325, 475), _Element),
     ],
 )
 def test_aicsimage_serialize(
-    resources_dir, tmpdir, filename, expected_shape, expected_metadata_type,
+    resources_dir,
+    tmpdir,
+    filename,
+    expected_shape,
+    expected_metadata_type,
 ):
     """
     Test that the entire AICSImage object can be serialized - a requirement to

--- a/aicsimageio/tests/test_transforms.py
+++ b/aicsimageio/tests/test_transforms.py
@@ -13,13 +13,37 @@ from aicsimageio.transforms import reshape_data, transpose_to_dims
 @pytest.mark.parametrize(
     "data_shape, given_dims, return_dims, other_args, expected_shape",
     [
-        ((10, 1, 5, 6, 200, 400), "STCZYX", "CSZYX", {}, (5, 10, 6, 200, 400),),
+        (
+            (10, 1, 5, 6, 200, 400),
+            "STCZYX",
+            "CSZYX",
+            {},
+            (5, 10, 6, 200, 400),
+        ),
         ((6, 200, 400), "ZYX", "STCZYX", {}, (1, 1, 1, 6, 200, 400)),
         ((6, 200, 400), "ZYX", "ZCYSXT", {}, (6, 1, 200, 1, 400, 1)),
         ((6, 200, 400), "ZYX", "CYSXT", {"Z": 2}, (1, 200, 1, 400, 1)),
-        ((6, 200, 400), "ZYX", "ZCYSXT", {"Z": [0, 1]}, (2, 1, 200, 1, 400, 1),),
-        ((6, 200, 400), "ZYX", "ZCYSXT", {"Z": (0, 1)}, (2, 1, 200, 1, 400, 1),),
-        ((6, 200, 400), "ZYX", "ZCYSXT", {"Z": range(2)}, (2, 1, 200, 1, 400, 1),),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": [0, 1]},
+            (2, 1, 200, 1, 400, 1),
+        ),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": (0, 1)},
+            (2, 1, 200, 1, 400, 1),
+        ),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": range(2)},
+            (2, 1, 200, 1, 400, 1),
+        ),
         (
             (6, 200, 400),
             "ZYX",
@@ -127,7 +151,12 @@ from aicsimageio.transforms import reshape_data, transpose_to_dims
     ],
 )
 def test_reshape_data_shape(
-    array_maker, data_shape, given_dims, return_dims, other_args, expected_shape,
+    array_maker,
+    data_shape,
+    given_dims,
+    return_dims,
+    other_args,
+    expected_shape,
 ):
     data = array_maker(data_shape)
 
@@ -223,15 +252,35 @@ TEST_DARRAY = da.stack([DA_ONES * i for i in range(7)])
         ("ZYX", "ZYX", {"Z": slice(6, 3, -1)}, [6, 5, 4], None),
         ("ZYX", "ZYX", {"Z": slice(-1, 3, -1)}, [6, 5, 4], None),
         # Dimension selection and order swap
-        ("ZYX", "YXZ", {"Z": (0, -1)}, [0, -1], (1, 2, 0),),
-        ("ZYX", "YXZ", {"Z": range(0, 6, 2)}, [0, 2, 4], (1, 2, 0),),
+        (
+            "ZYX",
+            "YXZ",
+            {"Z": (0, -1)},
+            [0, -1],
+            (1, 2, 0),
+        ),
+        (
+            "ZYX",
+            "YXZ",
+            {"Z": range(0, 6, 2)},
+            [0, 2, 4],
+            (1, 2, 0),
+        ),
     ],
 )
 def test_reshape_data_kwargs_values(
-    data, given_dims, return_dims, other_args, getitem_ops_for_expected, transposer,
+    data,
+    given_dims,
+    return_dims,
+    other_args,
+    getitem_ops_for_expected,
+    transposer,
 ):
     actual = reshape_data(
-        data=data, given_dims=given_dims, return_dims=return_dims, **other_args,
+        data=data,
+        given_dims=given_dims,
+        return_dims=return_dims,
+        **other_args,
     )
 
     expected = data[getitem_ops_for_expected]

--- a/aicsimageio/transforms.py
+++ b/aicsimageio/transforms.py
@@ -215,7 +215,9 @@ def reshape_data(
 
 
 def transpose_to_dims(
-    data: types.ArrayLike, given_dims: str, return_dims: str,
+    data: types.ArrayLike,
+    given_dims: str,
+    return_dims: str,
 ) -> types.ArrayLike:
     """
     This shuffles the data dimensions from given_dims to return_dims. Each dimension

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -191,7 +191,7 @@ class OmeTiffWriter:
         tif.close()
 
     def save_slice(self, data, z=0, c=0, t=0):
-        """ this doesn't do the necessary functionality at this point
+        """this doesn't do the necessary functionality at this point
 
         TODO:
             * make this insert a YX slice in between two other slices inside a full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,9 @@
 import os
 import sys
 
-import aicsimageio
 import sphinx_rtd_theme
+
+import aicsimageio
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -69,7 +70,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"aicsimageio"
-copyright = u"2019, Allen Institute for Cell Science"
+copyright = u"2020, Allen Institute for Cell Science"
 author = u"Allen Institute for Cell Science"
 
 # The version info for the project you"re documenting, acts as replacement

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,9 +59,9 @@ templates_path = ["_templates"]
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = {
-        ".rst": "restructuredtext",
-        ".txt": "markdown",
-        ".md": "markdown",
+    ".rst": "restructuredtext",
+    ".txt": "markdown",
+    ".md": "markdown",
 }
 
 # The master toctree document.
@@ -69,7 +69,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"aicsimageio"
-copyright = u'2019, Allen Institute for Cell Science'
+copyright = u"2019, Allen Institute for Cell Science"
 author = u"Allen Institute for Cell Science"
 
 # The version info for the project you"re documenting, acts as replacement
@@ -134,15 +134,12 @@ latex_elements = {
     # The paper size ("letterpaper" or "a4paper").
     #
     # "papersize": "letterpaper",
-
     # The font size ("10pt", "11pt" or "12pt").
     #
     # "pointsize": "10pt",
-
     # Additional stuff for the LaTeX preamble.
     #
     # "preamble": "",
-
     # Latex figure (float) alignment
     #
     # "figure_align": "htbp",
@@ -152,9 +149,13 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "aicsimageio.tex",
-     u"aicsimageio Documentation",
-     u"Allen Institute for Cell Science", "manual"),
+    (
+        master_doc,
+        "aicsimageio.tex",
+        u"aicsimageio Documentation",
+        u"Allen Institute for Cell Science",
+        "manual",
+    ),
 ]
 
 
@@ -162,11 +163,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, "aicsimageio",
-     u"aicsimageio Documentation",
-     [author], 1)
-]
+man_pages = [(master_doc, "aicsimageio", u"aicsimageio Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -175,10 +172,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, "aicsimageio",
-     u"aicsimageio Documentation",
-     author,
-     "aicsimageio",
-     "A Python library for reading and writing image data with specific support for handling bio-formats.",
-     "Image Processing, Computational Biology"),
+    (
+        master_doc,
+        "aicsimageio",
+        u"aicsimageio Documentation",
+        author,
+        "aicsimageio",
+        "A Python library for reading and writing image data with specific support for handling bio-formats.",
+        "Image Processing, Computational Biology",
+    ),
 ]

--- a/scripts/chart_benchmarks.py
+++ b/scripts/chart_benchmarks.py
@@ -78,7 +78,12 @@ def _generate_chart(results: pd.DataFrame, sorted: bool = False):
     return (
         alt.Chart(results)
         .mark_circle()
-        .encode(x="yx_planes:Q", y="read_duration:Q", color="reader:N", column=column,)
+        .encode(
+            x="yx_planes:Q",
+            y="read_duration:Q",
+            color="reader:N",
+            column=column,
+        )
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -90,16 +90,13 @@ extra_requirements = {
         *test_requirements,
         *setup_requirements,
         *dev_requirements,
-        *interactive_requirements
-    ]
+        *interactive_requirements,
+    ],
 }
 
 setup(
     author="Allen Institute for Cell Science",
-    author_email=(
-        "jacksonb@alleninstitute.org, "
-        "bowdenm@spu.edu"
-    ),
+    author_email=("jacksonb@alleninstitute.org, " "bowdenm@spu.edu"),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Description
We have received enough feedback regarding the speed of getting back image chunks using `get_image_data` on `AICSImage` and `Reader` that it is time to bite the bullet and simply change to "dask" means delayed, anything else uses in memory data.

This PR makes it so that `get_image_data` on both the `AICSImage` object and `Reader` object uses the `data` property instead of routing to `get_image_dask_data` and calling `compute` on the result. This should reduce the time it takes for the `get_image_data` function to return in two scenarios:

1. when the user has `aicsimageio.use_dask(False)` / no backing `distributed` cluster
2. when the user had not previously preloaded the data with `AICSImage.data` as an empty statement

In short, timing results for current and for this branch are below:
**current:**
* duration of first `get_image_data` call: 9.15s
* duration of subsequent `get_image_data` calls: 9.35s

_No change in subsequent to first calls because it is always reading using the dask array_

**this branch:**
* duration of first `get_image_data` call: 7.42s
* duration of subsequent `get_image_data` calls: 82ms

_Change in subsequent calls because the image is loaded in full during the first call_

This is a weird semi-non-semi breaking change. This is not a breaking change in End User API -- this is a breaking change in the single case where a user was using `get_image_data` on an image that was too large for memory and now this will attempt to load the entire image into memory before returning to `numpy`. Because of this, this will get it's entirely own 3.3.0 release.

_Additional changes from updating black formatting_

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

IPython log using current:
```
In [1]: from aicsimageio import AICSImage

In [2]: img = AICSImage("aicsimageio/tests/resources/3500001004_100X_20170623_6-Scene-2-P33-F05.ome.tiff")

In [3]: img.shape
Out[3]: (1, 1, 7, 65, 624, 924)

In [4]: %time img.get_image_data("ZYX", S=0, T=0, C=0).shape
CPU times: user 9.78 s, sys: 1.64 s, total: 11.4 s
Wall time: 9.15 s
Out[4]: (65, 624, 924)

In [5]: %time img.get_image_data("ZYX", S=0, T=0, C=1).shape
CPU times: user 10.3 s, sys: 1.45 s, total: 11.8 s
Wall time: 9.35 s
Out[5]: (65, 624, 924)
```

IPython log using this branch:
```
In [1]: from aicsimageio import AICSImage

In [2]: img = AICSImage("aicsimageio/tests/resources/3500001004_100X_20170623_6-Scene-2-P33-F05.ome.tiff")

In [3]: img.shape
Out[3]: (1, 1, 7, 65, 624, 924)

In [4]: %time img.get_image_data("ZYX", S=0, T=0, C=0).shape
CPU times: user 7.22 s, sys: 198 ms, total: 7.42 s
Wall time: 7.42 s
Out[4]: (65, 624, 924)

In [5]: %time img.get_image_data("ZYX", S=0, T=0, C=1).shape
CPU times: user 79 µs, sys: 0 ns, total: 79 µs
Wall time: 82.3 µs
Out[5]: (65, 624, 924)
```

Thanks for contributing!
