### PR TITLE
bugfix/tiff-rgb

### DIFF
--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -205,7 +205,11 @@ class TiffReader(Reader):
                 single_scene_dims = scenes[0].pages.axes
                 if scenes[0].keyframe.samplesperpixel != 1:
                     # if it's an RGB pixeltype then map Samples (S) to Channels (C)
-                    single_scene_dims = single_scene_dims.replace("S", "C")
+                    if "C" in single_scene_dims:
+                        msg = "MultiChannel RGB tif images are not currently supported."
+                        raise exceptions.UnsupportedFileFormatError(msg)
+                    else:
+                        single_scene_dims = single_scene_dims.replace("S", "C")
 
                 # We can sometimes trust the dimension info in the image
                 if all([d in Dimensions.DefaultOrder for d in single_scene_dims]):

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -130,7 +130,7 @@ class TiffReader(Reader):
             # Combine length of scenes and operating shape
             # Replace YX dims with empty dimensions
             operating_shape = (len(scenes), *operating_shape)
-            if scenes[self.specific_s_index].keyframe.samplesperpixel != 1:
+            if scenes[0].keyframe.samplesperpixel != 1:
                 # if it's a multichannel (RGB) we need to pull in the channels as well
                 operating_shape = operating_shape[:-3] + (1, 1, 1)
             else:  # the data is a 2D (Y, X) so read 2D planes
@@ -198,8 +198,12 @@ class TiffReader(Reader):
         if self._dims is None:
             # Get a single scenes dimensions in order
             with TiffFile(self._file) as tiff:
-                single_scene_dims = tiff.series[0].pages.axes
-                if tiff.series[0].keyframe.samplesperpixel != 1:
+                scenes = tiff.series
+                if not self._scene_shape_is_consistent(tiff, S=self.specific_s_index):
+                    scenes = [scenes[self.specific_s_index]]
+
+                single_scene_dims = scenes[0].pages.axes
+                if scenes[0].keyframe.samplesperpixel != 1:
                     # if it's an RGB pixeltype then map Samples (S) to Channels (C)
                     single_scene_dims = single_scene_dims.replace('S', 'C')
 

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -130,7 +130,10 @@ class TiffReader(Reader):
             # Combine length of scenes and operating shape
             # Replace YX dims with empty dimensions
             operating_shape = (len(scenes), *operating_shape)
-            operating_shape = operating_shape[:-2] + (1, 1)
+            if scenes[0].keyframe.samplesperpixel != 1:  # if it's a multichannel (RGB)
+                operating_shape = operating_shape[:-3] + (1, 1, 1)
+            else:
+                operating_shape = operating_shape[:-2] + (1, 1)
 
             # Make ndarray for lazy arrays to fill
             lazy_arrays = np.ndarray(operating_shape, dtype=object)

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -130,9 +130,10 @@ class TiffReader(Reader):
             # Combine length of scenes and operating shape
             # Replace YX dims with empty dimensions
             operating_shape = (len(scenes), *operating_shape)
-            if scenes[0].keyframe.samplesperpixel != 1:  # if it's a multichannel (RGB)
+            if scenes[self.specific_s_index].keyframe.samplesperpixel != 1:
+                # if it's a multichannel (RGB) we need to pull in the channels as well
                 operating_shape = operating_shape[:-3] + (1, 1, 1)
-            else:
+            else:  # the data is a 2D (Y, X) so read 2D planes
                 operating_shape = operating_shape[:-2] + (1, 1)
 
             # Make ndarray for lazy arrays to fill
@@ -198,6 +199,9 @@ class TiffReader(Reader):
             # Get a single scenes dimensions in order
             with TiffFile(self._file) as tiff:
                 single_scene_dims = tiff.series[0].pages.axes
+                if tiff.series[0].keyframe.samplesperpixel != 1:
+                    # if it's an RGB pixeltype then map Samples (S) to Channels (C)
+                    single_scene_dims = single_scene_dims.replace('S', 'C')
 
                 # We can sometimes trust the dimension info in the image
                 if all([d in Dimensions.DefaultOrder for d in single_scene_dims]):

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -205,7 +205,7 @@ class TiffReader(Reader):
                 single_scene_dims = scenes[0].pages.axes
                 if scenes[0].keyframe.samplesperpixel != 1:
                     # if it's an RGB pixeltype then map Samples (S) to Channels (C)
-                    single_scene_dims = single_scene_dims.replace('S', 'C')
+                    single_scene_dims = single_scene_dims.replace("S", "C")
 
                 # We can sometimes trust the dimension info in the image
                 if all([d in Dimensions.DefaultOrder for d in single_scene_dims]):

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -28,14 +28,6 @@ from aicsimageio.readers.lif_reader import LifReader
             ["Z", "Y", "X"],
         ),
         (
-                "s_3_t_1_c_1_z_1_RGB.lif",
-                (3, 1, 1, 1, 7548, 7548),
-                "STCZYX",
-                np.uint16,
-                0,
-                ["Z", "Y", "X"],
-        ),
-        (
             "s_1_t_4_c_2_z_1.lif",
             (1, 4, 2, 1, 614, 614),
             "STCZYX",

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -28,6 +28,14 @@ from aicsimageio.readers.lif_reader import LifReader
             ["Z", "Y", "X"],
         ),
         (
+                "s_3_t_1_c_1_z_1_RGB.lif",
+                (3, 1, 1, 1, 7548, 7548),
+                "STCZYX",
+                np.uint16,
+                0,
+                ["Z", "Y", "X"],
+        ),
+        (
             "s_1_t_4_c_2_z_1.lif",
             (1, 4, 2, 1, 614, 614),
             "STCZYX",

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -27,6 +27,13 @@ from aicsimageio.readers.tiff_reader import TiffReader
             0,
         ),
         (
+                "s_3_t_1_c_1_z_1_RGB.tiff",
+                (3, 1, 1, 1, 7548, 7548),
+                "STCZYX",
+                np.uint16,
+                0,
+        ),
+        (
             "s_1_t_1_c_10_z_1.ome.tiff",
             (10, 1736, 1776),
             "CYX",

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -28,7 +28,7 @@ from aicsimageio.readers.tiff_reader import TiffReader
         ),
         (
                 "s_3_t_1_c_1_z_1_RGB.tiff",
-                (3, 1, 1, 1, 7548, 7548),
+                (7548, 7548, 3),
                 "YXS",
                 np.uint16,
                 0,

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -55,6 +55,14 @@ from aicsimageio.readers.tiff_reader import TiffReader
             0,
         ),
         pytest.param(
+            "s_1_t_1_c_6_z_1_RGB.tiff",
+            (2, 32, 32, 3),
+            "CYXC",
+            np.uint8,
+            0,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+        pytest.param(
             "example.txt",
             None,
             None,

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -29,7 +29,7 @@ from aicsimageio.readers.tiff_reader import TiffReader
         (
             "s_3_t_1_c_1_z_1_RGB.tiff",
             (7548, 7548, 3),
-            "YXS",
+            "YXC",
             np.uint16,
             0,
         ),

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -29,7 +29,7 @@ from aicsimageio.readers.tiff_reader import TiffReader
         (
                 "s_3_t_1_c_1_z_1_RGB.tiff",
                 (3, 1, 1, 1, 7548, 7548),
-                "STCZYX",
+                "YXS",
                 np.uint16,
                 0,
         ),

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -27,7 +27,7 @@ from aicsimageio.readers.tiff_reader import TiffReader
             0,
         ),
         (
-            "s_3_t_1_c_1_z_1_RGB.tiff",
+            "s_1_t_1_c_3_z_1_RGB.tiff",
             (7548, 7548, 3),
             "YXC",
             np.uint16,

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -27,11 +27,11 @@ from aicsimageio.readers.tiff_reader import TiffReader
             0,
         ),
         (
-                "s_3_t_1_c_1_z_1_RGB.tiff",
-                (7548, 7548, 3),
-                "YXS",
-                np.uint16,
-                0,
+            "s_3_t_1_c_1_z_1_RGB.tiff",
+            (7548, 7548, 3),
+            "YXS",
+            np.uint16,
+            0,
         ),
         (
             "s_1_t_1_c_10_z_1.ome.tiff",

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -482,11 +482,7 @@ def test_aicsimage_serialize(
 @pytest.mark.parametrize(
     "filename, expected_dims, expected_shape",
     [
-        (
-            "s_1_t_1_c_3_z_1_RGB.tiff",
-            "STCZYX",
-            (1, 1, 3, 1, 7548, 7548)
-        ),
+        ("s_1_t_1_c_3_z_1_RGB.tiff", "STCZYX", (1, 1, 3, 1, 7548, 7548)),
         pytest.param(
             "s_1_t_1_c_6_z_1_RGB.tiff",
             "STCZYX",
@@ -496,10 +492,10 @@ def test_aicsimage_serialize(
     ],
 )
 def test_rgb_images(
-        resources_dir,
-        filename,
-        expected_dims,
-        expected_shape,
+    resources_dir,
+    filename,
+    expected_dims,
+    expected_shape,
 ):
     # Get file
     f = resources_dir / filename
@@ -507,5 +503,5 @@ def test_rgb_images(
     # Read file
     img = AICSImage(f)
 
-    assert(img.dims == expected_dims)
-    assert(img.shape == expected_shape)
+    assert img.dims == expected_dims
+    assert img.shape == expected_shape

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -477,3 +477,35 @@ def test_aicsimage_serialize(
 
     # Check that there are no open file pointers after retrieval
     assert str(f) not in [f.path for f in proc.open_files()]
+
+
+@pytest.mark.parametrize(
+    "filename, expected_dims, expected_shape",
+    [
+        (
+            "s_1_t_1_c_3_z_1_RGB.tiff",
+            "STCZYX",
+            (1, 1, 3, 1, 7548, 7548)
+        ),
+        pytest.param(
+            "s_1_t_1_c_6_z_1_RGB.tiff",
+            "STCZYX",
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+    ],
+)
+def test_rgb_images(
+        resources_dir,
+        filename,
+        expected_dims,
+        expected_shape,
+):
+    # Get file
+    f = resources_dir / filename
+
+    # Read file
+    img = AICSImage(f)
+
+    assert(img.dims == expected_dims)
+    assert(img.shape == expected_shape)

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="7307ccdea69e55c611f8d9b32e8de1a4409cb98b038783496cb4ec575c930c00",
+            default="ca3389109dcc0571894e2b292e7f5e8e78f6edd334f320c7441a5299fced0ac6",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="fb3aa3dccf08aab89031b63d84fc466e4a7c25a54ef80da21797302360ab3c6c",
+            default="7307ccdea69e55c611f8d9b32e8de1a4409cb98b038783496cb4ec575c930c00",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="ca3389109dcc0571894e2b292e7f5e8e78f6edd334f320c7441a5299fced0ac6",
+            default="c0b6ea188e8e1e5c980cf2ee0be580d9fad854c4493fdcc1b18aa5584a56f093",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(


### PR DESCRIPTION
## Description
RGB Images cause problems for the tiff reader class. The issue is the shape is (Y, X, S) where S seems to be the RGB channels. 
A typical gray16 or similar file would be (Y, X).  

I added a test but I would really appreciate people evaluating it as it isn't actually clear to me how RGB should be remapped. 
The current framework maps RGB => S=3. I think this is right but I'm not completely convinced.

fixes #152 