### PR TITLE
feature/add-default-reader

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -40,7 +40,8 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov-report xml --cov=aicsimageio aicsimageio/tests/
-        codecov -t ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload codecov
+      uses: codecov/codecov-action@v1
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -28,6 +28,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
     - name: Download Test Resources
       run: |
         python scripts/download_test_resources.py --debug

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -20,6 +20,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
     - name: Download Test Resources
       run: |
         python scripts/download_test_resources.py --debug

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ their operation. `AICSImage.dask_data`, `AICSImage.xarray_dask_data`, and
 memory instead of the entire image.
 
 ## Performance Considerations
+* **The quickest read operation will always be `.data` on a local file.** All other
+operations come with _some_ minor overhead. We try to minimize this overhead wherever
+possible.
 * **If your image fits in memory:** use `AICSImage.data`, `AICSImage.get_image_data`,
 or `Reader` equivalents.
 * **If your image is too large to fit in memory:** use `AICSImage.dask_data`,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Documentation](https://github.com/AllenCellModeling/aicsimageio/workflows/Documentation/badge.svg)](https://allencellmodeling.github.io/aicsimageio)
 [![Code Coverage](https://codecov.io/gh/AllenCellModeling/aicsimageio/branch/master/graph/badge.svg)](https://codecov.io/gh/AllenCellModeling/aicsimageio)
 
-Image Reading, Metadata Conversion, and Image Writing for Images in Pure Python
+Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in Pure
+Python
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Python
     * HTTP URLs (i.e. `https://my-domain.com/my-file.png`)
     * [s3fs](https://github.com/dask/s3fs) (i.e. `s3://my-bucket/my-file.png`)
     * [gcsfs](https://github.com/dask/gcsfs) (i.e. `gcs://my-bucket/my-file.png`)
-    * See the [list of known implementation](https://filesystem-spec.readthedocs.io/en/latest/?badge=latest#implementations).
+    * See the [list of known implementations](https://filesystem-spec.readthedocs.io/en/latest/?badge=latest#implementations).
 
 ## Installation
 **Stable Release:** `pip install aicsimageio`<br>
@@ -155,9 +155,9 @@ memory instead of the entire image.
 or `Reader` equivalents.
 * **If your image is too large to fit in memory:** use `AICSImage.dask_data`,
 `AICSImage.get_image_dask_data`, or `Reader` equivalents.
-* **If your image is not chunk reading native:** it may not be best to read chunks from
-a remote source. While possible, the format of the image matters a lot for chunked
-read performance.
+* **If your image does not support native chunk reading:** it may not be best to read
+chunks from a remote source. While possible, the format of the image matters a lot for
+chunked read performance.
 
 ## Napari Interactive Viewer
 [napari](https://github.com/Napari/napari) is a fast, interactive, multi-dimensional
@@ -170,13 +170,11 @@ that allows use of all the functionality described in this library, but in the `
 default viewer itself.
 
 ## Notes
-* Image `data`, `xarray_data`, `dask_data`, and `xarray_dask_data` are always returned
-as five dimensional in dimension order `TCZYX` or, `Time`, `Channel`, `Z`, `Y`, and `X`.
 * Each file format may use a different metadata parser as it is dependent on the
 format's reader class implementation.
 * The `AICSImage` object will only pull the `Scene`, `Time`, `Channel`, `Z`, `Y`, `X`
 dimensions from the reader. If your file has dimensions outside of those, use the base
-reader classes.
+`Reader` classes.
 
 ## Development
 See [CONTRIBUTING.md](CONTRIBUTING.md) for information related to developing the code.

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -14,10 +14,15 @@ class DimensionNames:
     SpatialX = "X"
 
 
-DEFAULT_DIMENSION_ORDER = (
-    f"{DimensionNames.Time}{DimensionNames.Channel}"
-    f"{DimensionNames.SpatialZ}{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
-)
+DEFAULT_DIMENSION_ORDER_LIST = [
+    DimensionNames.Time,
+    DimensionNames.Channel,
+    DimensionNames.SpatialZ,
+    DimensionNames.SpatialY,
+    DimensionNames.SpatialX,
+]
+
+DEFAULT_DIMENSION_ORDER = "".join(DEFAULT_DIMENSION_ORDER_LIST)
 
 ###############################################################################
 

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -35,7 +35,7 @@ class Dimensions:
         Parameters
         ----------
         dims: Union[str, Iterable]
-            An ordered string of the dimensions to pair with their sizes.
+            An ordered string or iterable of the dimensions to pair with their sizes.
         shape: Tuple[int]
             An ordered tuple of the dimensions sizes to pair with their names.
 

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Tuple
+from typing import Iterable, Tuple, Union
 
 ###############################################################################
 
@@ -23,13 +23,13 @@ DEFAULT_DIMENSION_ORDER = (
 
 
 class Dimensions:
-    def __init__(self, dims: str, shape: Tuple[int]):
+    def __init__(self, dims: Union[str, Iterable], shape: Tuple[int]):
         """
         A general object for managing the pairing of dimension name and dimension size.
 
         Parameters
         ----------
-        dims: str
+        dims: Union[str, Iterable]
             An ordered string of the dimensions to pair with their sizes.
         shape: Tuple[int]
             An ordered tuple of the dimensions sizes to pair with their names.
@@ -39,8 +39,15 @@ class Dimensions:
         >>> dims = Dimensions("TCZYX", (1, 4, 75, 624, 924))
         ... dims.X
         """
+        # Make dims a string
+        if not isinstance(dims, str):
+            dims = "".join(dims)
+
+        # Store order and shape
         self._order = dims
         self._shape = shape
+
+        # Create attributes
         self._dims_shape = dict(zip(dims, shape))
         for dim, size in self._dims_shape.items():
             setattr(self, dim, size)

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -6,6 +6,7 @@ class ConflictingArgumentsError(Exception):
     """
     This exception is returned when 2 arguments to the same function are in conflict.
     """
+
     pass
 
 

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################\
+
+
+class IOHandlingError(Exception):
+    pass
+
+
+class UnsupportedFileFormatError(Exception):
+    """
+    This exception is intended to communicate that the file extension is not one of
+    the supported file types and cannot be parsed with AICSImage.
+    """
+
+    def __init__(self, extension, **kwargs):
+        super().__init__(**kwargs)
+        self.extension = extension
+
+    def __str__(self):
+        return f"AICSImageIO does not support the image file type: '{self.extension}'."

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -2,7 +2,11 @@
 # -*- coding: utf-8 -*-
 
 
-class IOHandlingError(Exception):
+class ConflictingArgumentsError(Exception):
+    """
+    This exception is returned when 2 arguments to the same function are in conflict.
+    """
+
     pass
 
 

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-###############################################################################\
-
 
 class IOHandlingError(Exception):
     pass

--- a/aicsimageio/exceptions.py
+++ b/aicsimageio/exceptions.py
@@ -6,7 +6,6 @@ class ConflictingArgumentsError(Exception):
     """
     This exception is returned when 2 arguments to the same function are in conflict.
     """
-
     pass
 
 

--- a/aicsimageio/readers/__init__.py
+++ b/aicsimageio/readers/__init__.py
@@ -1,2 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+from .default_reader import DefaultReader  # noqa: F401

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -62,7 +62,7 @@ class DefaultReader(Reader):
         return extension, mode
 
     @staticmethod
-    def _reader_supports_image(fs: AbstractFileSystem, path: str) -> bool:
+    def _is_supported_image(fs: AbstractFileSystem, path: str) -> bool:
         # Get extension and mode for reading the file
         extension, mode = DefaultReader._get_extension_and_mode(path)
 
@@ -106,7 +106,7 @@ class DefaultReader(Reader):
         self.extension, self.imageio_read_mode = self._get_extension_and_mode(self.path)
 
         # Enforce valid image
-        if not self._reader_supports_image(self.fs, self.path):
+        if not self._is_supported_image(self.fs, self.path):
             raise exceptions.UnsupportedFileFormatError(self.extension)
 
     @staticmethod

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -63,7 +63,8 @@ class DefaultReader(Reader):
 
     def __init__(self, image: types.PathLike):
         """
-        A catch all for image file reading that defaults to using imageio implementations.
+        A catch all for image file reading that defaults to using imageio
+        implementations.
 
         Parameters
         ----------

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
+from typing import Dict, Set
+
 import dask.array as da
 import fsspec
 import imageio
 import numpy as np
+import xarray as xr
 from dask import delayed
 
-from .. import types
+from .. import exceptions, types
 from ..dimensions import Dimensions
 from ..utils import io_utils
 from .reader import Reader
@@ -24,12 +28,200 @@ class DefaultReader(Reader):
         Path to image file to construct Reader for.
     """
 
+    FFMPEG_FORMATS = ["mov", "avi", "mpg", "mpeg", "mp4", "mkv", "wmv", "ogg"]
+
     def __init__(self, image: types.PathLike):
         # Expand details of provided image
         self.abstract_file = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self.extension = self.abstract_file.path.split(".")[-1]
+
+        # Set mode to many-image reading if FFMPEG format was provided
+        if self.extension in DefaultReader.FFMPEG_FORMATS:
+            self.imageio_read_mode = "I"
+        # Otherwise, have imageio infer the mode
+        else:
+            self.imageio_read_mode = "?"
+
+    @staticmethod
+    def _assert_reader_supports_image(image: types.FSSpecBased) -> bool:
+        # Select extension to handle special formats
+        extension = image.path.split(".")[-1]
+
+        # Set mode to many-image reading if FFMPEG format was provided
+        if extension in DefaultReader.FFMPEG_FORMATS:
+            mode = "I"
+        # Otherwise, have imageio infer the mode
+        else:
+            mode = "?"
+
+        # Use imageio to check if they have a reader for this file
+        try:
+            with image.fs.open(image.path) as open_resource:
+                with imageio.get_reader(open_resource, format=extension, mode=mode):
+                    return True
+
+        except ValueError:
+            return False
 
 
-FFMPEG_FORMATS = ["mov", "avi", "mpg", "mpeg", "mp4", "mkv", "wmv", "ogg"]
+    @property
+    def scenes(self) -> Set[int]:
+        return [0]
+
+    @property
+    def current_scene(self) -> int:
+        return self.scenes[0]
+
+    def set_scene(self, id: int):
+        # We don't need to do any value setting here, we simply need to keep to the
+        # Reader spec and enforce that the scene id provided is valid
+        if id not in self.scenes:
+            raise IndexError(
+                f"Scene id: {id} "
+                f"is not present in available image scenes: {self.scenes}"
+            )
+
+    @staticmethod
+    def _get_image_data(
+        abstract_file: types.FSSpecBased, mode: str, format: str, index: int
+    ) -> np.ndarray:
+        with abstract_file.fs.open(abstract_file.path) as open_resource:
+            with imageio.get_reader(open_resource, format=format, mode=mode) as reader:
+                return np.asarray(reader.get_data(index))
+
+    @staticmethod
+    def _get_image_metadata(
+        abstract_file: types.FSSpecBased, mode: str, format: str,
+    ) -> Dict:
+        with abstract_file.fs.open(abstract_file.path) as open_resource:
+            with imageio.get_reader(open_resource, format=format, mode=mode) as reader:
+                return reader.get_meta_data()
+
+
+    def _read_delayed(self) -> xr.DataArray:
+        # Read image
+        with self.abstract_file.fs.open(self.abstract_file.path) as open_resource:
+            reader = imageio.get_reader(
+                open_resource, format=self.extension, mode=self.imageio_read_mode
+            )
+
+            # Store image length
+            try:
+                if self.extension in DefaultReader.FFMPEG_FORMATS:
+                    image_length = reader.count_frames()
+                else:
+                    image_length = reader.get_length()
+            except ValueError:
+                raise exception.IOHandlingError(
+                    "This reader cannot read the provided buffer. "
+                    "Please download the file locally before continuing your work."
+                )
+
+            # Handle single image formats like png, jpeg, etc
+            if image_length == 1:
+                image_data = da.from_array(self._get_image_data(
+                    abstract_file=self.abstract_file,
+                    mode=self.imageio_read_mode,
+                    format=self.extension,
+                    index=0
+                ))
+
+            # Handle many image formats like gif, mp4, etc
+            elif image_length > 1:
+                # Get a sample image
+                sample = self._get_image_data(
+                    abstract_file=self.abstract_file,
+                    mode=self.imageio_read_mode,
+                    format=self.extension,
+                    index=0
+                )
+
+                # Create operating shape for the final dask array by prepending
+                # image length to a tuple of ones that is the same length as
+                # the sample shape
+                operating_shape = (image_length,) + ((1,) * len(sample.shape))
+                # Create numpy array of empty arrays for delayed get data
+                # functions
+                lazy_arrays = np.ndarray(operating_shape, dtype=object)
+                for indicies, _ in np.ndenumerate(lazy_arrays):
+                    lazy_arrays[indicies] = da.from_delayed(
+                        delayed(self._get_image_data)(
+                            abstract_file=self.abstract_file,
+                            mode=self.imageio_read_mode,
+                            format=self.extension,
+                            index=indicies[0],
+                        ),
+                        shape=sample.shape,
+                        dtype=sample.dtype,
+                    )
+
+                # Block them into a single dask array
+                image_data = da.block(lazy_arrays.tolist())
+
+            # Catch all other image types as unsupported
+            # https://imageio.readthedocs.io/en/stable/userapi.html#imageio.core.format.Reader.get_length
+            else:
+                raise exceptions.UnsupportedFileFormatError(self.extension)
+
+            return xr.DataArray(
+                image_data,
+                dims=[c for c in self.guess_dim_order(image_data.shape)],
+                # TODO:
+                # Solve this dask bug w/ delayed
+                # 
+                # attrs=delayed(self._get_image_metadata)(
+                #     abstract_file=self.abstract_file,
+                #     mode=self.imageio_read_mode,
+                #     format=self.extension,
+                # ),
+            )
+
+
+    def _read_immediate(self) -> xr.DataArray:
+        # Read image
+        with self.abstract_file.fs.open(self.abstract_file.path) as open_resource:
+            reader = imageio.get_reader(
+                open_resource, format=self.extension, mode=self.imageio_read_mode
+            )
+
+            # Store image length
+            try:
+                if self.extension in DefaultReader.FFMPEG_FORMATS:
+                    image_length = reader.count_frames()
+                else:
+                    image_length = reader.get_length()
+            except ValueError:
+                raise exceptions.IOHandlingError(
+                    "This reader cannot read the provided buffer. "
+                    "Please download the file locally before continuing your work."
+                )
+
+            # Handle single-image formats like png, jpeg, etc
+            if image_length == 1:
+                image_data = reader.get_data(0)
+
+            # Handle many image formats like gif, mp4, etc
+            elif image_length > 1:
+                # Read and stack all frames
+                frames = []
+                for i, frame in enumerate(reader.iter_data()):
+                    frames.append(frame)
+
+                image_data = np.stack(frames)
+
+            return xr.DataArray(
+                image_data,
+                dims=[c for c in self.guess_dim_order(image_data.shape)],
+                attrs=reader.get_meta_data(),
+            )
+
+            raise TypeError(path)
+
+    def dims(self):
+        pass
+
+    def metadata(self):
+        pass
 
 # BIG BUCK BUNNY 15 SECONDS:
 # "https://archive.org/embed/archive-video-files/test.mp4"
@@ -39,51 +231,3 @@ FFMPEG_FORMATS = ["mov", "avi", "mpg", "mpeg", "mp4", "mkv", "wmv", "ogg"]
 # s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/example.jpg
 # s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/example.gif
 # s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/s_1_t_1_c_1_z_1.tiff
-
-class UnsupportedIOException(Exception):
-    pass
-
-def read_image(image: types.PathLike):
-    abstract_file = io_utils.pathlike_to_fs(image, enforce_exists=True)
-
-    # Get / unpack file info
-    # Select extension to handle special formats
-    extension = abstract_file.path.split(".")[-1]
-
-    # Set mode to many-image reading if FFMPEG format was provided
-    if extension in FFMPEG_FORMATS:
-        mode = "I"
-    # Otherwise, have imageio infer the mode
-    else:
-        mode = "?"
-
-    # Read image
-    slices = []
-    with abstract_file.fs.open(abstract_file.path) as open_resource:
-        reader = imageio.get_reader(open_resource, format=extension, mode=mode)
-
-        # Store image length
-        try:
-            if extension in FFMPEG_FORMATS:
-                image_length = reader.count_frames()
-            else:
-                image_length = reader.get_length()
-        except ValueError:
-            raise UnsupportedIOException(
-                "This reader cannot read the provided buffer. "
-                "Please download the file locally before continuing your work."
-            )
-
-        # Handle single-image formats like png, jpeg, etc
-        if image_length == 1:
-            return reader.get_data(0)
-
-        # Handle many image formats like gif, mp4, etc
-        elif image_length > 1:
-            frames = []
-            for i, frame in enumerate(reader.iter_data()):
-                frames.append(frame)
-
-            return np.stack(frames)
-
-        raise TypeError(path)

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Set
+from typing import Dict, List, Set, Tuple
 
 import dask.array as da
 import imageio
@@ -10,6 +10,7 @@ import xarray as xr
 from dask import delayed
 
 from .. import exceptions, types
+from ..dimensions import DimensionNames
 from ..utils import io_utils
 from .reader import Reader
 
@@ -28,29 +29,65 @@ class DefaultReader(Reader):
 
     FFMPEG_FORMATS = ["mov", "avi", "mpg", "mpeg", "mp4", "mkv", "wmv", "ogg"]
 
-    def __init__(self, image: types.PathLike):
-        # Expand details of provided image
-        self.abstract_file = io_utils.pathlike_to_fs(image, enforce_exists=True)
-        self.extension = self.abstract_file.path.split(".")[-1]
-
-        # Set mode to many-image reading if FFMPEG format was provided
-        if self.extension in DefaultReader.FFMPEG_FORMATS:
-            self.imageio_read_mode = "I"
-        # Otherwise, have imageio infer the mode
-        else:
-            self.imageio_read_mode = "?"
-
     @staticmethod
-    def _assert_reader_supports_image(image: types.FSSpecBased) -> bool:
+    def _get_extension_and_mode(abstract_file: types.FSSpecBased) -> Tuple[str, str]:
+        """
+        Provided an FSSpecBased file, proved back the extension (format) of the file
+        and the imageio read mode to use for reading.
+
+        Parameters
+        ----------
+        abstract_file: types.FSSpecBased
+            The file to provide extension and mode info for.
+
+        Returns
+        -------
+        extension: str
+            The extension (a naive guess at the format) of the file.
+        mode: str
+            The imageio read mode to use for image reading.
+        """
         # Select extension to handle special formats
-        extension = image.path.split(".")[-1]
+        extension = abstract_file.path.split(".")[-1]
 
         # Set mode to many-image reading if FFMPEG format was provided
+        # https://imageio.readthedocs.io/en/stable/userapi.html#imageio.get_reader
         if extension in DefaultReader.FFMPEG_FORMATS:
             mode = "I"
         # Otherwise, have imageio infer the mode
         else:
             mode = "?"
+
+        return extension, mode
+
+    def __init__(self, image: types.PathLike):
+        # Expand details of provided image
+        self.abstract_file = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self.extension, self.imageio_read_mode = self._get_extension_and_mode(
+            self.abstract_file
+        )
+
+    @staticmethod
+    def guess_dim_order(shape: Tuple[int]) -> str:
+        if len(shape) == 2:
+            return f"{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
+        elif len(shape) == 3:
+            return (
+                f"{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
+                f"{DimensionNames.Channel}"
+            )
+        elif len(shape) == 4:
+            return (
+                f"{DimensionNames.Time}{DimensionNames.SpatialY}"
+                f"{DimensionNames.SpatialX}{DimensionNames.Channel}"
+            )
+
+        return Reader.guess_dim_order(shape)
+
+    @staticmethod
+    def _assert_reader_supports_image(image: types.FSSpecBased) -> bool:
+        # Get extension and mode for reading the file
+        extension, mode = DefaultReader._get_extension_and_mode(image)
 
         # Use imageio to check if they have a reader for this file
         try:
@@ -80,103 +117,228 @@ class DefaultReader(Reader):
 
     @staticmethod
     def _get_image_data(
-        abstract_file: types.FSSpecBased, mode: str, format: str, index: int
+        abstract_file: types.FSSpecBased, format: str, mode: str, index: int
     ) -> np.ndarray:
+        """
+        Open a file for reading, seek to plane index and read as numpy.
+
+        Parameters
+        ----------
+        abstract_file: types.FSSpecBased
+            The file to open and read.
+        format: str
+            The format to use to read the file.
+            For our use case this is primarily the file extension.
+        mode: str
+            The read mode to use for opening and reading.
+            See mode parameter on imageio.get_reader
+            https://imageio.readthedocs.io/en/stable/userapi.html#imageio.get_reader
+        index: int
+            The image plane index to seek to and read from the file.
+
+        Returns
+        -------
+        plane: np.ndarray
+            The image plane as a numpy array.
+        """
         with abstract_file.fs.open(abstract_file.path) as open_resource:
             with imageio.get_reader(open_resource, format=format, mode=mode) as reader:
                 return np.asarray(reader.get_data(index))
 
     @staticmethod
-    def _get_image_metadata(
+    def _get_image_length(
         abstract_file: types.FSSpecBased,
-        mode: str,
         format: str,
-    ) -> Dict:
-        with abstract_file.fs.open(abstract_file.path) as open_resource:
-            with imageio.get_reader(open_resource, format=format, mode=mode) as reader:
-                return reader.get_meta_data()
+        mode: str,
+    ) -> int:
+        """
+        Parameters
+        ----------
+        abstract_file: types.FSSpecBased
+            The file to open and read.
+        format: str
+            The format to use to read the file.
+            For our use case this is primarily the file extension.
+        mode: str
+            The read mode to use for opening and reading.
+            See mode parameter on imageio.get_reader
+            https://imageio.readthedocs.io/en/stable/userapi.html#imageio.get_reader
+
+        Returns
+        -------
+        length: int
+            The length of the image (number of planes).
+
+        Raises
+        ------
+        exceptions.IOHandlingError: The provided file cannot be read from a remote
+            source.
+        """
+        try:
+            with abstract_file.fs.open(abstract_file.path) as open_resource:
+                with imageio.get_reader(
+                    open_resource, format=format, mode=mode
+                ) as reader:
+                    # Handle FFMPEG formats
+                    if format in DefaultReader.FFMPEG_FORMATS:
+                        return reader.count_frames()
+
+                    # Default get_length call for all others
+                    return reader.get_length()
+
+        except ValueError:
+            raise exceptions.IOHandlingError(
+                f"Cannot read the provided file ({abstract_file.path}) remotely. "
+                f"Please download the file locally before continuing your work."
+            )
+
+    @staticmethod
+    def _unpack_dims_and_coords(
+        image_data: types.ImageLike, metadata: Dict
+    ) -> Tuple[List[str], Dict]:
+        """
+        Unpack image data into assumed dims and coords.
+
+        Parameters
+        ----------
+        image_data: types.ImageLike
+            The image data to unpack dims and coords for.
+        metadata: Dict
+            The EXIF, XMP, etc metadata dictionary.
+
+        Returns
+        -------
+        dims: List[str]
+            The dimension names for each dimension in the image data.
+        coords: Dict
+            If possible, the coordinates for dimensions in the image data.
+        """
+        # Guess dims
+        dims = [c for c in DefaultReader.guess_dim_order(image_data.shape)]
+
+        # Use dims for coord determination
+        coords = {}
+
+        # Handle typical RGB and RGBA from channels
+        if DimensionNames.Channel in dims:
+            if image_data.shape[dims.index(DimensionNames.Channel)] == 3:
+                coords[DimensionNames.Channel] = ["R", "G", "B"]
+            elif image_data.shape[dims.index(DimensionNames.Channel)] == 4:
+                coords[DimensionNames.Channel] = ["R", "G", "B", "A"]
+
+        # Handle time when duration is present in metadata
+        if DimensionNames.Time in dims:
+            if "duration" in metadata:
+                coords[DimensionNames.Time] = np.linspace(
+                    0,
+                    metadata["duration"],
+                    image_data.shape[dims.index(DimensionNames.Time)],
+                )
+
+        return dims, coords
 
     def _read_delayed(self) -> xr.DataArray:
-        # Read image
-        with self.abstract_file.fs.open(self.abstract_file.path) as open_resource:
-            reader = imageio.get_reader(
-                open_resource, format=self.extension, mode=self.imageio_read_mode
-            )
+        """
+        Construct the delayed xarray DataArray object for the image.
 
-            # Store image length
-            try:
-                if self.extension in DefaultReader.FFMPEG_FORMATS:
-                    image_length = reader.count_frames()
-                else:
-                    image_length = reader.get_length()
-            except ValueError:
-                raise exceptions.IOHandlingError(
-                    "This reader cannot read the provided buffer. "
-                    "Please download the file locally before continuing your work."
+        Returns
+        -------
+        image: xr.DataArray
+            The fully constructed and fully delayed image as a DataArray object.
+            Metadata is both attached in some cases as coords, dims, and attrs.
+
+        Raises
+        ------
+        exceptions.UnsupportedFileFormatError: The file could not be read or is not
+            supported.
+        """
+        with self.abstract_file.fs.open(self.abstract_file.path) as open_resource:
+            with imageio.get_reader(
+                open_resource, format=self.extension, mode=self.imageio_read_mode
+            ) as reader:
+                # Store image length
+                image_length = self._get_image_length(
+                    self.abstract_file,
+                    format=self.extension,
+                    mode=self.imageio_read_mode,
                 )
 
-            # Handle single image formats like png, jpeg, etc
-            if image_length == 1:
-                image_data = da.from_array(
-                    self._get_image_data(
+                # Handle single image formats like png, jpeg, etc
+                if image_length == 1:
+                    image_data = da.from_array(
+                        self._get_image_data(
+                            abstract_file=self.abstract_file,
+                            format=self.extension,
+                            mode=self.imageio_read_mode,
+                            index=0,
+                        )
+                    )
+
+                # Handle many image formats like gif, mp4, etc
+                elif image_length > 1:
+                    # Get a sample image
+                    sample = self._get_image_data(
                         abstract_file=self.abstract_file,
-                        mode=self.imageio_read_mode,
                         format=self.extension,
+                        mode=self.imageio_read_mode,
                         index=0,
                     )
+
+                    # Create operating shape for the final dask array by prepending
+                    # image length to a tuple of ones that is the same length as
+                    # the sample shape
+                    operating_shape = (image_length,) + ((1,) * len(sample.shape))
+                    # Create numpy array of empty arrays for delayed get data
+                    # functions
+                    lazy_arrays = np.ndarray(operating_shape, dtype=object)
+                    for indicies, _ in np.ndenumerate(lazy_arrays):
+                        lazy_arrays[indicies] = da.from_delayed(
+                            delayed(self._get_image_data)(
+                                abstract_file=self.abstract_file,
+                                format=self.extension,
+                                mode=self.imageio_read_mode,
+                                index=indicies[0],
+                            ),
+                            shape=sample.shape,
+                            dtype=sample.dtype,
+                        )
+
+                    # Block them into a single dask array
+                    image_data = da.block(lazy_arrays.tolist())
+
+                # Catch all other image types as unsupported
+                # https://imageio.readthedocs.io/en/stable/userapi.html#imageio.core.format.Reader.get_length
+                else:
+                    raise exceptions.UnsupportedFileFormatError(self.extension)
+
+                # Get basic metadata
+                metadata = reader.get_meta_data()
+
+                # Create extra metadata from assumptions based off image data
+                dims, coords = self._unpack_dims_and_coords(image_data, metadata)
+
+                return xr.DataArray(
+                    image_data,
+                    dims=dims,
+                    coords=coords,
+                    attrs=metadata,
                 )
-
-            # Handle many image formats like gif, mp4, etc
-            elif image_length > 1:
-                # Get a sample image
-                sample = self._get_image_data(
-                    abstract_file=self.abstract_file,
-                    mode=self.imageio_read_mode,
-                    format=self.extension,
-                    index=0,
-                )
-
-                # Create operating shape for the final dask array by prepending
-                # image length to a tuple of ones that is the same length as
-                # the sample shape
-                operating_shape = (image_length,) + ((1,) * len(sample.shape))
-                # Create numpy array of empty arrays for delayed get data
-                # functions
-                lazy_arrays = np.ndarray(operating_shape, dtype=object)
-                for indicies, _ in np.ndenumerate(lazy_arrays):
-                    lazy_arrays[indicies] = da.from_delayed(
-                        delayed(self._get_image_data)(
-                            abstract_file=self.abstract_file,
-                            mode=self.imageio_read_mode,
-                            format=self.extension,
-                            index=indicies[0],
-                        ),
-                        shape=sample.shape,
-                        dtype=sample.dtype,
-                    )
-
-                # Block them into a single dask array
-                image_data = da.block(lazy_arrays.tolist())
-
-            # Catch all other image types as unsupported
-            # https://imageio.readthedocs.io/en/stable/userapi.html#imageio.core.format.Reader.get_length
-            else:
-                raise exceptions.UnsupportedFileFormatError(self.extension)
-
-            return xr.DataArray(
-                image_data,
-                dims=[c for c in self.guess_dim_order(image_data.shape)],
-                # TODO:
-                # Solve this dask bug w/ delayed
-                #
-                # attrs=delayed(self._get_image_metadata)(
-                #     abstract_file=self.abstract_file,
-                #     mode=self.imageio_read_mode,
-                #     format=self.extension,
-                # ),
-            )
 
     def _read_immediate(self) -> xr.DataArray:
+        """
+        Construct the in-memory xarray DataArray object for the image.
+
+        Returns
+        -------
+        image: xr.DataArray
+            The fully constructed and fully read into memory image as a DataArray
+            object. Metadata is both attached in some cases as coords, dims, and attrs.
+
+        Raises
+        ------
+        exceptions.UnsupportedFileFormatError: The file could not be read or is not
+            supported.
+        """
         # Read image
         with self.abstract_file.fs.open(self.abstract_file.path) as open_resource:
             reader = imageio.get_reader(
@@ -184,16 +346,9 @@ class DefaultReader(Reader):
             )
 
             # Store image length
-            try:
-                if self.extension in DefaultReader.FFMPEG_FORMATS:
-                    image_length = reader.count_frames()
-                else:
-                    image_length = reader.get_length()
-            except ValueError:
-                raise exceptions.IOHandlingError(
-                    "This reader cannot read the provided buffer. "
-                    "Please download the file locally before continuing your work."
-                )
+            image_length = self._get_image_length(
+                self.abstract_file, format=self.extension, mode=self.imageio_read_mode
+            )
 
             # Handle single-image formats like png, jpeg, etc
             if image_length == 1:
@@ -208,10 +363,17 @@ class DefaultReader(Reader):
 
                 image_data = np.stack(frames)
 
+            # Get basic metadata
+            metadata = reader.get_meta_data()
+
+            # Create extra metadata from assumptions based off image data
+            dims, coords = self._unpack_dims_and_coords(image_data, metadata)
+
             return xr.DataArray(
                 image_data,
-                dims=[c for c in self.guess_dim_order(image_data.shape)],
-                attrs=reader.get_meta_data(),
+                dims=dims,
+                coords=coords,
+                attrs=metadata,
             )
 
     def dims(self):

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -128,6 +128,10 @@ class DefaultReader(Reader):
 
     @property
     def scenes(self) -> Tuple[int]:
+        # There is currently an assumption that DefaultReader will not encounter
+        # files with multiple scenes. But, if we do encounter a file that DefaultReader
+        # hits and a user wants scene management from that file type, we can update
+        # this property then.
         return (0,)
 
     @property
@@ -203,7 +207,7 @@ class DefaultReader(Reader):
         Returns
         -------
         length: int
-            The length of the image (number of planes).
+            The length of the image (number of YX planes).
 
         Notes
         -----

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -237,14 +237,14 @@ class DefaultReader(Reader):
 
     @staticmethod
     def _unpack_dims_and_coords(
-        image_data: types.ImageLike, metadata: Dict
+        image_data: types.ArrayLike, metadata: Dict
     ) -> Tuple[List[str], Dict]:
         """
         Unpack image data into assumed dims and coords.
 
         Parameters
         ----------
-        image_data: types.ImageLike
+        image_data: types.ArrayLike
             The image data to unpack dims and coords for.
         metadata: Dict
             The EXIF, XMP, etc metadata dictionary.

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -109,9 +109,6 @@ class DefaultReader(Reader):
         if not self._reader_supports_image(self.fs, self.path):
             raise exceptions.UnsupportedFileFormatError(self.extension)
 
-        # Lazy load
-        self._physical_pixel_sizes = None
-
     @staticmethod
     def guess_dim_order(shape: Tuple[int]) -> str:
         if len(shape) == 2:
@@ -438,23 +435,4 @@ class DefaultReader(Reader):
 
     @property
     def physical_pixel_sizes(self) -> PhysicalPixelSizes:
-        # See EXIF example
-        # https://en.wikipedia.org/wiki/Exif#Example
-        if self._physical_pixel_sizes is None:
-            if "Y resolution" in self.metadata:
-                y_pixel_size = 1 / self.metadata["Y resolution"]
-            else:
-                y_pixel_size = 1.0
-
-            if "X resolution" in self.metadata:
-                x_pixel_size = 1 / self.metadata["X resolution"]
-            else:
-                x_pixel_size = 1.0
-
-            self._physical_pixel_sizes = PhysicalPixelSizes(
-                1.0,
-                y_pixel_size,
-                x_pixel_size,
-            )
-
-        return self._physical_pixel_sizes
+        return PhysicalPixelSizes(1.0, 1.0, 1.0)

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -376,11 +376,16 @@ class DefaultReader(Reader):
                 attrs=metadata,
             )
 
+    @property
     def dims(self):
         pass
 
+    @property
     def metadata(self):
-        pass
+        if self._metadata is None:
+            self._metadata = self.xarray_dask_data.attrs
+
+        return self._metadata
 
 
 # BIG BUCK BUNNY 15 SECONDS:

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -109,6 +109,9 @@ class DefaultReader(Reader):
         if not self._reader_supports_image(self.fs, self.path):
             raise exceptions.UnsupportedFileFormatError(self.extension)
 
+        # Lazy load
+        self._physical_pixel_sizes = None
+
     @staticmethod
     def guess_dim_order(shape: Tuple[int]) -> str:
         if len(shape) == 2:
@@ -435,4 +438,23 @@ class DefaultReader(Reader):
 
     @property
     def physical_pixel_sizes(self) -> PhysicalPixelSizes:
-        return PhysicalPixelSizes(None, 1.0, 1.0)
+        # See EXIF example
+        # https://en.wikipedia.org/wiki/Exif#Example
+        if self._physical_pixel_sizes is None:
+            if "Y resolution" in self.metadata:
+                y_pixel_size = 1 / self.metadata["Y resolution"]
+            else:
+                y_pixel_size = 1.0
+
+            if "X resolution" in self.metadata:
+                x_pixel_size = 1 / self.metadata["X resolution"]
+            else:
+                x_pixel_size = 1.0
+
+            self._physical_pixel_sizes = PhysicalPixelSizes(
+                1.0,
+                y_pixel_size,
+                x_pixel_size,
+            )
+
+        return self._physical_pixel_sizes

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -27,14 +27,6 @@ REMOTE_READ_FAIL_MESSAGE = (
 
 
 class DefaultReader(Reader):
-    """
-    A catch all for image file reading that defaults to using imageio implementations.
-
-    Parameters
-    ----------
-    image: types.PathLike
-        Path to image file to construct Reader for.
-    """
 
     FFMPEG_FORMATS = ["mov", "avi", "mpg", "mpeg", "mp4", "mkv", "wmv", "ogg"]
 
@@ -70,6 +62,14 @@ class DefaultReader(Reader):
         return extension, mode
 
     def __init__(self, image: types.PathLike):
+        """
+        A catch all for image file reading that defaults to using imageio implementations.
+
+        Parameters
+        ----------
+        image: types.PathLike
+            Path to image file to construct Reader for.
+        """
         # Expand details of provided image
         self.fs, self.path = io_utils.pathlike_to_fs(image, enforce_exists=True)
         self.extension, self.imageio_read_mode = self._get_extension_and_mode(self.path)

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -63,7 +63,7 @@ class Reader(ABC):
 
     @staticmethod
     @abstractmethod
-    def _assert_reader_supports_image(image: types.FSSpecBased) -> bool:
+    def _reader_supports_image(image: types.FSSpecBased) -> bool:
         """
         The per-Reader implementation of validating that an image is supported or not by
         the Reader itself.
@@ -78,7 +78,7 @@ class Reader(ABC):
         pass
 
     @classmethod
-    def assert_reader_supports_image(cls, image: types.ImageLike) -> bool:
+    def reader_supports_image(cls, image: types.ImageLike) -> bool:
         """
         Asserts that the provided image like object is supported by the current Reader.
 
@@ -455,7 +455,7 @@ class Reader(ABC):
         return list(self.xarray_dask_data[DimensionNames.Channel].values)
 
     @property
-    def physical_pixel_size(self) -> PhysicalPixelSizes:
+    def physical_pixel_sizes(self) -> PhysicalPixelSizes:
         """
         Returns
         -------

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -440,7 +440,10 @@ class Reader(ABC):
             Using available metadata, the list of strings representing channel names.
             If no channel dimension present in the data, returns None.
         """
-        return list(self.xarray_dask_data[DimensionNames.Channel].values)
+        if DimensionNames.Channel in self.xarray_dask_data.dims:
+            return list(self.xarray_dask_data[DimensionNames.Channel].values)
+
+        return None
 
     @property
     def physical_pixel_sizes(self) -> PhysicalPixelSizes:
@@ -452,3 +455,11 @@ class Reader(ABC):
             dimensions Z, Y, and X.
         """
         pass
+
+    def __str__(self):
+        return (
+            f"<{self.__class__.__name__} [In-Memory: {self._xarray_data is not None}]>"
+        )
+
+    def __repr__(self):
+        return str(self)

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -10,7 +10,7 @@ import numpy as np
 import xarray as xr
 from fsspec.spec import AbstractBufferedFile
 
-from .. import types
+from .. import transforms, types
 from ..dimensions import DEFAULT_DIMENSION_ORDER, DimensionNames, Dimensions
 from ..types import PhysicalPixelSizes
 
@@ -342,7 +342,17 @@ class Reader(ABC):
 
         See `aicsimageio.transforms.reshape_data` for more details.
         """
-        pass
+        # If no out orientation, simply return current data as dask array
+        if dimension_order_out is None:
+            return self.dask_data
+
+        # Transform and return
+        return transforms.reshape_data(
+            data=self.dask_data,
+            given_dims=self.dims.order,
+            return_dims=dimension_order_out,
+            **kwargs,
+        )
 
     def get_image_data(
         self, dimension_order_out: Optional[str] = None, **kwargs
@@ -410,7 +420,17 @@ class Reader(ABC):
 
         See `aicsimageio.transforms.reshape_data` for more details.
         """
-        pass
+        # If no out orientation, simply return current data as dask array
+        if dimension_order_out is None:
+            return self.data
+
+        # Transform and return
+        return transforms.reshape_data(
+            data=self.data,
+            given_dims=self.dims.order,
+            return_dims=dimension_order_out,
+            **kwargs,
+        )
 
     @property
     @abstractmethod

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -22,6 +22,49 @@ class Reader(ABC):
     _dims = None
     _metadata = None
 
+    @staticmethod
+    @abstractmethod
+    def _reader_supports_image(fs: AbstractFileSystem, path: str) -> bool:
+        """
+        The per-Reader implementation used to validate that an image is supported or not
+        by the Reader itself.
+
+        Parameters
+        ----------
+        fs: AbstractFileSystem
+            The file system to used for reading.
+        path: str
+            The path to the file to read.
+
+        Returns
+        -------
+        supported: bool
+            Boolean value indicating if the file is supported by the reader.
+        """
+        pass
+
+    @classmethod
+    def reader_supports_image(cls, image: types.ImageLike) -> bool:
+        """
+        Asserts that the provided image like object is supported by the current Reader.
+
+        Parameters
+        ----------
+        image: types.ImageLike
+            The filepath or array to validate as a supported type.
+
+        Returns
+        -------
+        supported: bool
+            Boolean indicated if the provided data is or is not supported by the
+            current Reader.
+
+        Raises
+        ------
+        TypeError: Invalid type provided to image parameter.
+        """
+        pass
+
     def __init__(self, image: types.ImageLike, **kwargs):
         """
         A small class to build standardized image reader objects that deal with the raw
@@ -59,49 +102,6 @@ class Reader(ABC):
             The guessed dimension order.
         """
         return DEFAULT_DIMENSION_ORDER[len(DEFAULT_DIMENSION_ORDER) - len(shape) :]
-
-    @staticmethod
-    @abstractmethod
-    def _reader_supports_image(fs: AbstractFileSystem, path: str) -> bool:
-        """
-        The per-Reader implementation of validating that an image is supported or not by
-        the Reader itself.
-
-        Parameters
-        ----------
-        fs: AbstractFileSystem
-            The file system to used for reading.
-        path: str
-            The path to the file to read.
-
-        Returns
-        -------
-        supported: bool
-            Boolean value indicating if the file is supported by the reader.
-        """
-        pass
-
-    @classmethod
-    def reader_supports_image(cls, image: types.ImageLike) -> bool:
-        """
-        Asserts that the provided image like object is supported by the current Reader.
-
-        Parameters
-        ----------
-        image: types.ImageLike
-            The filepath or array to validate as a supported type.
-
-        Returns
-        -------
-        supported: bool
-            Boolean indicated if the provided data is or is not supported by the
-            current Reader.
-
-        Raises
-        ------
-        TypeError: Invalid type provided to image parameter.
-        """
-        pass
 
     @property
     @abstractmethod

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Set, Tuple
 
 import dask.array as da
 import numpy as np
 import xarray as xr
+from fsspec.spec import AbstractBufferedFile
 
 from .. import types
 from ..dimensions import DEFAULT_DIMENSION_ORDER, DimensionNames, Dimensions
@@ -144,6 +146,22 @@ class Reader(ABC):
         IndexError: the provided scene id is not found in the available scene id list
         """
         pass
+
+    @staticmethod
+    def _warn_remote_chunked_read(abstract_file: types.FSSpecBased):
+        """
+        Checks if the file is remote and if so warns of chunked reading failure.
+
+        Parameters
+        ----------
+        abstract_file: types.FSSpecBased
+            The file to check.
+        """
+        if isinstance(abstract_file, AbstractBufferedFile):
+            warnings.warn(
+                "Remote chunked reading (using the *_dask_* properties) will result in "
+                "failures for this file type."
+            )
 
     @abstractmethod
     def _read_delayed(self) -> xr.DataArray:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -468,6 +468,11 @@ class Reader(ABC):
         sizes: PhysicalPixelSizes
             Using available metadata, the floats representing physical pixel sizes for
             dimensions Z, Y, and X.
+
+        Notes
+        -----
+        We currently do not handle unit attachment to these values. Please see the file
+        metadata for unit information.
         """
         pass
 

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -163,6 +163,13 @@ class Reader(ABC):
 
             It is additionally recommended to closely monitor how dask array chunks are
             managed.
+
+        Notes
+        -----
+        Requirements for the returned xr.DataArray:
+        * Must have the `dims` populated.
+        * If a channel dimension is present, please populate the channel dimensions
+        coordinate array the respective channel coordinate values.
         """
         pass
 
@@ -175,6 +182,13 @@ class Reader(ABC):
         -------
         data: xr.DataArray
             The fully read data array.
+
+        Notes
+        -----
+        Requirements for the returned xr.DataArray:
+        * Must have the `dims` populated.
+        * If a channel dimension is present, please populate the channel dimensions
+        coordinate array the respective channel coordinate values.
         """
         pass
 
@@ -202,7 +216,8 @@ class Reader(ABC):
         if self._xarray_data is None:
             self._xarray_data = self._read_immediate()
 
-            # Store dask data as rechunked dask array from the already in-mem
+            # Remake the delayed xarray dataarray object using a rechunked dask array
+            # from the just retrieved in-memory xarray dataarray
             self._xarray_dask_data = xr.DataArray(
                 da.from_array(self._xarray_data.data),
                 dims=self._xarray_data.dims,

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -265,7 +265,6 @@ class Reader(ABC):
         return self.xarray_dask_data.shape
 
     @property
-    @abstractmethod
     def dims(self) -> Dimensions:
         """
         Returns
@@ -273,7 +272,10 @@ class Reader(ABC):
         dims: Dimensions
             Object with the paired dimension names and their sizes.
         """
-        pass
+        if self._dims is None:
+            self._dims = Dimensions(dims=self.xarray_dask_data.dims, shape=self.shape)
+
+        return self._dims
 
     def get_image_dask_data(
         self, dimension_order_out: Optional[str] = None, **kwargs

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -24,7 +24,7 @@ class Reader(ABC):
 
     @staticmethod
     @abstractmethod
-    def _reader_supports_image(fs: AbstractFileSystem, path: str) -> bool:
+    def _is_supported_image(fs: AbstractFileSystem, path: str) -> bool:
         """
         The per-Reader implementation used to validate that an image is supported or not
         by the Reader itself.
@@ -44,7 +44,7 @@ class Reader(ABC):
         pass
 
     @classmethod
-    def reader_supports_image(cls, image: types.ImageLike) -> bool:
+    def is_supported_image(cls, image: types.ImageLike) -> bool:
         """
         Asserts that the provided image like object is supported by the current Reader.
 

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -16,8 +16,8 @@ from ..types import PhysicalPixelSizes
 
 
 class Reader(ABC):
-    _dask_data = None
-    _data = None
+    _dask_xarray = None
+    _xarray = None
     _dims = None
     _metadata = None
 

--- a/aicsimageio/tests/__init__.py
+++ b/aicsimageio/tests/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/tests/conftest.py
+++ b/aicsimageio/tests/conftest.py
@@ -3,14 +3,18 @@
 
 from pathlib import Path
 
-import pytest
+###############################################################################
 
 
-@pytest.fixture
-def local_resources_dir() -> str:
-    return Path(__file__).parent / "resources"
+LOCAL = "LOCAL"
+REMOTE = "REMOTE"
+
+LOCAL_RESOURCES_DIR = Path(__file__).parent / "resources"
+REMOTE_RESOURCES_DIR = "s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources"  # noqa: E501
 
 
-@pytest.fixture
-def remote_resources_dir() -> str:
-    return "s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources"  # noqa: E501
+def get_resource_full_path(filename, host):
+    if host is LOCAL:
+        return LOCAL_RESOURCES_DIR / filename
+    elif host is REMOTE:
+        return f"{REMOTE_RESOURCES_DIR}/{filename}"

--- a/aicsimageio/tests/conftest.py
+++ b/aicsimageio/tests/conftest.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def local_resources_dir() -> str:
+    return Path(__file__).parent / "resources"
+
+
+@pytest.fixture
+def remote_resources_dir() -> str:
+    return "s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources"  # noqa: E501

--- a/aicsimageio/tests/readers/__init__.py
+++ b/aicsimageio/tests/readers/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -49,7 +49,7 @@ def run_image_read_checks(
     expected_dtype: np.dtype,
     expected_dims_order: str,
     expected_channel_names: Optional[List[str]],
-    expected_physical_pixel_sizes: Tuple[Optional[float]],
+    expected_physical_pixel_sizes: Tuple[float],
 ) -> Reader:
     # Read file
     reader = ReaderClass(uri)

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pickle
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pytest
+from fsspec.implementations.local import LocalFileOpener
+from psutil import Process
+from xarray.testing import assert_equal
+
+from aicsimageio import types
+from aicsimageio.readers.reader import Reader
+
+###############################################################################
+
+
+def check_local_file_not_open(abstract_file: types.FSSpecBased):
+    # Check that there are no open file pointers
+    if isinstance(abstract_file, LocalFileOpener):
+        proc = Process()
+        assert str(abstract_file.path) not in [f.path for f in proc.open_files()]
+
+
+def check_can_serialize_reader(reader: Reader):
+    # Dump and reconstruct
+    _bytes = pickle.dumps(reader)
+    reconstructed = pickle.loads(_bytes)
+
+    # Assert primary attrs are equal
+    if reader._xarray_data is None:
+        assert reconstructed._xarray_data is None
+    else:
+        assert_equal(reader._xarray_data, reconstructed._xarray_data)
+
+    if reader._xarray_dask_data is None:
+        assert reconstructed._xarray_dask_data is None
+    else:
+        assert_equal(reader._xarray_dask_data, reconstructed._xarray_dask_data)
+
+
+def run_image_read_checks(
+    ReaderClass: Reader,
+    uri: types.PathLike,
+    can_read_chunks: bool,
+    expected_shape: Tuple[int],
+    expected_dtype: np.dtype,
+    expected_dims_order: str,
+    expected_channel_names: Optional[List[str]],
+    expected_physical_pixel_sizes: Tuple[Optional[float]],
+) -> Reader:
+    # Read file
+    reader = ReaderClass(uri)
+
+    # check_local_file_not_open(reader.abstract_file)
+    check_can_serialize_reader(reader)
+
+    # Check basics
+    # Due to how data is routed through the _xarray_dask_data prop,
+    # any call to metadata will be initially routed through it
+    # thus the first call and test needs additional warnings check handling
+    if can_read_chunks:
+        assert reader.dims.order == expected_dims_order
+    else:
+        with pytest.warns(UserWarning):
+            assert reader.dims.order == expected_dims_order
+
+    # Finish checking basics
+    assert reader.metadata
+    assert reader.shape == expected_shape
+    assert reader.dtype == expected_dtype
+    assert reader.channel_names == expected_channel_names
+    assert reader.physical_pixel_sizes == expected_physical_pixel_sizes
+
+    # check_local_file_not_open(reader.abstract_file)
+    check_can_serialize_reader(reader)
+
+    # Try reading remote chunks
+    if can_read_chunks:
+        assert reader.get_image_dask_data("YX").compute() is not None
+    else:
+        with pytest.raises(AttributeError):
+            assert reader.get_image_dask_data("YX").compute() is not None
+
+    # check_local_file_not_open(reader.abstract_file)
+    check_can_serialize_reader(reader)
+
+    # Read the image in full
+    # All readers should be able to do this unless there is some weird format
+    # We can try our best but some implementations just don't exist for reading buffers
+    # I am looking at you FFMPEG formats
+    assert reader.data.shape == expected_shape
+    assert reader.data.dtype == expected_dtype
+
+    # check_local_file_not_open(reader.abstract_file)
+    check_can_serialize_reader(reader)
+
+    return reader

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -25,19 +25,7 @@ def check_local_file_not_open(fs: AbstractFileSystem, path: str):
 
 def check_can_serialize_reader(reader: Reader):
     # Dump and reconstruct
-    header, frames = serialize(reader)
-    reconstructed = deserialize(header, frames)
-
-    # Assert primary attrs are equal
-    if reader._xarray_data is None:
-        assert reconstructed._xarray_data is None
-    else:
-        assert_equal(reader._xarray_data, reconstructed._xarray_data)
-
-    if reader._xarray_dask_data is None:
-        assert reconstructed._xarray_dask_data is None
-    else:
-        assert_equal(reader._xarray_dask_data, reconstructed._xarray_dask_data)
+    deserialize(serialize(reader))
 
 
 def run_image_read_checks(

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -8,6 +8,7 @@ from distributed.protocol import deserialize, serialize
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from psutil import Process
+from xarray.testing import assert_equal
 
 from aicsimageio import types
 from aicsimageio.readers.reader import Reader
@@ -24,7 +25,18 @@ def check_local_file_not_open(fs: AbstractFileSystem, path: str):
 
 def check_can_serialize_reader(reader: Reader):
     # Dump and reconstruct
-    deserialize(*serialize(reader))
+    reconstructed = deserialize(*serialize(reader))
+
+    # Assert primary attrs are equal
+    if reader._xarray_data is None:
+        assert reconstructed._xarray_data is None
+    else:
+        assert_equal(reader._xarray_data, reconstructed._xarray_data)
+
+    if reader._xarray_dask_data is None:
+        assert reconstructed._xarray_dask_data is None
+    else:
+        assert_equal(reader._xarray_dask_data, reconstructed._xarray_dask_data)
 
 
 def run_image_read_checks(

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pickle
 from typing import List, Optional, Set, Tuple
 
 import numpy as np
+from distributed.protocol import deserialize, serialize
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from psutil import Process
@@ -25,8 +25,8 @@ def check_local_file_not_open(fs: AbstractFileSystem, path: str):
 
 def check_can_serialize_reader(reader: Reader):
     # Dump and reconstruct
-    _bytes = pickle.dumps(reader)
-    reconstructed = pickle.loads(_bytes)
+    header, frames = serialize(reader)
+    reconstructed = deserialize(header, frames)
 
     # Assert primary attrs are equal
     if reader._xarray_data is None:

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -8,7 +8,6 @@ from distributed.protocol import deserialize, serialize
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from psutil import Process
-from xarray.testing import assert_equal
 
 from aicsimageio import types
 from aicsimageio.readers.reader import Reader

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -80,17 +80,16 @@ def run_image_read_checks(
     check_local_file_not_open(reader.fs, reader.path)
     check_can_serialize_reader(reader)
 
-    # Try reading remote chunks
-    assert reader.get_image_dask_data("YX").compute() is not None
-    assert reader.get_image_data("YX") is not None
+    # Read only a chunk, then read a chunk from the in-memory, compare
+    np.testing.assert_array_equal(
+        reader.get_image_dask_data("YX").compute(),
+        reader.get_image_data("YX"),
+    )
 
     check_local_file_not_open(reader.fs, reader.path)
     check_can_serialize_reader(reader)
 
-    # Read the image in full
-    # All readers should be able to do this unless there is some weird format
-    # We can try our best but some implementations just don't exist for reading buffers
-    # I am looking at you FFMPEG formats
+    # Check that the shape and dtype are expected after reading in full
     assert reader.data.shape == expected_shape
     assert reader.data.dtype == expected_dtype
 

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -5,7 +5,6 @@ import pickle
 from typing import List, Optional, Set, Tuple
 
 import numpy as np
-from distributed import Client
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from psutil import Process
@@ -93,17 +92,6 @@ def run_image_read_checks(
     # Check that the shape and dtype are expected after reading in full
     assert reader.data.shape == expected_shape
     assert reader.data.dtype == expected_dtype
-
-    check_local_file_not_open(reader.fs, reader.path)
-    check_can_serialize_reader(reader)
-
-    # Check that the dask array can be read with in parallel
-    # This is not checking speed / benchmark
-    # Just checking that all objects can be serialized and parallelized
-    client = Client()
-
-    # Read the full image using dask compute
-    np.testing.assert_array_equal(reader.dask_data.compute(), reader.data)
 
     check_local_file_not_open(reader.fs, reader.path)
     check_can_serialize_reader(reader)

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -65,9 +65,6 @@ def run_image_read_checks(
     assert reader.scenes == expected_scenes
     assert reader.current_scene == expected_current_scene
 
-    check_local_file_not_open(reader.fs, reader.path)
-    check_can_serialize_reader(reader)
-
     # Check basics
     assert reader.shape == expected_shape
     assert reader.dtype == expected_dtype
@@ -77,17 +74,11 @@ def run_image_read_checks(
     assert reader.channel_names == expected_channel_names
     assert reader.physical_pixel_sizes == expected_physical_pixel_sizes
 
-    check_local_file_not_open(reader.fs, reader.path)
-    check_can_serialize_reader(reader)
-
     # Read only a chunk, then read a chunk from the in-memory, compare
     np.testing.assert_array_equal(
         reader.get_image_dask_data("YX").compute(),
         reader.get_image_data("YX"),
     )
-
-    check_local_file_not_open(reader.fs, reader.path)
-    check_can_serialize_reader(reader)
 
     # Check that the shape and dtype are expected after reading in full
     assert reader.data.shape == expected_shape

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -25,7 +25,7 @@ def check_local_file_not_open(fs: AbstractFileSystem, path: str):
 
 def check_can_serialize_reader(reader: Reader):
     # Dump and reconstruct
-    deserialize(serialize(reader))
+    deserialize(*serialize(reader))
 
 
 def run_image_read_checks(

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -19,7 +19,20 @@ from .reader_test_utils import run_image_read_checks
         ("example.png", 0, (800, 537, 4), "YXC", ["R", "G", "B", "A"]),
         ("example.jpg", 0, (452, 400, 3), "YXC", ["R", "G", "B"]),
         ("example.gif", 0, (72, 268, 268, 4), "TYXC", ["R", "G", "B", "A"]),
-        ("example.mp4", 0, (62, 1080, 1920, 3), "TYXC", ["R", "G", "B"]),
+        (
+            "example_invalid_frame_count.mp4",
+            0,
+            (55, 1080, 1920, 3),
+            "TYXC",
+            ["R", "G", "B"],
+        ),
+        (
+            "example_valid_frame_count.mp4",
+            0,
+            (72, 272, 272, 3),
+            "TYXC",
+            ["R", "G", "B"],
+        ),
         pytest.param(
             "example.txt",
             None,

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -73,7 +73,7 @@ def test_default_reader(
         expected_dtype=np.uint8,
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
-        expected_physical_pixel_sizes=(None, 1.0, 1.0),
+        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
     )
 
 

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+from aicsimageio import exceptions
+from aicsimageio.readers import DefaultReader
+
+from .reader_test_utils import run_image_read_checks
+
+
+@pytest.mark.parametrize(
+    (
+        "filename, "
+        "from_local, "
+        "can_read_chunks, "
+        "expected_shape, "
+        "expected_dims_order, "
+        "expected_channel_names, "
+    ),
+    [
+        (
+            "example.bmp",
+            True,
+            True,
+            (480, 640, 4),
+            "YXC",
+            ["R", "G", "B", "A"],
+        ),
+        (
+            "example.bmp",
+            False,
+            True,
+            (480, 640, 4),
+            "YXC",
+            ["R", "G", "B", "A"],
+        ),
+        (
+            "example.png",
+            True,
+            True,
+            (800, 537, 4),
+            "YXC",
+            ["R", "G", "B", "A"],
+        ),
+        (
+            "example.png",
+            False,
+            True,
+            (800, 537, 4),
+            "YXC",
+            ["R", "G", "B", "A"],
+        ),
+        ("example.jpg", True, True, (452, 400, 3), "YXC", ["R", "G", "B"]),
+        ("example.jpg", False, True, (452, 400, 3), "YXC", ["R", "G", "B"]),
+        (
+            "example.gif",
+            True,
+            True,
+            (72, 268, 268, 4),
+            "TYXC",
+            ["R", "G", "B", "A"],
+        ),
+        (
+            "example.gif",
+            False,
+            False,
+            (72, 268, 268, 4),
+            "TYXC",
+            ["R", "G", "B", "A"],
+        ),
+        (
+            "example.mp4",
+            True,
+            True,
+            (183, 1080, 1920, 3),
+            "TYXC",
+            ["R", "G", "B"],
+        ),
+        (
+            "example.mp4",
+            False,
+            False,
+            (183, 1080, 1920, 3),
+            "TYXC",
+            ["R", "G", "B"],
+        ),
+        pytest.param(
+            "example.txt",
+            True,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+        pytest.param(
+            "example.txt",
+            False,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+    ],
+)
+def test_default_reader(
+    local_resources_dir,
+    remote_resources_dir,
+    filename,
+    from_local,
+    can_read_chunks,
+    expected_shape,
+    expected_dims_order,
+    expected_channel_names,
+):
+    # Construct full filepath
+    if from_local:
+        uri = local_resources_dir / filename
+    else:
+        uri = f"{remote_resources_dir}/{filename}"
+
+    # Run checks
+    run_image_read_checks(
+        ReaderClass=DefaultReader,
+        uri=uri,
+        can_read_chunks=can_read_chunks,
+        expected_shape=expected_shape,
+        expected_dtype=np.uint8,
+        expected_dims_order=expected_dims_order,
+        expected_channel_names=expected_channel_names,
+        expected_physical_pixel_sizes=(None, 1.0, 1.0),
+    )

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -149,3 +149,9 @@ def test_default_reader(
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=(None, 1.0, 1.0),
     )
+
+
+def test_ffmpeg_header_fail():
+    with pytest.raises(IOError):
+        # Big Buck Bunny
+        DefaultReader("https://archive.org/embed/archive-video-files/test.mp4")

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -11,94 +11,17 @@ from ..conftest import LOCAL, REMOTE, get_resource_full_path
 from .reader_test_utils import run_image_read_checks
 
 
+@pytest.mark.parametrize("host", [LOCAL, REMOTE])
 @pytest.mark.parametrize(
-    (
-        "filename, "
-        "host, "
-        "set_scene, "
-        "expected_shape, "
-        "expected_dims_order, "
-        "expected_channel_names, "
-    ),
+    "filename, set_scene, expected_shape, expected_dims_order, expected_channel_names",
     [
-        (
-            "example.bmp",
-            LOCAL,
-            0,
-            (480, 640, 4),
-            "YXC",
-            ["R", "G", "B", "A"],
-        ),
-        (
-            "example.bmp",
-            REMOTE,
-            0,
-            (480, 640, 4),
-            "YXC",
-            ["R", "G", "B", "A"],
-        ),
-        (
-            "example.png",
-            LOCAL,
-            0,
-            (800, 537, 4),
-            "YXC",
-            ["R", "G", "B", "A"],
-        ),
-        (
-            "example.png",
-            REMOTE,
-            0,
-            (800, 537, 4),
-            "YXC",
-            ["R", "G", "B", "A"],
-        ),
-        ("example.jpg", LOCAL, 0, (452, 400, 3), "YXC", ["R", "G", "B"]),
-        ("example.jpg", REMOTE, 0, (452, 400, 3), "YXC", ["R", "G", "B"]),
-        (
-            "example.gif",
-            LOCAL,
-            0,
-            (72, 268, 268, 4),
-            "TYXC",
-            ["R", "G", "B", "A"],
-        ),
-        (
-            "example.gif",
-            REMOTE,
-            0,
-            (72, 268, 268, 4),
-            "TYXC",
-            ["R", "G", "B", "A"],
-        ),
-        (
-            "example.mp4",
-            LOCAL,
-            0,
-            (183, 1080, 1920, 3),
-            "TYXC",
-            ["R", "G", "B"],
-        ),
-        (
-            "example.mp4",
-            REMOTE,
-            0,
-            (183, 1080, 1920, 3),
-            "TYXC",
-            ["R", "G", "B"],
-        ),
+        ("example.bmp", 0, (480, 640, 4), "YXC", ["R", "G", "B", "A"]),
+        ("example.png", 0, (800, 537, 4), "YXC", ["R", "G", "B", "A"]),
+        ("example.jpg", 0, (452, 400, 3), "YXC", ["R", "G", "B"]),
+        ("example.gif", 0, (72, 268, 268, 4), "TYXC", ["R", "G", "B", "A"]),
+        ("example.mp4", 0, (183, 1080, 1920, 3), "TYXC", ["R", "G", "B"]),
         pytest.param(
             "example.txt",
-            LOCAL,
-            None,
-            None,
-            None,
-            None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
-        ),
-        pytest.param(
-            "example.txt",
-            REMOTE,
             None,
             None,
             None,
@@ -107,16 +30,6 @@ from .reader_test_utils import run_image_read_checks
         ),
         pytest.param(
             "example.png",
-            LOCAL,
-            1,
-            None,
-            None,
-            None,
-            marks=pytest.mark.raises(exception=IndexError),
-        ),
-        pytest.param(
-            "example.png",
-            REMOTE,
             1,
             None,
             None,

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -19,7 +19,7 @@ from .reader_test_utils import run_image_read_checks
         ("example.png", 0, (800, 537, 4), "YXC", ["R", "G", "B", "A"]),
         ("example.jpg", 0, (452, 400, 3), "YXC", ["R", "G", "B"]),
         ("example.gif", 0, (72, 268, 268, 4), "TYXC", ["R", "G", "B", "A"]),
-        ("example.mp4", 0, (183, 1080, 1920, 3), "TYXC", ["R", "G", "B"]),
+        ("example.mp4", 0, (62, 1080, 1920, 3), "TYXC", ["R", "G", "B"]),
         pytest.param(
             "example.txt",
             None,

--- a/aicsimageio/tests/test_dummy.py
+++ b/aicsimageio/tests/test_dummy.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    pass

--- a/aicsimageio/tests/test_transforms.py
+++ b/aicsimageio/tests/test_transforms.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from aicsimageio.exceptions import ConflictingArgumentsError
+from aicsimageio.transforms import reshape_data, transpose_to_dims
+
+
+@pytest.mark.parametrize("array_maker", [np.zeros, da.zeros])
+@pytest.mark.parametrize(
+    "data_shape, given_dims, return_dims, other_args, expected_shape",
+    [
+        (
+            (10, 1, 5, 6, 200, 400),
+            "STCZYX",
+            "CSZYX",
+            {},
+            (5, 10, 6, 200, 400),
+        ),
+        ((6, 200, 400), "ZYX", "STCZYX", {}, (1, 1, 1, 6, 200, 400)),
+        ((6, 200, 400), "ZYX", "ZCYSXT", {}, (6, 1, 200, 1, 400, 1)),
+        ((6, 200, 400), "ZYX", "CYSXT", {"Z": 2}, (1, 200, 1, 400, 1)),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": [0, 1]},
+            (2, 1, 200, 1, 400, 1),
+        ),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": (0, 1)},
+            (2, 1, 200, 1, 400, 1),
+        ),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": range(2)},
+            (2, 1, 200, 1, 400, 1),
+        ),
+        (
+            (6, 200, 400),
+            "ZYX",
+            "ZCYSXT",
+            {"Z": slice(0, 2, 1)},
+            (2, 1, 200, 1, 400, 1),
+        ),
+        ((2, 2, 2), "ABI", "ZCYSXT", {}, (1, 1, 1, 1, 1, 1)),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXC",
+            {"Z": 7},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZ",
+            {"Z": 7},
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": 7},
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCX",
+            {"Z": [0, 1, 4]},
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": [0, 1, 7]},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": (0, 1, 7)},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": range(7)},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": slice(0, 7, 2)},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": [0, 1, -7]},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": (0, 1, -7)},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": range(0, -8, -1)},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            (6, 200, 400),
+            "ZYX",
+            "TYXCZX",
+            {"Z": slice(-7, 0, 2)},
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+    ],
+)
+def test_reshape_data_shape(
+    array_maker,
+    data_shape,
+    given_dims,
+    return_dims,
+    other_args,
+    expected_shape,
+):
+    data = array_maker(data_shape)
+
+    actual = reshape_data(
+        data=data, given_dims=given_dims, return_dims=return_dims, **other_args
+    )
+    assert actual.shape == expected_shape
+
+    # Check that the output data is the same type as the input
+    assert type(actual) == type(data)
+
+
+@pytest.mark.parametrize(
+    "data, given_dims, return_dims, idx_in, idx_out",
+    [
+        (
+            np.random.rand(10, 1, 5, 6, 200, 400),
+            "STCZYX",
+            "CSZYX",
+            (5, 0, 3, 3, ...),
+            (3, 5, 3, ...),
+        ),
+        (
+            da.random.random((10, 1, 5, 6, 200, 400)),
+            "STCZYX",
+            "CSZYX",
+            (5, 0, 3, 3, ...),
+            (3, 5, 3, ...),
+        ),
+        (
+            np.zeros((6, 200, 400)),
+            "ZYX",
+            "STCZYX",
+            (..., 100, 200),
+            (0, 0, 0, ..., 100, 200),
+        ),
+        (
+            da.zeros((6, 200, 400)),
+            "ZYX",
+            "STCZYX",
+            (..., 100, 200),
+            (0, 0, 0, ..., 100, 200),
+        ),
+        (
+            np.zeros((6, 200, 400)),
+            "ZYX",
+            "ZCYSXT",
+            (3, 100, ...),
+            (3, 0, 100, 0, ..., 0),
+        ),
+        (
+            da.zeros((6, 200, 400)),
+            "ZYX",
+            "ZCYSXT",
+            (3, 100, ...),
+            (3, 0, 100, 0, ..., 0),
+        ),
+    ],
+)
+def test_reshape_data_values(data, given_dims, return_dims, idx_in, idx_out):
+    slice_in = data[idx_in]
+    actual = reshape_data(data=data, given_dims=given_dims, return_dims=return_dims)
+    if isinstance(data, da.core.Array):
+        slice_in = slice_in.compute()
+        actual = actual.compute()
+    np.testing.assert_array_equal(slice_in, actual[idx_out])
+
+    # Check that the output data is the same type as the input
+    assert type(actual) == type(slice_in)
+
+
+# Arrays used for value checking on kwarg provided reshape_data
+NP_ONES = np.ones((10, 10))
+TEST_NDARRAY = np.stack([NP_ONES * i for i in range(7)])
+DA_ONES = da.ones((10, 10))
+TEST_DARRAY = da.stack([DA_ONES * i for i in range(7)])
+
+
+@pytest.mark.parametrize("data", [TEST_NDARRAY, TEST_DARRAY])
+@pytest.mark.parametrize(
+    "given_dims, return_dims, other_args, getitem_ops_for_expected, transposer",
+    [
+        # Just dimension selection
+        ("ZYX", "YX", {}, 0, None),
+        ("ZYX", "YX", {"Z": 1}, 1, None),
+        ("ZYX", "ZYX", {"Z": [0, 1]}, [0, 1], None),
+        ("ZYX", "ZYX", {"Z": (0, 1)}, [0, 1], None),
+        ("ZYX", "ZYX", {"Z": [0, -1]}, [0, -1], None),
+        ("ZYX", "ZYX", {"Z": (0, -1)}, [0, -1], None),
+        ("ZYX", "ZYX", {"Z": range(2)}, [0, 1], None),
+        ("ZYX", "ZYX", {"Z": range(0, 6, 2)}, [0, 2, 4], None),
+        ("ZYX", "ZYX", {"Z": slice(0, 6, 2)}, [0, 2, 4], None),
+        ("ZYX", "ZYX", {"Z": slice(6, 3, -1)}, [6, 5, 4], None),
+        ("ZYX", "ZYX", {"Z": slice(-1, 3, -1)}, [6, 5, 4], None),
+        # Dimension selection and order swap
+        (
+            "ZYX",
+            "YXZ",
+            {"Z": (0, -1)},
+            [0, -1],
+            (1, 2, 0),
+        ),
+        (
+            "ZYX",
+            "YXZ",
+            {"Z": range(0, 6, 2)},
+            [0, 2, 4],
+            (1, 2, 0),
+        ),
+    ],
+)
+def test_reshape_data_kwargs_values(
+    data,
+    given_dims,
+    return_dims,
+    other_args,
+    getitem_ops_for_expected,
+    transposer,
+):
+    actual = reshape_data(
+        data=data,
+        given_dims=given_dims,
+        return_dims=return_dims,
+        **other_args,
+    )
+
+    expected = data[getitem_ops_for_expected]
+
+    if transposer is not None:
+        if isinstance(data, np.ndarray):
+            expected = np.transpose(expected, transposer)
+        else:
+            expected = da.transpose(expected, transposer)
+
+    # Check that the output data is the same type as the input
+    assert type(actual) == type(expected)
+
+    if isinstance(data, da.core.Array):
+        actual = actual.compute()
+        expected = expected.compute()
+
+    # Check actual data
+    np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "data, given_dims, return_dims, expected_shape",
+    [
+        (np.zeros((1, 2, 3, 4, 5, 6)), "STCZYX", "XYZCTS", (6, 5, 4, 3, 2, 1)),
+        (da.zeros((1, 2, 3, 4, 5, 6)), "STCZYX", "XYZCTS", (6, 5, 4, 3, 2, 1)),
+        (np.zeros((1, 2, 3)), "ZYX", "ZXY", (1, 3, 2)),
+        (da.zeros((1, 2, 3)), "ZYX", "ZXY", (1, 3, 2)),
+        pytest.param(
+            np.zeros((6, 200, 400)),
+            "ZYX",
+            "TYXC",
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+        pytest.param(
+            da.zeros((6, 200, 400)),
+            "ZYX",
+            "TYXC",
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+        pytest.param(
+            np.zeros((6, 200, 400)),
+            "ZYX",
+            "TYXCZ",
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+        pytest.param(
+            da.zeros((6, 200, 400)),
+            "ZYX",
+            "TYXCZ",
+            None,
+            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+        ),
+    ],
+)
+def test_transpose_to_dims(data, given_dims, return_dims, expected_shape):
+    actual = transpose_to_dims(
+        data=data, given_dims=given_dims, return_dims=return_dims
+    )
+    assert actual.shape == expected_shape
+
+    # Check that the output data is the same type as the input
+    assert type(actual) == type(data)

--- a/aicsimageio/tests/utils/__init__.py
+++ b/aicsimageio/tests/utils/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-

--- a/aicsimageio/tests/utils/test_io_utils.py
+++ b/aicsimageio/tests/utils/test_io_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from aicsimageio.utils.io_utils import pathlike_to_fs
+
+from ..conftest import LOCAL, REMOTE, get_resource_full_path
+
+
+@pytest.mark.parametrize(
+    "filename, host, enforce_exists",
+    [
+        ("example.txt", LOCAL, False),
+        ("example.txt", REMOTE, False),
+        ("does-not-exist.good", LOCAL, False),
+        ("does-not-exist.good", REMOTE, False),
+        pytest.param(
+            "does-not-exist.bad",
+            LOCAL,
+            True,
+            marks=pytest.mark.raises(exception=FileNotFoundError),
+        ),
+        pytest.param(
+            "does-not-exist.bad",
+            REMOTE,
+            True,
+            marks=pytest.mark.raises(exception=FileNotFoundError),
+        ),
+    ],
+)
+def test_pathlike_to_fs(filename, host, enforce_exists):
+    # Construct full filepath
+    uri = get_resource_full_path(filename, host)
+
+    pathlike_to_fs(uri, enforce_exists)

--- a/aicsimageio/tests/utils/test_io_utils.py
+++ b/aicsimageio/tests/utils/test_io_utils.py
@@ -8,22 +8,21 @@ from aicsimageio.utils.io_utils import pathlike_to_fs
 from ..conftest import LOCAL, REMOTE, get_resource_full_path
 
 
+@pytest.mark.parametrize("host", [LOCAL, REMOTE])
 @pytest.mark.parametrize(
-    "filename, host, enforce_exists",
+    "filename, enforce_exists",
     [
-        ("example.txt", LOCAL, False),
-        ("example.txt", REMOTE, False),
-        ("does-not-exist.good", LOCAL, False),
-        ("does-not-exist.good", REMOTE, False),
+        ("example.txt", False),
+        ("example.txt", False),
+        ("does-not-exist.good", False),
+        ("does-not-exist.good", False),
         pytest.param(
             "does-not-exist.bad",
-            LOCAL,
             True,
             marks=pytest.mark.raises(exception=FileNotFoundError),
         ),
         pytest.param(
             "does-not-exist.bad",
-            REMOTE,
             True,
             marks=pytest.mark.raises(exception=FileNotFoundError),
         ),

--- a/aicsimageio/transforms.py
+++ b/aicsimageio/transforms.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from collections import Counter
+
+from . import types
+from .constants import Dimensions
+from .exceptions import ConflictingArgumentsError
+
+###############################################################################
+
+
+def transpose_to_dims(
+    data: types.ArrayLike,
+    given_dims: str,
+    return_dims: str,
+) -> types.ArrayLike:
+    """
+    This shuffles the data dimensions from given_dims to return_dims. Each dimension
+    must be present in given_dims must be used in return_dims
+
+    data: types.ArrayLike
+        Either a dask array or numpy.ndarray of arbitrary shape but with the dimensions
+        specified in given_dims
+    given_dims: str
+        The dimension ordering of data, "CZYX", "VBTCXZY" etc
+    return_dims: str
+        The dimension ordering of the return data
+
+    Returns
+    -------
+    data: types.ArrayLike
+        The data with the specified dimension ordering.
+
+    Raises
+    ------
+    ConflictingArgumentsError: given_dims and return_dims are incompatible.
+    """
+    # Use a counter to track that the contents are composed of the same letters
+    # and that no letter is repeated
+    if (
+        Counter(given_dims) != Counter(return_dims)
+        or max(Counter(given_dims).values()) > 1
+    ):
+        raise ConflictingArgumentsError(
+            f"given_dims={given_dims} and return_dims={return_dims} are incompatible."
+        )
+    # Resort the data into return_dims order
+    match_map = {dim: given_dims.find(dim) for dim in given_dims}
+    transposer = []
+    for dim in return_dims:
+        transposer.append(match_map[dim])
+    data = data.transpose(transposer)
+    return data
+
+
+def reshape_data(
+    data: types.ArrayLike, given_dims: str, return_dims: str, **kwargs
+) -> types.ArrayLike:
+    """
+    Reshape the data into return_dims, pad missing dimensions, and prune extra
+    dimensions. Warns the user to use the base reader if the depth of the Dimension
+    being removed is not 1.
+
+    Parameters
+    ----------
+    data: types.ArrayLike
+        Either a dask array or numpy.ndarray of arbitrary shape but with the dimensions
+        specified in given_dims
+    given_dims: str
+        The dimension ordering of data, "CZYX", "VBTCXZY" etc
+    return_dims: str
+        The dimension ordering of the return data
+    kwargs:
+        * C=1 => desired specific channel, if C in the input data has depth 3 then C=1
+          returns the 2nd slice (0 indexed)
+        * Z=10 => desired specific channel, if Z in the input data has depth 20 then
+          Z=10 returns the 11th slice
+        * T=[0, 1] => desired specific timepoints, if T in the input data has depth 100
+          then T=[0, 1] returns the 1st and 2nd slice (0 indexed)
+        * T=(0, 1) => desired specific timepoints, if T in the input data has depth 100
+          then T=(0, 1) returns the 1st and 2nd slice (0 indexed)
+        * T=(0, -1) => desired specific timepoints, if T in the input data has depth 100
+          then T=(0, -1) returns the first and last slice
+        * T=range(10) => desired specific timepoints, if T in the input data has depth
+          100 then T=range(10) returns the first ten slices
+        * T=slice(0, -1, 5) => desired specific timepoints, T=slice(0, -1, 5) returns
+          every fifth timepoint
+
+    Returns
+    -------
+    data: types.ArrayLike
+        The data with the specified dimension ordering.
+
+    Raises
+    ------
+    ConflictingArgumentsError: Missing dimension in return dims when using range,
+        slice, or multi-index dimension selection for the requested dimension.
+    IndexError: Requested dimension index not present in data.
+
+    Examples
+    --------
+    Specific index selection
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... z1 = reshape_data(data, "ZYX", "YX", Z=1)
+
+    List of index selection
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... first_and_second = reshape_data(data, "ZYX", "YX", Z=[0, 1])
+
+    Tuple of index selection
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... first_and_last = reshape_data(data, "ZYX", "YX", Z=(0, -1))
+
+    Range of index selection
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... first_three = reshape_data(data, "ZYX", "YX", Z=range(3))
+
+    Slice selection
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... every_other = reshape_data(data, "ZYX", "YX", Z=slice(0, -1, 2))
+
+    Empty dimension expansion
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... with_time = reshape_data(data, "ZYX", "TZYX")
+
+    Dimension order shuffle
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... as_zx_base = reshape_data(data, "ZYX", "YZX")
+
+    Selections, empty dimension expansions, and dimension order shuffle
+
+    >>> data = np.random.rand((10, 100, 100))
+    ... example = reshape_data(data, "CYX", "BSTCZYX", C=slice(0, -1, 3))
+    """
+    # Check for parameter conflicts
+    for dim in Dimensions.DefaultOrderList:
+        # return_dims='TCZYX' and fixed dimensions 'C=1'
+        # Dimension is in kwargs
+        # Dimension is an integer
+        # Dimension is in return dimensions
+        if isinstance(kwargs.get(dim), int) and dim in return_dims:
+            raise ConflictingArgumentsError(
+                f"When selecting a single dimension index, the specified dimension can "
+                f"not be provided in return_dims. "
+                f"return_dims={return_dims}, dimension {dim} = {kwargs.get(dim)}"
+            )
+
+        # return_dims='CZYX' and iterable dimensions 'T=range(10)'
+        # Dimension is in kwargs
+        # Dimension is an iterable
+        # Dimension is not in return dimensions
+        if (
+            isinstance(kwargs.get(dim), (list, tuple, range, slice))
+            and dim not in return_dims
+        ):
+            raise ConflictingArgumentsError(
+                f"When selecting a multiple dimension indicies, the specified "
+                f"dimension must be provided in return_dims. "
+                f"return_dims={return_dims}, dimension {dim} = {kwargs.get(dim)}"
+            )
+
+    # Process each dimension available
+    new_dims = given_dims
+    dim_specs = []
+    for dim in given_dims:
+        # Store index of the dim as it is in given data
+        dim_index = given_dims.index(dim)
+
+        # Handle dim in return dims which means that it is
+        # an iterable or None selection
+        if dim in return_dims:
+            # Specific iterable requested
+            if dim in kwargs:
+                # Actual dim specification
+                # The specification provided for this dimension in the kwargs
+                dim_spec = kwargs.get(dim)
+                display_dim_spec = dim_spec
+
+                # Convert operator to standard list or slice
+                # dask.Array and numpy.ndarray both natively support
+                # List[int] and slices being passed to getitem so no need to cast them
+                # to anything different
+                if isinstance(dim_spec, (tuple, range)):
+                    dim_spec = list(dim_spec)
+
+                # Get the largest absolute value index in the list using min and max
+                if isinstance(dim_spec, list):
+                    check_selection_max = max([abs(min(dim_spec)), max(dim_spec)])
+
+                # Get the largest absolute value index from start and stop of slice
+                if isinstance(dim_spec, slice):
+                    check_selection_max = max([abs(dim_spec.stop), abs(dim_spec.start)])
+            else:
+                # Nothing was requested from this dimension
+                dim_spec = slice(None, None, None)
+                display_dim_spec = dim_spec
+
+                # No op means that it doesn't matter how much data is in this dimension
+                check_selection_max = 0
+
+        # Not in given dims means that it is a fixed integer selection
+        else:
+            if dim in kwargs:
+                # Integer requested
+                dim_spec = kwargs.get(dim)
+                display_dim_spec = dim_spec
+
+                # Check that integer
+                check_selection_max = dim_spec
+            else:
+                dim_spec = 0
+                display_dim_spec = dim_spec
+                check_selection_max = 0
+
+            # Remove dim from new dims as it is fixed size
+            new_dims = new_dims.replace(dim, "")
+
+        # Check that fixed integer request isn't outside of request
+        if check_selection_max > data.shape[dim_index]:
+            raise IndexError(
+                f"Dimension specified with {dim}={display_dim_spec} "
+                f"but Dimension shape is {data.shape[dim_index]}."
+            )
+
+        # All checks and operations passed, append dim operation to getitem ops
+        dim_specs.append(dim_spec)
+
+    # Run getitems
+    data = data[tuple(dim_specs)]
+
+    # Add empty dims where dimensions were requested but data doesn't exist
+    # Add dimensions to new dims where empty dims are added
+    for i, dim in enumerate(return_dims):
+        # This dimension wasn't processed
+        if dim not in given_dims:
+            new_dims = f"{new_dims[:i]}{dim}{new_dims[i:]}"
+            data = data.reshape(*data.shape[:i], 1, *data.shape[i:])
+
+    # Any extra dimensions have been removed, only a problem if the depth is > 1
+    return transpose_to_dims(
+        data, given_dims=new_dims, return_dims=return_dims
+    )  # don't pass kwargs or 2 copies

--- a/aicsimageio/transforms.py
+++ b/aicsimageio/transforms.py
@@ -4,7 +4,7 @@
 from collections import Counter
 
 from . import types
-from .constants import Dimensions
+from .dimensions import DEFAULT_DIMENSION_ORDER_LIST
 from .exceptions import ConflictingArgumentsError
 
 ###############################################################################
@@ -141,7 +141,7 @@ def reshape_data(
     ... example = reshape_data(data, "CYX", "BSTCZYX", C=slice(0, -1, 3))
     """
     # Check for parameter conflicts
-    for dim in Dimensions.DefaultOrderList:
+    for dim in DEFAULT_DIMENSION_ORDER_LIST:
         # return_dims='TCZYX' and fixed dimensions 'C=1'
         # Dimension is in kwargs
         # Dimension is an integer

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -8,9 +8,11 @@ from typing import NamedTuple, Union
 import dask.array as da
 import numpy as np
 import xarray as xr
+from fsspec.implementations.local import LocalFileOpener
+from fsspec.spec import AbstractBufferedFile
 
 # IO Types
-FSSpecBased = "fsspec-based"
+FSSpecBased = Union[AbstractBufferedFile, LocalFileOpener]
 PathLike = Union[str, Path]
 BytesLike = Union[bytes, BufferedIOBase]
 FileLike = Union[PathLike, BytesLike]

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -7,12 +7,14 @@ from typing import NamedTuple, Union
 
 import dask.array as da
 import numpy as np
+import xarray as xr
 
 # IO Types
+FSSpecBased = "fsspec-based"
 PathLike = Union[str, Path]
 BytesLike = Union[bytes, BufferedIOBase]
 FileLike = Union[PathLike, BytesLike]
-ArrayLike = Union[np.ndarray, da.Array]
+ArrayLike = Union[np.ndarray, da.Array, xr.DataArray]
 ImageLike = Union[FileLike, ArrayLike]
 
 

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pathlib import Path
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple, Union
 
 import dask.array as da
 import numpy as np
@@ -17,6 +17,6 @@ ImageLike = Union[PathLike, ArrayLike]
 
 # Image Utility Types
 class PhysicalPixelSizes(NamedTuple):
-    Z: Optional[float]
-    Y: Optional[float]
-    X: Optional[float]
+    Z: float
+    Y: float
+    X: float

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -1,23 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from io import BufferedIOBase
 from pathlib import Path
 from typing import NamedTuple, Optional, Union
 
 import dask.array as da
 import numpy as np
-import xarray as xr
-from fsspec.implementations.local import LocalFileOpener
-from fsspec.spec import AbstractBufferedFile
+
+###############################################################################
 
 # IO Types
-FSSpecBased = Union[AbstractBufferedFile, LocalFileOpener]
 PathLike = Union[str, Path]
-BytesLike = Union[bytes, BufferedIOBase]
-FileLike = Union[PathLike, BytesLike]
-ArrayLike = Union[np.ndarray, da.Array, xr.DataArray]
-ImageLike = Union[FileLike, ArrayLike]
+ArrayLike = Union[np.ndarray, da.Array]
+ImageLike = Union[PathLike, ArrayLike]
 
 
 # Image Utility Types

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -3,7 +3,7 @@
 
 from io import BufferedIOBase
 from pathlib import Path
-from typing import NamedTuple, Union
+from typing import NamedTuple, Optional, Union
 
 import dask.array as da
 import numpy as np
@@ -22,6 +22,6 @@ ImageLike = Union[FileLike, ArrayLike]
 
 # Image Utility Types
 class PhysicalPixelSizes(NamedTuple):
-    Z: float
-    Y: float
-    X: float
+    Z: Optional[float]
+    Y: Optional[float]
+    X: Optional[float]

--- a/aicsimageio/utils/io_utils.py
+++ b/aicsimageio/utils/io_utils.py
@@ -51,4 +51,7 @@ def pathlike_to_fs(
             raise FileNotFoundError(f"{fs.protocol}://{path}")
 
     # Get and store details
+    # We do not return an AbstractBufferedFile (i.e. fs.open) as we do not want to have
+    # any open file buffers _after_ any API call. API calls must themselves call
+    # fs.open and complete their function during the context of the opened buffer.
     return fs, path

--- a/aicsimageio/utils/io_utils.py
+++ b/aicsimageio/utils/io_utils.py
@@ -6,11 +6,12 @@ from typing import Union
 
 from fsspec.core import url_to_fs
 from fsspec.implementations.local import LocalFileOpener
-from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
+from fsspec.spec import AbstractBufferedFile
 
 from ..types import PathLike
 
 ###############################################################################
+
 
 def pathlike_to_fs(
     uri: PathLike,

--- a/aicsimageio/utils/io_utils.py
+++ b/aicsimageio/utils/io_utils.py
@@ -2,11 +2,10 @@
 # -*- coding: utf-8 -*-
 
 from pathlib import Path
-from typing import Union
+from typing import Tuple
 
 from fsspec.core import url_to_fs
-from fsspec.implementations.local import LocalFileOpener
-from fsspec.spec import AbstractBufferedFile
+from fsspec.spec import AbstractFileSystem
 
 from ..types import PathLike
 
@@ -16,7 +15,7 @@ from ..types import PathLike
 def pathlike_to_fs(
     uri: PathLike,
     enforce_exists: bool = False,
-) -> Union[AbstractBufferedFile, LocalFileOpener]:
+) -> Tuple[AbstractFileSystem, str]:
     """
     Find and return the appropriate filesystem and path from a path-like object.
 
@@ -29,8 +28,10 @@ def pathlike_to_fs(
 
     Returns
     -------
-    abstract_file: Union[AbstractBufferedFile, LocalFileOpener]
-        A file like object to operate on.
+    fs: AbstractFileSystem
+        The filesystem to operate on.
+    path: str
+        The full path to the target resource.
 
     Raises
     ------
@@ -50,4 +51,4 @@ def pathlike_to_fs(
             raise FileNotFoundError(f"{fs.protocol}://{path}")
 
     # Get and store details
-    return fs.open(path)
+    return fs, path

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="711efcccecd89984d24f164b051d6b188ba6c5c591f68576ad43461fe817fb7c",
+            default="88b4196592e9e5287404064edd0ee229f1a14240d46858de137b4f6f720734bf",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="fb3aa3dccf08aab89031b63d84fc466e4a7c25a54ef80da21797302360ab3c6c",
+            default="be58d5297245eb07ab1d8c5a180b6e2fcc150cf2bb6b506dd02943874354dfbc",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="be58d5297245eb07ab1d8c5a180b6e2fcc150cf2bb6b506dd02943874354dfbc",
+            default="711efcccecd89984d24f164b051d6b188ba6c5c591f68576ad43461fe817fb7c",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup_requirements = [
 test_requirements = [
     "black>=19.10b0",
     "codecov>=2.1.4",
+    "distributed>=2.9.0",
     "docutils>=0.10,<0.16",
     "flake8>=3.8.3",
     "flake8-debugger>=3.2.1",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ test_requirements = [
     "pytest>=5.4.3",
     "pytest-cov>=2.9.0",
     "pytest-raises>=0.11",
-    "quilt3>=3.1.12",
+    "quilt3>=3.1.12",  # downloading test resources locally
+    "s3fs>=0.5.1",  # remote reading
 ]
 
 dev_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,11 @@ extra_requirements = {
 
 setup(
     author="Allen Institute for Cell Science",
-    author_email=("jacksonb@alleninstitute.org, " "bowdenm@spu.edu"),
+    author_email=(
+        "jmaxfieldbrown@gmail.com, "
+        "jamies@alleninstitute.org, "
+        "bowdenm@spu.edu"
+    ),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
@@ -90,8 +94,8 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     description=(
-        "Delayed parallel image reading, metadata parsing, and image writing for "
-        "microscopy formats in pure Python from the Allen Institute for Cell Science."
+        "Image Reading, Metadata Conversion, and Image Writing for Microscopy Images "
+        "in Pure Python"
     ),
     entry_points={},
     install_requires=requirements,
@@ -99,7 +103,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     include_package_data=True,
-    keywords="aicsimageio, allen cell, imaging, computational biology",
+    keywords="imageio, image reading, image writing, metadata, aicsimageio, allen cell",
     name="aicsimageio",
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
     python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ with open("README.md") as readme_file:
 requirements = [
     "aicspylibczi>=2.5.0",
     "dask>=2.9.0",
-    "distributed>=2.9.3",
     "fsspec>=0.8.4",
     "numpy>=1.16",
     "imagecodecs>=2020.2.18",
@@ -19,7 +18,6 @@ requirements = [
     "readlif>=0.2.1",
     "lxml>=4.4.2",
     "tifffile>=2019.7.26.2",
-    "toolz>=0.10.0",
     "xarray>=0.16.0",
 ]
 
@@ -62,9 +60,11 @@ benchmark_requirements = [
     "altair_saver",
     "czifile==2019.7.2",
     "dask_jobqueue==0.7.0",
+    "distributed>=2.9.3",
     "imageio==2.8.0",
     "quilt3>=3.1.12",
     "tifffile==2020.2.16",
+    "toolz>=0.10.0",
     "tqdm",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as readme_file:
 
 requirements = [
     "aicspylibczi>=2.5.0",
-    "dask>=2.9.0",
+    "dask[array]>=2.9.0",
     "fsspec>=0.8.4",
     "numpy>=1.16",
     "imagecodecs>=2020.2.18",
@@ -64,7 +64,6 @@ benchmark_requirements = [
     "imageio==2.8.0",
     "quilt3>=3.1.12",
     "tifffile==2020.2.16",
-    "toolz>=0.10.0",
     "tqdm",
 ]
 
@@ -79,9 +78,7 @@ extra_requirements = {
 setup(
     author="Allen Institute for Cell Science",
     author_email=(
-        "jmaxfieldbrown@gmail.com, "
-        "jamies@alleninstitute.org, "
-        "bowdenm@spu.edu"
+        "jmaxfieldbrown@gmail.com, " "jamies@alleninstitute.org, " "bowdenm@spu.edu"
     ),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ with open("README.md") as readme_file:
 
 requirements = [
     "aicspylibczi>=2.5.0",
+    # Cannot move to 3.7.* due to:
+    # https://github.com/aio-libs/aiohttp/issues/5128
+    "aiohttp==3.6.3",
     "dask[array]>=2.9.0",
     "fsspec>=0.8.4",
     "numpy>=1.16",
@@ -37,7 +40,7 @@ test_requirements = [
     "pytest-cov>=2.9.0",
     "pytest-raises>=0.11",
     "quilt3>=3.1",
-    "s3fs"
+    "s3fs>=0.5",
 ]
 
 dev_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,6 @@ with open("README.md") as readme_file:
 
 requirements = [
     "aicspylibczi>=2.6.0",
-    # Cannot move to 3.7.* due to:
-    # https://github.com/aio-libs/aiohttp/issues/5128
-    "aiohttp==3.6.3",
     "dask[array]>=2.9.0",
     "fsspec>=0.8.4",
     "numpy>=1.16",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "lxml>=4.4.2",
     "tifffile>=2019.7.26.2",
     "toolz>=0.10.0",
-    "xarray>=0.16"
+    "xarray>=0.16",
 ]
 
 setup_requirements = [
@@ -82,9 +82,7 @@ extra_requirements = {
 setup(
     author="Allen Institute for Cell Science",
     author_email=(
-        "jmaxfieldbrown@gmail.com, "
-        "jamies@alleninstitute.org, "
-        "bowdenm@spu.edu"
+        "jmaxfieldbrown@gmail.com, jamies@alleninstitute.org, bowdenm@spu.edu"
     ),
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     "aicspylibczi>=2.5.0",
     "dask>=2.9.0",
     "distributed>=2.9.3",
-    "fsspec>=0.7.4",
+    "fsspec>=0.8.4",
     "numpy>=1.16",
     "imagecodecs>=2020.2.18",
     "imageio[ffmpeg]>=2.3.0",
@@ -20,6 +20,7 @@ requirements = [
     "lxml>=4.4.2",
     "tifffile>=2019.7.26.2",
     "toolz>=0.10.0",
+    "xarray>=0.16.0",
 ]
 
 setup_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -9,20 +9,20 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "aicspylibczi>=2.5.0",
+    "aicspylibczi>=2.6.0",
     # Cannot move to 3.7.* due to:
     # https://github.com/aio-libs/aiohttp/issues/5128
     "aiohttp==3.6.3",
     "dask[array]>=2.9.0",
     "fsspec>=0.8.4",
     "numpy>=1.16",
-    "imagecodecs>=2020.2.18",
-    "imageio[ffmpeg]>=2.3.0",
+    "imagecodecs>=2020.5.30",
+    "imageio[ffmpeg]>=2.9.0",
     "readlif>=0.2.1",
-    "lxml>=4.4.2",
-    "tifffile>=2019.7.26.2",
-    "toolz>=0.10.0",
-    "xarray>=0.16",
+    "lxml>=4.5.2",
+    "tifffile>=2020.9.22",
+    "toolz>=0.10.1",
+    "xarray>=0.16.1",
 ]
 
 setup_requirements = [
@@ -40,7 +40,7 @@ test_requirements = [
     "pytest>=5.4.3",
     "pytest-cov>=2.9.0",
     "pytest-raises>=0.11",
-    "quilt3>=3.1",
+    "quilt3>=3.1.12",
     "s3fs>=0.5",
 ]
 


### PR DESCRIPTION
**This PR points to `feature/update-to-4.0-api`.** I will basically be rewriting all the current modules to match the 4.0 API and placing them into that branch, then, finally once that is all done, be merging `feature/update-to-4.0-api` and `release-4.0`.

## Description

This changes the `Reader` spec to heavily rely on `xarray`, but, in doing so, it makes it much easier to manage the actual image data, dims, and extra metadata.

* `fsspec` works for chunked local or remote :tada: 
* `ffmpeg` formats can now be read (in most cases)
* I even added some nifty interactions on the `xarray` side where the `T` coordinates get filled if `duration` is present in metadata and such.

All in all, this now "just works" ^ TM:
```python
from aicsimageio.readers import DefaultReader

r = DefaultReader("s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/example.mp4")

# read w.e. chunk you want out of a big remote file
last_ten = r.get_image_dask_data("TYXC", T=range(-10, 0))
last_ten = last_ten.compute()

# or just read the whole thing in
r.data
```

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

WIP #106 
WIP #144 

- [x] Provide relevant tests for your feature or bug fix.

~Two tests are failing because apparently keeping multiple copies of a `(183, 1080, 1920, 3)` array for serialization checking takes up a lot memory.~

~So, once we get AWS credentials figured out for me as a non-Allen person I will upload a new, smaller, test file that fits into the CI's memory.~

I have updated the test files and additionally have made a specific `gh-actions-service-account` IAM user in the AWS org that only has S3 read access. The secrets for this repo are using that accounts credentials.

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
