### PR TITLE
feature/add-tiff-reader

### DIFF
--- a/aicsimageio/readers/__init__.py
+++ b/aicsimageio/readers/__init__.py
@@ -2,3 +2,4 @@
 # -*- coding: utf-8 -*-
 
 from .default_reader import DefaultReader  # noqa: F401
+from .tiff_reader import TiffReader  # noqa: F401

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -12,7 +12,6 @@ from fsspec.spec import AbstractFileSystem
 
 from .. import exceptions, types
 from ..dimensions import DimensionNames
-from ..types import PhysicalPixelSizes
 from ..utils import io_utils
 from .reader import Reader
 
@@ -110,7 +109,7 @@ class DefaultReader(Reader):
             raise exceptions.UnsupportedFileFormatError(self.extension)
 
     @staticmethod
-    def guess_dim_order(shape: Tuple[int]) -> str:
+    def _guess_dim_order(shape: Tuple[int]) -> str:
         if len(shape) == 2:
             return f"{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
         elif len(shape) == 3:
@@ -124,7 +123,7 @@ class DefaultReader(Reader):
                 f"{DimensionNames.SpatialX}{DimensionNames.Channel}"
             )
 
-        return Reader.guess_dim_order(shape)
+        return Reader._guess_dim_order(shape)
 
     @property
     def scenes(self) -> Tuple[int]:
@@ -137,15 +136,6 @@ class DefaultReader(Reader):
     @property
     def current_scene(self) -> int:
         return self.scenes[0]
-
-    def set_scene(self, id: int):
-        # We don't need to do any value setting here, we simply need to keep to the
-        # Reader spec and enforce that the scene id provided is valid
-        if id not in self.scenes:
-            raise IndexError(
-                f"Scene id: {id} "
-                f"is not present in available image scenes: {self.scenes}"
-            )
 
     @staticmethod
     def _get_image_data(
@@ -261,7 +251,7 @@ class DefaultReader(Reader):
             If possible, the coordinates for dimensions in the image data.
         """
         # Guess dims
-        dims = [c for c in DefaultReader.guess_dim_order(image_data.shape)]
+        dims = [c for c in DefaultReader._guess_dim_order(image_data.shape)]
 
         # Use dims for coord determination
         coords = {}
@@ -436,7 +426,3 @@ class DefaultReader(Reader):
             self._metadata = self.xarray_dask_data.attrs
 
         return self._metadata
-
-    @property
-    def physical_pixel_sizes(self) -> PhysicalPixelSizes:
-        return PhysicalPixelSizes(1.0, 1.0, 1.0)

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -21,6 +21,8 @@ class Reader(ABC):
     _xarray_data = None
     _dims = None
     _metadata = None
+    _scenes = None
+    _current_scene = None
 
     @staticmethod
     @abstractmethod
@@ -84,7 +86,7 @@ class Reader(ABC):
         pass
 
     @staticmethod
-    def guess_dim_order(shape: Tuple[int]) -> str:
+    def _guess_dim_order(shape: Tuple[int]) -> str:
         """
         Given an image shape attempts to guess the dimension order.
 
@@ -149,7 +151,24 @@ class Reader(ABC):
         ------
         IndexError: the provided scene id is not found in the available scene id list
         """
-        pass
+        # Only need to run when the scene id is different from current scene
+        if id != self.current_scene:
+
+            # Validate scene id
+            if id not in self.scenes:
+                raise IndexError(
+                    f"Scene id: {id} "
+                    f"is not present in available image scenes: {self.scenes}"
+                )
+
+            # Update current scene
+            self._current_scene = id
+
+            # Reset the data stored in the Reader object
+            self._xarray_dask_data = None
+            self._xarray_data = None
+            self._dims = None
+            self._metadata = None
 
     @abstractmethod
     def _read_delayed(self) -> xr.DataArray:
@@ -474,7 +493,7 @@ class Reader(ABC):
         We currently do not handle unit attachment to these values. Please see the file
         metadata for unit information.
         """
-        pass
+        return PhysicalPixelSizes(1.0, 1.0, 1.0)
 
     def __str__(self):
         return (

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -138,13 +138,13 @@ class Reader(ABC):
         """
         pass
 
-    def set_scene(self, id: int):
+    def set_scene(self, scene_id: int):
         """
         Set the operating scene.
 
         Parameters
         ----------
-        id: int
+        scene_id: int
             The scene id to set as the operating scene.
 
         Raises
@@ -152,17 +152,17 @@ class Reader(ABC):
         IndexError: the provided scene id is not found in the available scene id list
         """
         # Only need to run when the scene id is different from current scene
-        if id != self.current_scene:
+        if scene_id != self.current_scene:
 
             # Validate scene id
-            if id not in self.scenes:
+            if scene_id not in self.scenes:
                 raise IndexError(
-                    f"Scene id: {id} "
+                    f"Scene id: {scene_id} "
                     f"is not present in available image scenes: {self.scenes}"
                 )
 
             # Update current scene
-            self._current_scene = id
+            self._current_scene = scene_id
 
             # Reset the data stored in the Reader object
             self._xarray_dask_data = None

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import Dict, Tuple
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+from dask import delayed
+from fsspec.spec import AbstractFileSystem
+from tifffile import TiffFile, TiffFileError
+
+from .. import exceptions, types
+from ..dimensions import DEFAULT_DIMENSION_ORDER, DimensionNames
+from ..utils import io_utils
+from .reader import Reader
+
+###############################################################################
+
+
+class TiffReader(Reader):
+    @staticmethod
+    def _is_supported_image(fs: AbstractFileSystem, path: str) -> bool:
+        try:
+            with fs.open(path) as open_resource:
+                with TiffFile(open_resource):
+                    return True
+
+        except (TiffFileError, TypeError):
+            return False
+
+    def __init__(self, image: types.PathLike):
+        """
+        Wraps the tifffile API to provide the same aicsimageio Reader API but for
+        volumetric Tiff (and other tifffile supported) images.
+
+        Parameters
+        ----------
+        image: types.PathLike
+            Path to image file to construct Reader for.
+        """
+        # Expand details of provided image
+        self.fs, self.path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self.extension = self.path.split(".")[-1]
+
+        # Enforce valid image
+        if not self._is_supported_image(self.fs, self.path):
+            raise exceptions.UnsupportedFileFormatError(self.extension)
+
+    @property
+    def scenes(self) -> Tuple[int]:
+        if self._scenes is None:
+            with self.fs.open(self.path) as open_resource:
+                with TiffFile(open_resource) as tiff:
+                    # This is non-metadata tiff, just use available series indicies
+                    self._scenes = tuple(range(tiff.scenes))
+
+        return self._scenes
+
+    @property
+    def current_scene(self) -> int:
+        if self._current_scene is None:
+            self._current_scene = self.scenes[0]
+
+        return self._current_scene
+
+    @staticmethod
+    def _get_image_data(
+        fs: AbstractFileSystem, path: str, scene: int, index: int
+    ) -> np.ndarray:
+        """
+        Open a file for reading, seek to plane index and read as numpy.
+
+        Parameters
+        ----------
+        fs: AbstractFileSystem
+            The file system to use for reading.
+        path: str
+            The path to file to read.
+        scene: int
+            The scene index to pull the plane from.
+        index: int
+            The image plane index to seek to and read from the file.
+
+        Returns
+        -------
+        plane: np.ndarray
+            The image plane as a numpy array.
+        """
+        with fs.open(path) as open_resource:
+            with TiffFile(open_resource) as tiff:
+                return tiff.series[scene].pages[index].asarray()
+
+    @staticmethod
+    def _get_metadata(
+        fs: AbstractFileSystem,
+        path: str,
+        scene: int,
+    ) -> Dict:
+        with fs.open(path) as open_resource:
+            with TiffFile(open_resource) as tiff:
+                return tiff.scenes[scene].pages[0].tags
+
+    @staticmethod
+    def _merge_dim_guesses(dims_from_meta: str, guessed_dims: str):
+        # Construct a "best guess" (super naive)
+        best_guess = []
+        for dim_from_meta in dims_from_meta:
+            # Dim from meta is recognized, add it
+            if dim_from_meta in DEFAULT_DIMENSION_ORDER:
+                best_guess.append(dim_from_meta)
+
+            # Dim from meta isn't recognized
+            # Find next dim that isn't already in best guess
+            else:
+                appended_dim = False
+                for guessed_dim in guessed_dims:
+                    if guessed_dim not in best_guess:
+                        best_guess.append(guessed_dim)
+                        appended_dim = True
+                        break
+
+                # All of our guess dims were already in the best guess list,
+                # append the dim read from meta
+                if not appended_dim:
+                    best_guess.append(dim_from_meta)
+
+        return "".join(best_guess)
+
+    def _guess_dim_order(self):
+        with self.fs.open(self.path) as open_resource:
+            with TiffFile(open_resource) as tiff:
+                scene = tiff.series[self.current_scene]
+                dims_from_meta = scene.pages.axes
+
+                # We can sometimes trust the dimension info in the image
+                if all([d in DEFAULT_DIMENSION_ORDER for d in dims_from_meta]):
+                    return dims_from_meta
+
+                # Sometimes the dimension info is wrong in certain dimensions,
+                # so guess that dimension
+                else:
+                    # Get basic guess from shape size
+                    guessed_dims = Reader._guess_dim_order(scene.shape)
+                    return self._merge_dim_guesses(dims_from_meta, guessed_dims)
+
+    @staticmethod
+    def _get_coords(dims: str, shape: Tuple[int]):
+        # Use dims for coord determination
+        coords = {}
+
+        # Use range for channel indices
+        if DimensionNames.Channel in dims:
+            coords[DimensionNames.Channel] = list(
+                range(shape[dims.index(DimensionNames.Channel)])
+            )
+
+        return coords
+
+    def _read_delayed(self) -> xr.DataArray:
+        """
+        Construct the delayed xarray DataArray object for the image.
+
+        Returns
+        -------
+        image: xr.DataArray
+            The fully constructed and fully delayed image as a DataArray  object.
+            Metadata is attached in some cases as coords, dims, and attrs.
+
+        Raises
+        ------
+        exceptions.UnsupportedFileFormatError: The file could not be read or is not
+            supported.
+        """
+        with self.fs.open(self.path) as open_resource:
+            with TiffFile(open_resource) as tiff:
+                # Get a sample YX plane
+                sample = self._get_image_data(
+                    fs=self.fs,
+                    path=self.path,
+                    scene=self.current_scene,
+                    index=0,
+                )
+
+                # Get shape of current scene
+                # Replace YX dims with empty dimensions
+                operating_shape = tiff.scenes[self.current_scene].shape
+                operating_shape = operating_shape[:-2] + (1, 1)
+
+                # Make ndarray for lazy arrays to fill
+                lazy_arrays = np.ndarray(operating_shape, dtype=object)
+                for plane_index, (np_index, _) in enumerate(
+                    np.ndenumerate(lazy_arrays)
+                ):
+                    # Fill the numpy array with the delayed arrays
+                    lazy_arrays[np_index] = da.from_delayed(
+                        delayed(TiffReader._imread)(
+                            fs=self.fs,
+                            path=self.path,
+                            scene=self.current_scene,
+                            index=plane_index,
+                        ),
+                        shape=sample.shape,
+                        dtype=sample.dtype,
+                    )
+
+                # Convert the numpy array of lazy readers into a dask array
+                image_data = da.block(lazy_arrays.tolist())
+
+                # Get metadata from tags
+                metadata = self._get_metadata(
+                    fs=self.fs,
+                    path=self.path,
+                    scene=self.current_scene,
+                )
+
+                # Create dims and coords
+                dims = self._guess_dim_order()
+                coords = self._get_coords(dims, image_data.shape)
+
+                return xr.DataArray(
+                    image_data,
+                    dims=dims,
+                    coords=coords,
+                    attrs=metadata,
+                )
+
+    def _read_immediate(self) -> xr.DataArray:
+        """
+        Construct the in-memory xarray DataArray object for the image.
+
+        Returns
+        -------
+        image: xr.DataArray
+            The fully constructed and fully read into memory image as a DataArray
+            object. Metadata is attached in some cases as coords, dims, and attrs.
+
+        Raises
+        ------
+        exceptions.UnsupportedFileFormatError: The file could not be read or is not
+            supported.
+        """
+        with self.fs.open(self.path) as open_resource:
+            with TiffFile(open_resource) as tiff:
+                image_data = tiff.scenes[self.current_scene].asarray()
+
+                # Get metadata from tags
+                metadata = self._get_metadata(
+                    fs=self.fs,
+                    path=self.path,
+                    scene=self.current_scene,
+                )
+
+                # Create dims and coords
+                dims = self._guess_dim_order()
+                coords = self._get_coords(dims, image_data.shape)
+
+                return xr.DataArray(
+                    image_data,
+                    dims=dims,
+                    coords=coords,
+                    attrs=metadata,
+                )
+
+    @property
+    def metadata(self):
+        if self._metadata is None:
+            self._metadata = self.xarray_dask_data.attrs
+
+        return self._metadata

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -111,11 +111,14 @@ class TiffReader(Reader):
                 best_guess.append(dim_from_meta)
 
             # Dim from meta isn't recognized
-            # Find next dim that isn't already in best guess
+            # Find next dim that isn't already in best guess or dims from meta
             else:
                 appended_dim = False
                 for guessed_dim in guessed_dims:
-                    if guessed_dim not in best_guess:
+                    if (
+                        guessed_dim not in best_guess
+                        and guessed_dim not in dims_from_meta
+                    ):
                         best_guess.append(guessed_dim)
                         appended_dim = True
                         break

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 from distributed.protocol import deserialize, serialize
@@ -43,7 +43,7 @@ def run_image_read_checks(
     ReaderClass: Reader,
     uri: types.PathLike,
     set_scene: int,
-    expected_scenes: Set[int],
+    expected_scenes: Tuple[int],
     expected_current_scene: int,
     expected_shape: Tuple[int],
     expected_dtype: np.dtype,

--- a/aicsimageio/tests/readers/reader_test_utils.py
+++ b/aicsimageio/tests/readers/reader_test_utils.py
@@ -51,6 +51,9 @@ def run_image_read_checks(
     expected_channel_names: Optional[List[str]],
     expected_physical_pixel_sizes: Tuple[float],
 ) -> Reader:
+    """
+    A general suite of tests to run against every Reader.
+    """
     # Read file
     reader = ReaderClass(uri)
 
@@ -82,6 +85,62 @@ def run_image_read_checks(
     # Check that the shape and dtype are expected after reading in full
     assert reader.data.shape == expected_shape
     assert reader.data.dtype == expected_dtype
+
+    check_local_file_not_open(reader.fs, reader.path)
+    check_can_serialize_reader(reader)
+
+    return reader
+
+
+def run_multi_scene_image_read_checks(
+    ReaderClass: Reader,
+    uri: types.PathLike,
+    first_scene_id: int,
+    first_scene_shape: Tuple[int],
+    first_scene_dtype: np.dtype,
+    second_scene_id: int,
+    second_scene_shape: Tuple[int],
+    second_scene_dtype: np.dtype,
+) -> Reader:
+    """
+    A suite of tests to ensure that data is reset when switching scenes.
+    """
+    # Read file
+    reader = ReaderClass(uri)
+
+    check_local_file_not_open(reader.fs, reader.path)
+    check_can_serialize_reader(reader)
+
+    # Set scene
+    reader.set_scene(first_scene_id)
+
+    # Check basics
+    assert reader.shape == first_scene_shape
+    assert reader.dtype == first_scene_dtype
+
+    # Check that the shape and dtype are expected after reading in full
+    assert reader.data.shape == first_scene_shape
+    assert reader.data.dtype == first_scene_dtype
+
+    check_local_file_not_open(reader.fs, reader.path)
+    check_can_serialize_reader(reader)
+
+    # Change scene
+    reader.set_scene(second_scene_id)
+
+    # Check data was reset
+    assert reader._xarray_dask_data is None
+    assert reader._xarray_data is None
+    assert reader._dims is None
+    assert reader._metadata is None
+
+    # Check basics
+    assert reader.shape == second_scene_shape
+    assert reader.dtype == second_scene_dtype
+
+    # Check that the shape and dtype are expected after reading in full
+    assert reader.data.shape == first_scene_shape
+    assert reader.data.dtype == first_scene_dtype
 
     check_local_file_not_open(reader.fs, reader.path)
     check_can_serialize_reader(reader)

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -17,25 +17,36 @@ from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read
     "set_scene, "
     "expected_scenes, "
     "expected_shape, "
+    "expected_dtype, "
     "expected_dims_order, "
     "expected_channel_names",
     [
-        ("s_1_t_1_c_1_z_1.ome.tiff", 0, (0,), (325, 475), "YX", None),
-        ("s_1_t_1_c_1_z_1.tiff", 0, (0,), (325, 475), "YX", None),
+        ("s_1_t_1_c_1_z_1.ome.tiff", 0, (0,), (325, 475), np.uint16, "YX", None),
+        ("s_1_t_1_c_1_z_1.tiff", 0, (0,), (325, 475), np.uint16, "YX", None),
         (
             "s_1_t_1_c_10_z_1.ome.tiff",
             0,
             (0,),
             (10, 1736, 1776),
+            np.uint16,
             "CYX",
             ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
         ),
-        ("s_1_t_10_c_3_z_1.tiff", 0, (0,), (10, 3, 325, 475), "TCYX", ["0", "1", "2"]),
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            0,
+            (0,),
+            (10, 3, 325, 475),
+            np.uint16,
+            "TCYX",
+            ["0", "1", "2"],
+        ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
             0,
             (0, 1, 2),
             (5, 3, 325, 475),
+            np.uint16,
             "ZCYX",
             ["0", "1", "2"],
         ),
@@ -44,6 +55,7 @@ from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read
             1,
             (0, 1, 2),
             (5, 3, 325, 475),
+            np.uint16,
             "ZCYX",
             ["0", "1", "2"],
         ),
@@ -52,11 +64,31 @@ from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read
             2,
             (0, 1, 2),
             (5, 3, 325, 475),
+            np.uint16,
             "ZCYX",
             ["0", "1", "2"],
         ),
+        (
+            "s_1_t_1_c_1_z_1_RGB.tiff",
+            0,
+            (0,),
+            (7548, 7548, 3),
+            np.uint16,
+            "YXS",  # S stands for samples dimension
+            None,
+        ),
+        (
+            "s_1_t_1_c_2_z_1_RGB.tiff",
+            0,
+            (0,),
+            (2, 32, 32, 3),
+            np.uint8,
+            "CYXS",  # S stands for samples dimension
+            ["0", "1"],
+        ),
         pytest.param(
             "example.txt",
+            None,
             None,
             None,
             None,
@@ -71,6 +103,7 @@ from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read
             None,
             None,
             None,
+            None,
             marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
@@ -80,11 +113,13 @@ from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read
             None,
             None,
             None,
+            None,
             marks=pytest.mark.raises(exception=IndexError),
         ),
         pytest.param(
             "s_3_t_1_c_3_z_5.ome.tiff",
             3,
+            None,
             None,
             None,
             None,
@@ -99,6 +134,7 @@ def test_tiff_reader(
     set_scene,
     expected_scenes,
     expected_shape,
+    expected_dtype,
     expected_dims_order,
     expected_channel_names,
 ):
@@ -113,7 +149,7 @@ def test_tiff_reader(
         expected_scenes=expected_scenes,
         expected_current_scene=set_scene,
         expected_shape=expected_shape,
-        expected_dtype=np.uint16,
+        expected_dtype=expected_dtype,
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=(1.0, 1.0, 1.0),

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -8,8 +8,7 @@ from aicsimageio import exceptions
 from aicsimageio.readers import TiffReader
 
 from ..conftest import LOCAL, REMOTE, get_resource_full_path
-from .reader_test_utils import (run_image_read_checks,
-                                run_multi_scene_image_read_checks)
+from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read_checks
 
 
 @pytest.mark.parametrize("host", [LOCAL, REMOTE])
@@ -56,11 +55,6 @@ from .reader_test_utils import (run_image_read_checks,
             "ZCYX",
             ["0", "1", "2"],
         ),
-        (
-            "s_1_t_1_c_3_z_1_RGB_1.tiff",
-            (0),
-            (0,),
-        )
         pytest.param(
             "example.txt",
             None,

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -118,3 +118,17 @@ def test_tiff_reader(
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
     )
+
+
+@pytest.mark.parametrize(
+    "dims_from_meta, guessed_dims, expected",
+    [
+        ("QZYX", "CZYX", "CZYX"),
+        ("ZQYX", "CZYX", "ZCYX"),
+        ("ZYXC", "CZYX", "ZYXC"),
+        ("TQQYX", "TCZYX", "TCZYX"),
+        ("QTQYX", "TCZYX", "CTZYX"),
+    ],
+)
+def test_merge_dim_guesses(dims_from_meta, guessed_dims, expected):
+    assert TiffReader._merge_dim_guesses(dims_from_meta, guessed_dims) == expected

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -8,7 +8,7 @@ from aicsimageio import exceptions
 from aicsimageio.readers import TiffReader
 
 from ..conftest import LOCAL, REMOTE, get_resource_full_path
-from .reader_test_utils import run_image_read_checks
+from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read_checks
 
 
 @pytest.mark.parametrize("host", [LOCAL, REMOTE])
@@ -117,6 +117,54 @@ def test_tiff_reader(
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+    )
+
+
+@pytest.mark.parametrize("host", [LOCAL, REMOTE])
+@pytest.mark.parametrize(
+    "filename, "
+    "first_scene_id, "
+    "first_scene_shape, "
+    "second_scene_id, "
+    "second_scene_shape",
+    [
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            0,
+            (5, 3, 325, 475),
+            1,
+            (5, 3, 325, 475),
+        ),
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            1,
+            (5, 3, 325, 475),
+            2,
+            (5, 3, 325, 475),
+        ),
+    ],
+)
+def test_multi_scene_tiff_reader(
+    filename,
+    host,
+    first_scene_id,
+    first_scene_shape,
+    second_scene_id,
+    second_scene_shape,
+):
+    # Construct full filepath
+    uri = get_resource_full_path(filename, host)
+
+    # Run checks
+    run_multi_scene_image_read_checks(
+        ReaderClass=TiffReader,
+        uri=uri,
+        first_scene_id=first_scene_id,
+        first_scene_shape=first_scene_shape,
+        first_scene_dtype=np.uint16,
+        second_scene_id=second_scene_id,
+        second_scene_shape=second_scene_shape,
+        second_scene_dtype=np.uint16,
     )
 
 

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -8,7 +8,8 @@ from aicsimageio import exceptions
 from aicsimageio.readers import TiffReader
 
 from ..conftest import LOCAL, REMOTE, get_resource_full_path
-from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read_checks
+from .reader_test_utils import (run_image_read_checks,
+                                run_multi_scene_image_read_checks)
 
 
 @pytest.mark.parametrize("host", [LOCAL, REMOTE])
@@ -55,6 +56,11 @@ from .reader_test_utils import run_image_read_checks, run_multi_scene_image_read
             "ZCYX",
             ["0", "1", "2"],
         ),
+        (
+            "s_1_t_1_c_3_z_1_RGB_1.tiff",
+            (0),
+            (0,),
+        )
         pytest.param(
             "example.txt",
             None,
@@ -176,6 +182,8 @@ def test_multi_scene_tiff_reader(
         ("ZYXC", "CZYX", "ZYXC"),
         ("TQQYX", "TCZYX", "TCZYX"),
         ("QTQYX", "TCZYX", "CTZYX"),
+        # testing that nothing happens when Q isn't present
+        ("LTCYX", "DIMOK", "LTCYX"),
     ],
 )
 def test_merge_dim_guesses(dims_from_meta, guessed_dims, expected):

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+from aicsimageio import exceptions
+from aicsimageio.readers import TiffReader
+
+from ..conftest import LOCAL, REMOTE, get_resource_full_path
+from .reader_test_utils import run_image_read_checks
+
+
+@pytest.mark.parametrize("host", [LOCAL, REMOTE])
+@pytest.mark.parametrize(
+    "filename, "
+    "set_scene, "
+    "expected_scenes, "
+    "expected_shape, "
+    "expected_dims_order, "
+    "expected_channel_names",
+    [
+        ("s_1_t_1_c_1_z_1.ome.tiff", 0, (0,), (325, 475), "YX", None),
+        ("s_1_t_1_c_1_z_1.tiff", 0, (0,), (325, 475), "YX", None),
+        (
+            "s_1_t_1_c_10_z_1.ome.tiff",
+            0,
+            (0,),
+            (10, 1736, 1776),
+            "CYX",
+            ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+        ),
+        ("s_1_t_10_c_3_z_1.tiff", 0, (0,), (10, 3, 325, 475), "TCYX", ["0", "1", "2"]),
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            0,
+            (0, 1, 2),
+            (5, 3, 325, 475),
+            "ZCYX",
+            ["0", "1", "2"],
+        ),
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            1,
+            (0, 1, 2),
+            (5, 3, 325, 475),
+            "ZCYX",
+            ["0", "1", "2"],
+        ),
+        (
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            2,
+            (0, 1, 2),
+            (5, 3, 325, 475),
+            "ZCYX",
+            ["0", "1", "2"],
+        ),
+        pytest.param(
+            "example.txt",
+            None,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+        pytest.param(
+            "s_1_t_1_c_2_z_1.lif",
+            None,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+        pytest.param(
+            "s_1_t_1_c_1_z_1.ome.tiff",
+            1,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            "s_3_t_1_c_3_z_5.ome.tiff",
+            3,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+    ],
+)
+def test_tiff_reader(
+    filename,
+    host,
+    set_scene,
+    expected_scenes,
+    expected_shape,
+    expected_dims_order,
+    expected_channel_names,
+):
+    # Construct full filepath
+    uri = get_resource_full_path(filename, host)
+
+    # Run checks
+    run_image_read_checks(
+        ReaderClass=TiffReader,
+        uri=uri,
+        set_scene=set_scene,
+        expected_scenes=expected_scenes,
+        expected_current_scene=set_scene,
+        expected_shape=expected_shape,
+        expected_dtype=np.uint16,
+        expected_dims_order=expected_dims_order,
+        expected_channel_names=expected_channel_names,
+        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+    )

--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -40,7 +40,7 @@ class Args(argparse.Namespace):
         p.add_argument(
             "--top-hash",
             # Generated package hash from upload_test_resources
-            default="88b4196592e9e5287404064edd0ee229f1a14240d46858de137b4f6f720734bf",
+            default="2632d3ab3768eda1f61f7766667e5de87b015bd7c65d7266c96b0b6bc927755f",
             help="A specific version of the package to retrieve.",
         )
         p.add_argument(


### PR DESCRIPTION
**This PR points to `feature/update-to-4.0-api`.** I will basically be rewriting all the current modules to match the 4.0 API and placing them into that branch, then, finally once that is all done, be merging `feature/update-to-4.0-api` and `release-4.0`.

## Description
This adds the `TiffReader` class. Notably:
* Adopts the new scene management API
* Because of Scene management API we can now read pyramidal TIFFs (not tested, @toloudis @heeler please request a test pyramid file)
* Because of Scene management API we are no longer overloading the `S` dimension (`tifffile` `S` dim refers to "Samples" as in "RGB" tiff) and we now support multi-channel RGB tiffs
* Minor changes to base `Reader` and `DefaultReader` to generalize it a bit more as we add more inheritting `Reader` classes

Reading remote TIFFs now works:
```python
from aicsimageio.readers import TiffReader

r = TiffReader("s3://aics-modeling-packages-test-resources/aicsimageio/test_resources/resources/s_3_t_1_c_3_z_5.ome.tiff")
r.data
```

As per existing comment in [Performance Considerations](https://github.com/AllenCellModeling/aicsimageio/tree/feature/update-to-4.0-api#performance-considerations):
> **If your image does not support native chunk reading:** it may not be best to read chunks from a remote source. While possible, the format of the image matters a lot for chunked read performance.

I would not recommend reading chunks of the TIFF remotely unless required, and if you do need to read chunks of the TIFF, I would highly recommend reading from a worker close to the data, i.e. an EC2 or GCP Cloud Compute instance. This is where benchmarks would be really useful. I am curious to see how fast CZI is for chunked reads though considering `aicspylibczi>=2.7.2`.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

WIP #144
WIP #140
WIP #106

Expands support for #152 

Did not do: #132

- [x] Provide relevant tests for your feature or bug fix.

Test comparisons for:
* [release-4.0](https://github.com/AllenCellModeling/aicsimageio/compare/release-4.0...feature/tiff-reader#diff-d1f96752c7d52709b55460e0c275e377e37e135f25cc33a11aefb1ed494debdd)
* [master](https://github.com/AllenCellModeling/aicsimageio/compare/master...feature/tiff-reader#diff-d1f96752c7d52709b55460e0c275e377e37e135f25cc33a11aefb1ed494debdd)

- [x] Provide or update documentation for any feature added by your pull request.


## Other Comments

I have mentioned in the past that it may be nice to add a scene caching layer so that when someone switches scenes and then back they don't have to reread the data if their cache has enough memory for the operation. Because we haven't discussed this fully I did not implement anything like that but I do see value in it still.

This also does not yet resolve the `xarray.attrs` debate. I think after writing `TiffReader` though I am on board for `xarray.attrs` to return a dictionary of `{"raw": raw_meta_from_file, "processed": our_return_from_reader_dot_metadata}`.

Lastly, I have decided to remove the super old "Alex magic" parts of `TiffReader` as `tifffile` / Gohlke do that for us:
Comparison on `BufferReader`: [old Alex magic](https://github.com/AllenCellModeling/aicsimageio/blob/master/aicsimageio/readers/tiff_reader.py#L56) -- [just plain tifffile](https://github.com/cgohlke/tifffile/blob/master/tifffile/tifffile.py#L2759)
Comparison on `TIFF Description`: [old Alex magic](https://github.com/AllenCellModeling/aicsimageio/blob/master/aicsimageio/readers/tiff_reader.py#L272) -- [just plain tifffile](https://github.com/cgohlke/tifffile/blob/master/tifffile/tifffile.py#L5081)

Thanks for contributing!
