### PR TITLE
bugfix/adopt-samples-as-rgb-default

### DIFF
--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -12,6 +12,7 @@ class DimensionNames:
     SpatialZ = "Z"
     SpatialY = "Y"
     SpatialX = "X"
+    Samples = "S"
 
 
 DEFAULT_DIMENSION_ORDER_LIST = [

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -115,12 +115,12 @@ class DefaultReader(Reader):
         elif len(shape) == 3:
             return (
                 f"{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
-                f"{DimensionNames.Channel}"
+                f"{DimensionNames.Samples}"
             )
         elif len(shape) == 4:
             return (
                 f"{DimensionNames.Time}{DimensionNames.SpatialY}"
-                f"{DimensionNames.SpatialX}{DimensionNames.Channel}"
+                f"{DimensionNames.SpatialX}{DimensionNames.Samples}"
             )
 
         return Reader._guess_dim_order(shape)
@@ -255,13 +255,6 @@ class DefaultReader(Reader):
 
         # Use dims for coord determination
         coords = {}
-
-        # Handle typical RGB and RGBA from channels
-        if DimensionNames.Channel in dims:
-            if image_data.shape[dims.index(DimensionNames.Channel)] == 3:
-                coords[DimensionNames.Channel] = ["R", "G", "B"]
-            elif image_data.shape[dims.index(DimensionNames.Channel)] == 4:
-                coords[DimensionNames.Channel] = ["R", "G", "B", "A"]
 
         # Handle time when duration is present in metadata
         if DimensionNames.Time in dims:

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -256,6 +256,13 @@ class DefaultReader(Reader):
         # Use dims for coord determination
         coords = {}
 
+        # Handle typical RGB and RGBA from Samples
+        if DimensionNames.Samples in dims:
+            if image_data.shape[dims.index(DimensionNames.Samples)] == 3:
+                coords[DimensionNames.Samples] = ["R", "G", "B"]
+            elif image_data.shape[dims.index(DimensionNames.Samples)] == 4:
+                coords[DimensionNames.Samples] = ["R", "G", "B", "A"]
+
         # Handle time when duration is present in metadata
         if DimensionNames.Time in dims:
             if "duration" in metadata:

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -13,29 +13,26 @@ from .reader_test_utils import run_image_read_checks
 
 @pytest.mark.parametrize("host", [LOCAL, REMOTE])
 @pytest.mark.parametrize(
-    "filename, set_scene, expected_shape, expected_dims_order, expected_channel_names",
+    "filename, set_scene, expected_shape, expected_dims_order",
     [
-        ("example.bmp", 0, (480, 640, 4), "YXC", ["R", "G", "B", "A"]),
-        ("example.png", 0, (800, 537, 4), "YXC", ["R", "G", "B", "A"]),
-        ("example.jpg", 0, (452, 400, 3), "YXC", ["R", "G", "B"]),
-        ("example.gif", 0, (72, 268, 268, 4), "TYXC", ["R", "G", "B", "A"]),
+        ("example.bmp", 0, (480, 640, 4), "YXS"),
+        ("example.png", 0, (800, 537, 4), "YXS"),
+        ("example.jpg", 0, (452, 400, 3), "YXS"),
+        ("example.gif", 0, (72, 268, 268, 4), "TYXS"),
         (
             "example_invalid_frame_count.mp4",
             0,
             (55, 1080, 1920, 3),
-            "TYXC",
-            ["R", "G", "B"],
+            "TYXS",
         ),
         (
             "example_valid_frame_count.mp4",
             0,
             (72, 272, 272, 3),
-            "TYXC",
-            ["R", "G", "B"],
+            "TYXS",
         ),
         pytest.param(
             "example.txt",
-            None,
             None,
             None,
             None,
@@ -44,7 +41,6 @@ from .reader_test_utils import run_image_read_checks
         pytest.param(
             "example.png",
             1,
-            None,
             None,
             None,
             marks=pytest.mark.raises(exception=IndexError),
@@ -57,7 +53,6 @@ def test_default_reader(
     set_scene,
     expected_shape,
     expected_dims_order,
-    expected_channel_names,
 ):
     # Construct full filepath
     uri = get_resource_full_path(filename, host)
@@ -72,7 +67,7 @@ def test_default_reader(
         expected_shape=expected_shape,
         expected_dtype=np.uint8,
         expected_dims_order=expected_dims_order,
-        expected_channel_names=expected_channel_names,
+        expected_channel_names=None,
         expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
     )
 


### PR DESCRIPTION
## Description

See [Dev Meeting Notes](https://github.com/AllenCellModeling/aicsimageio/issues/164#issuecomment-728405786).

We had a discussion about "how to make RGB data more standard" across the various image formats and decided to use the standard laid out by `tifffile` / OME which is to have a "SamplesPerPixel" but expand that out to it's dimension `S`.

This was already done in the `TiffReader` PR (#160) and to further expand that standardization we are making that same change to `DefaultReader`.

While this is another breaking change from 3.* to 4.*, it is further in the direction of array access standardization.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
