### PR TITLE
bugfix/replace-napari-is-pyramid-with-multiscale

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -531,7 +531,7 @@ class AICSImage:
                 with napari.gui_qt():
                     napari.view_image(
                         data,
-                        is_pyramid=False,
+                        multiscale=False,
                         ndisplay=3 if Dimensions.SpatialZ in dims else 2,
                         title=title,
                         axis_labels=dims.replace(Dimensions.Channel, ""),
@@ -568,7 +568,7 @@ class AICSImage:
                 with napari.gui_qt():
                     napari.view_image(
                         data,
-                        is_pyramid=False,
+                        multiscale=False,
                         ndisplay=3 if Dimensions.SpatialZ in dims else 2,
                         channel_axis=c_axis,
                         axis_labels=dims,

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -409,7 +409,7 @@ def test_view_napari(
 
             # Check extra call kwargs
             call_kwargs = mocked_napari.call_args[1]
-            assert not call_kwargs["is_pyramid"]
+            assert not call_kwargs["multiscale"]
             assert call_kwargs["ndisplay"] == expected_ndim
             assert call_kwargs["axis_labels"] == expected_axis_labels
             if not rgb:


### PR DESCRIPTION
## Description
I exchanged is_pyramid with multiscale.

Resolves #171 

I am sorry, but this is the first time for me doing this, so I am not sure on what kind of test files would be needed to attach. However, tests on py38 and lint succeeded with a coverage of 82%.