### PR TITLE
ome-xml as string to ome tiff writer

### DIFF
--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -168,7 +168,7 @@ class OmeTiffWriter:
             )
             xml = self.omeMetadata.to_xml().encode()
         elif isinstance(ome_xml, str):
-            # if the xml passed in is a string, 
+            # if the xml passed in is a string,
             # then just pass it straight through to the writer.
             self.omeMetadata = omexml.OMEXML(ome_xml)
             xml = ome_xml.encode()

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -167,8 +167,9 @@ class OmeTiffWriter:
                 dimension_order=dimension_order,
             )
             xml = self.omeMetadata.to_xml().encode()
-        elif type(ome_xml) == str:
-            # if the xml passed in is a string, then just pass it straight through to the writer.
+        elif isinstance(ome_xml, str):
+            # if the xml passed in is a string, 
+            # then just pass it straight through to the writer.
             self.omeMetadata = omexml.OMEXML(ome_xml)
             xml = ome_xml.encode()
         else:

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -166,11 +166,16 @@ class OmeTiffWriter:
                 channel_colors=channel_colors,
                 dimension_order=dimension_order,
             )
+            xml = self.omeMetadata.to_xml().encode()
+        elif type(ome_xml) == str:
+            # if the xml passed in is a string, then just pass it straight through to the writer.
+            self.omeMetadata = omexml.OMEXML(ome_xml)
+            xml = ome_xml.encode()
         else:
             pixels = ome_xml.image().Pixels
             pixels.populate_TiffData()
             self.omeMetadata = ome_xml
-        xml = self.omeMetadata.to_xml().encode()
+            xml = self.omeMetadata.to_xml().encode()
 
         tif = tifffile.TiffWriter(
             self.file_path, bigtiff=self._size_of_ndarray(data=data) > BYTE_BOUNDARY


### PR DESCRIPTION
This is a "quick" stopgap solution to allow preformed ome-xml strings to be written out without the omexml.py module interfering.  Burden is on the caller to provide valid ome-xml.

It is anticipated that the upcoming 4.x releases will completely blow this code away.

My use case is: using ome-types library to construct valid ome-xml outside of aicsimageio but then using the OmeTiffWriter to save the resulting file.