### PR TITLE
bugfix/pin-readlif

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "numpy>=1.16",
     "imagecodecs>=2020.5.30",
     "imageio>=2.3.0",
-    "readlif>=0.2.1",
+    "readlif==0.3.1",
     "lxml>=4.4.2",
     "tifffile>=2020.9.22",
     "toolz>=0.10.0",


### PR DESCRIPTION
## Description

`readlif` released a new `0.4.0` to support mosaic image reading but this release included breaking changes. So pinning `readlif` to the most recent, non-mosaic image reading version. This should be upgraded in the `4.0.0` release branch when I add support for the upgraded `LifReader`.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
