### PR TITLE
feature/set-known-coords

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -61,7 +61,7 @@ class AICSImage:
 
     Initialize an image and pass arguments to the reader using kwargs.
 
-    >>> img = AICSImage("my_file.czi", chunk_by_dims=["T", "Y", "X"])
+    >>> img = AICSImage("my_file.czi", chunk_dims=["T", "Y", "X"])
 
     Initialize an image, change scene, read data to numpy.
 

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -29,7 +29,7 @@ class AICSImage:
     ----------
     image: types.ImageLike
         A string, Path, fsspec supported URI, or arraylike to read.
-    known_reader: Optional[types.ReaderType]
+    reader: Optional[types.ReaderType]
         The Reader class to specifically use for reading the provided image.
         Default: None (find matching reader)
     kwargs: Any
@@ -71,7 +71,7 @@ class AICSImage:
 
     Initialize an image with a specific reader.
 
-    >>> img = AICSImage("malformed_metadata.ome.tiff", known_reader=readers.TiffReader)
+    >>> img = AICSImage("malformed_metadata.ome.tiff", reader=readers.TiffReader)
 
     Notes
     -----
@@ -157,15 +157,15 @@ class AICSImage:
     def __init__(
         self,
         image: types.ImageLike,
-        known_reader: Optional[ReaderType] = None,
+        reader: Optional[ReaderType] = None,
         **kwargs: Any,
     ):
-        if known_reader is None:
+        if reader is None:
             # Determine reader class and create dask delayed array
             ReaderClass = self.determine_reader(image, **kwargs)
         else:
-            # Init known reader
-            ReaderClass = known_reader
+            # Init reader
+            ReaderClass = reader
 
         # Init and store reader
         self._reader = ReaderClass(image, **kwargs)

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -147,9 +147,20 @@ class AICSImage:
             ),
         )
 
-    def __init__(self, image: types.ImageLike, **kwargs: Any):
-        # Determine reader class and create dask delayed array
-        ReaderClass = self.determine_reader(image, **kwargs)
+    def __init__(
+        self,
+        image: types.ImageLike,
+        known_reader: Optional[ReaderType] = None,
+        **kwargs: Any,
+    ):
+        if known_reader is None:
+            # Determine reader class and create dask delayed array
+            ReaderClass = self.determine_reader(image, **kwargs)
+        else:
+            # Init known reader
+            ReaderClass = known_reader
+
+        # Init and store reader
         self._reader = ReaderClass(image, **kwargs)
 
         # Lazy load data from reader and reformat to standard dimensions

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -69,7 +69,9 @@ class AICSImage:
     ... img.set_scene("Image:3")
     ... img.data
 
-    Initialize an image with a specific reader.
+    Initialize an image with a specific reader. This is useful if you know the file
+    type in advance or would like to skip a few of the file format checks we do
+    internally. Useful when reading from remote sources to reduce network round trips.
 
     >>> img = AICSImage("malformed_metadata.ome.tiff", reader=readers.TiffReader)
 

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -29,6 +29,9 @@ class AICSImage:
     ----------
     image: types.ImageLike
         A string, Path, fsspec supported URI, or arraylike to read.
+    known_reader: Optional[types.ReaderType]
+        The Reader class to specifically use for reading the provided image.
+        Default: None (find matching reader)
     kwargs: Any
         Extra keyword arguments that will be passed down to the reader subclass.
 
@@ -65,6 +68,10 @@ class AICSImage:
     >>> img = AICSImage("my_many_scene.czi")
     ... img.set_scene("Image:3")
     ... img.data
+
+    Initialize an image with a specific reader.
+
+    >>> img = AICSImage("malformed_metadata.ome.tiff", known_reader=readers.TiffReader)
 
     Notes
     -----

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -46,14 +46,14 @@ DEFAULT_DIMENSION_ORDER_WITH_MOSAIC_TILES_AND_SAMPLES = "".join(
     DEFAULT_DIMENSION_ORDER_LIST_WITH_MOSAIC_TILES_AND_SAMPLES
 )
 
-DEFAULT_CHUNK_BY_DIMS = [
+DEFAULT_CHUNK_DIMS = [
     DimensionNames.SpatialZ,
     DimensionNames.SpatialY,
     DimensionNames.SpatialX,
     DimensionNames.Samples,
 ]
 
-REQUIRED_CHUNK_BY_DIMS = [
+REQUIRED_CHUNK_DIMS = [
     DimensionNames.SpatialY,
     DimensionNames.SpatialX,
     DimensionNames.Samples,

--- a/aicsimageio/formats.py
+++ b/aicsimageio/formats.py
@@ -21,12 +21,12 @@ from typing import Dict
 
 FORMAT_IMPLEMENTATIONS: Dict[str, str] = {
     "array-like": "aicsimageio.readers.array_like_reader.ArrayLikeReader",
-    "czi": "aicsimageio.readers.czi_reader.CziReader",
-    "lif": "aicsimageio.readers.lif_reader.LifReader",
     "ome.tiff": "aicsimageio.readers.ome_tiff_reader.OmeTiffReader",
     "ome.tif": "aicsimageio.readers.ome_tiff_reader.OmeTiffReader",
     "tiff": "aicsimageio.readers.tiff_reader.TiffReader",
     "tif": "aicsimageio.readers.tiff_reader.TiffReader",
+    "czi": "aicsimageio.readers.czi_reader.CziReader",
+    "lif": "aicsimageio.readers.lif_reader.LifReader",
     # BASE-IMAGEIO FORMATS (with tifffile + non-existant removals)
     #
     # Pulled using:

--- a/aicsimageio/readers/array_like_reader.py
+++ b/aicsimageio/readers/array_like_reader.py
@@ -37,19 +37,19 @@ class ArrayLikeReader(Reader):
         A single, numpy ndarray, dask Array, or xarray DataArray, or list of many.
         If provided a list, each item in the list will be exposed through the scene API.
         If provided an xarray DataArray alone or as an element of the list, the
-        known_dims and known_channel_names kwargs are ignored if there non-xarray
+        dim_order and channel_names kwargs are ignored if there non-xarray
         default dimension (or channel coordinate) information attached the xarray
         object. The channel and dimension information are updated independent of the
         other. If either is using xarray default values, they will be replaced by
         AICSImageIO defaults will be added.
 
-    known_dims: Optional[Union[List[str], str]]
-        A string of known dimensions to be applied to all array(s) or a
+    dim_order: Optional[Union[List[str], str]]
+        A string of dimensions to be applied to all array(s) or a
         list of string dimension names to be mapped onto the list of arrays
         provided to image. I.E. "TYX".
         Default: None (guess dimensions for single array or multiple arrays)
 
-    known_channel_names: Optional[Union[List[str], List[List[str]]]]
+    channel_names: Optional[Union[List[str], List[List[str]]]]
         A list of string channel names to be applied to all array(s) or a
         list of lists of string channel names to be mapped onto the list of arrays
         provided to image.
@@ -62,11 +62,11 @@ class ArrayLikeReader(Reader):
         provided to the metadata parameters if as a list.
 
     exceptions.ConflictingArgumentsError
-        Raised when known_channel_names is provided but the channel dimension was
-        either not guessed or not provided in known_dims.
+        Raised when channel_names is provided but the channel dimension was
+        either not guessed or not provided in dim_order.
 
     ValueError
-        Provided known_dims string or known_channel_names are not the same length as
+        Provided dim_order string or channel_names are not the same length as
         the number of dimensions or the size of the channel dimensions for the array at
         the matching index.
 
@@ -84,8 +84,8 @@ class ArrayLikeReader(Reader):
     ... some_dask = ...
     ... reader = ArrayLikeReader(
     ...     image=[some_metadata_attached_xr, some_np, some_dask],
-    ...     known_dims=[None, "CTYX", "ZTYX"],
-    ...     known_channel_names=[None, ["A", "B", C"], None],
+    ...     dim_order=[None, "CTYX", "ZTYX"],
+    ...     channel_names=[None, ["A", "B", C"], None],
     ... )
 
     Will create a three scene ArrayLikeReader with the metadata and coordinate
@@ -109,8 +109,8 @@ class ArrayLikeReader(Reader):
     def __init__(
         self,
         image: Union[List[MetaArrayLike], MetaArrayLike],
-        known_dims: Optional[Union[List[str], str]] = None,
-        known_channel_names: Optional[Union[List[str], List[List[str]]]] = None,
+        dim_order: Optional[Union[List[str], str]] = None,
+        channel_names: Optional[Union[List[str], List[List[str]]]] = None,
         **kwargs: Any,
     ):
         # Enforce valid image
@@ -120,7 +120,7 @@ class ArrayLikeReader(Reader):
             )
 
         # General note
-        # Any time we do a `known_channel_names[0]` it's because the type check for
+        # Any time we do a `channel_names[0]` it's because the type check for
         # channel names is a List[List[str]], so by checking the first element we should
         # be getting back a list or a string. Anything else will error.
 
@@ -132,58 +132,59 @@ class ArrayLikeReader(Reader):
         # If metadata is attached as lists
         # Enforcing matching shape
         if isinstance(image, list):
-            if isinstance(known_dims, list):
-                # Check known dims
-                if len(known_dims) != len(image):
+            if isinstance(dim_order, list):
+                # Check dim order
+                if len(dim_order) != len(image):
                     raise exceptions.ConflictingArgumentsError(
                         f"ArrayLikeReader received a list of arrays to use as scenes "
-                        f"but the provided list of known dimensions is of different "
-                        f"length. "
+                        f"but the provided list of dimension orderingsensions is of "
+                        f"different length. "
                         f"Number of provided scenes: {len(image)}, "
-                        f"Number of provided known dimension strings: {len(known_dims)}"
+                        f"Number of provided dimension orderingsension strings: "
+                        f"{len(dim_order)}"
                     )
 
-            # Check known channel names
-            if known_channel_names is not None:
-                if isinstance(known_channel_names[0], list):
-                    if len(known_channel_names) != len(image):
+            # Check channel names
+            if channel_names is not None:
+                if isinstance(channel_names[0], list):
+                    if len(channel_names) != len(image):
                         raise exceptions.ConflictingArgumentsError(
                             f"ArrayLikeReader received a list of arrays to use as "
-                            f"scenes but the provided list of known channel names is "
+                            f"scenes but the provided list of channel names is "
                             f"of different length. "
                             f"Number of provided scenes: {len(image)}, "
-                            f"Number of provided known channel names: "
-                            f"{len(known_channel_names)}"
+                            f"Number of provided channel names: "
+                            f"{len(channel_names)}"
                         )
 
         # If metadata is attached as singles
         # but many scenes provided, expand
         if isinstance(image, list):
-            if known_dims is None or isinstance(known_dims, str):
-                known_dims = [known_dims for i in range(len(image))]  # type: ignore
-            if known_channel_names is None or isinstance(known_channel_names[0], str):
-                known_channel_names = [  # type: ignore
-                    known_channel_names for i in range(len(image))
+            if dim_order is None or isinstance(dim_order, str):
+                dim_order = [dim_order for i in range(len(image))]  # type: ignore
+            if channel_names is None or isinstance(channel_names[0], str):
+                channel_names = [  # type: ignore
+                    channel_names for i in range(len(image))
                 ]
 
         # Set all kwargs to lists for standard interface
         if not isinstance(image, list):
             image = [image]
-        if not isinstance(known_dims, list):
-            known_dims = [known_dims]  # type: ignore
-        if known_channel_names is None:
-            known_channel_names = [known_channel_names]  # type: ignore
+        if not isinstance(dim_order, list):
+            dim_order = [dim_order]  # type: ignore
+        if channel_names is None:
+            channel_names = [channel_names]  # type: ignore
         # Also wrap the channel names list if they were provided
         # but only a single scene was
-        elif len(image) == 1 and not isinstance(known_channel_names[0], list):
-            known_channel_names = [known_channel_names]  # type: ignore
+        elif len(image) == 1 and not isinstance(channel_names[0], list):
+            channel_names = [channel_names]  # type: ignore
 
         # Store image(s)
         self._all_scenes = image
 
         # Validate and store dims
         self._scene_dims_list = []
-        for i, dims_string in enumerate(known_dims):
+        for i, dims_string in enumerate(dim_order):
             this_scene = self._all_scenes[i]
             # Provided None, guess
             if dims_string is None:
@@ -244,7 +245,7 @@ class ArrayLikeReader(Reader):
 
         # Validate and store channel_names
         self._scene_channel_names = []
-        for s_index, channel_names in enumerate(known_channel_names):  # type: ignore
+        for s_index, channel_names in enumerate(channel_names):  # type: ignore
             this_scene = self._all_scenes[s_index]
             this_scene_dims = self._scene_dims_list[s_index]
 

--- a/aicsimageio/readers/array_like_reader.py
+++ b/aicsimageio/readers/array_like_reader.py
@@ -137,10 +137,10 @@ class ArrayLikeReader(Reader):
                 if len(dim_order) != len(image):
                     raise exceptions.ConflictingArgumentsError(
                         f"ArrayLikeReader received a list of arrays to use as scenes "
-                        f"but the provided list of dimension orderingsensions is of "
+                        f"but the provided list of dimension order strings is of "
                         f"different length. "
                         f"Number of provided scenes: {len(image)}, "
-                        f"Number of provided dimension orderingsension strings: "
+                        f"Number of provided dimension order strings: "
                         f"{len(dim_order)}"
                     )
 

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -43,6 +43,17 @@ class DefaultReader(Reader):
     ----------
     image: types.PathLike
         Path to image file to construct Reader for.
+
+    known_dims: Optional[Union[List[str], str]]
+            Optional list (or string) of dimension short names for the image to use
+            instead of guess.
+            Must provide the same number of dimensions as read.
+            Default: None (guess)
+
+    known_channel_names: Optional[List[str]]
+        Optional list of channel names.
+        Must provide the same number of channels as the read channel dimension.
+        Default: None (generate standard names)
 
     Notes
     -----
@@ -112,12 +123,26 @@ class DefaultReader(Reader):
         except OSError:
             raise IOError(REMOTE_READ_FAIL_MESSAGE.format(path=path))
 
-    def __init__(self, image: types.PathLike, **kwargs: Any):
+    def __init__(
+        self,
+        image: types.PathLike,
+        known_dims: Optional[Union[List[str], str]] = None,
+        known_channel_names: Optional[List[str]] = None,
+        **kwargs: Any,
+    ):
         # Expand details of provided image
         self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
         self.extension, self.imageio_read_mode = self._get_extension_and_mode(
             self._path
         )
+
+        # Cast to list to standardize usage
+        if isinstance(known_dims, str):
+            known_dims = list(known_dims)
+
+        # Store extras
+        self.known_dims = known_dims
+        self.known_channel_names = known_channel_names
 
         # Enforce valid image
         if not self._is_supported_image(self._fs, self._path):
@@ -160,7 +185,7 @@ class DefaultReader(Reader):
 
     @staticmethod
     def _get_image_data(
-        fs: AbstractFileSystem, path: str, format: str, mode: str, index: int
+        fs: AbstractFileSystem, path: str, extension: str, mode: str, index: int
     ) -> np.ndarray:
         """
         Open a file for reading, seek to plane index and read as numpy.
@@ -171,8 +196,8 @@ class DefaultReader(Reader):
             The file system to use for reading.
         path: str
             The path to file to read.
-        format: str
-            The format to use to read the file.
+        extension: str
+            The file extension naively indicating format to use to read the file.
             For our use case this is primarily the file extension.
         mode: str
             The read mode to use for opening and reading.
@@ -187,14 +212,16 @@ class DefaultReader(Reader):
             The image plane as a numpy array.
         """
         with fs.open(path) as open_resource:
-            with imageio.get_reader(open_resource, format=format, mode=mode) as reader:
+            with imageio.get_reader(
+                open_resource, format=extension, mode=mode
+            ) as reader:
                 return np.asarray(reader.get_data(index))
 
     @staticmethod
     def _get_image_length(
         fs: AbstractFileSystem,
         path: str,
-        format: str,
+        extension: str,
         mode: str,
     ) -> int:
         """
@@ -207,7 +234,7 @@ class DefaultReader(Reader):
             The file system to use for reading.
         path: str
             The path to file to read.
-        format: str
+        extension: str
             The format to use to read the file.
             For our use case this is primarily the file extension.
         mode: str
@@ -230,9 +257,11 @@ class DefaultReader(Reader):
         See here for more details: https://github.com/imageio/imageio/issues/168
         """
         with fs.open(path) as open_resource:
-            with imageio.get_reader(open_resource, format=format, mode=mode) as reader:
+            with imageio.get_reader(
+                open_resource, format=extension, mode=mode
+            ) as reader:
                 # Handle FFMPEG formats
-                if format in DefaultReader.FFMPEG_FORMATS:
+                if extension in DefaultReader.FFMPEG_FORMATS:
                     # A reminder, this is the _total_ frame count, not the last index
                     reported_frames = reader.count_frames()
 
@@ -252,7 +281,11 @@ class DefaultReader(Reader):
 
     @staticmethod
     def _unpack_dims_and_coords(
-        image_data: types.ArrayLike, metadata: Dict
+        image_data: types.ArrayLike,
+        metadata: Dict,
+        scene_id: str,
+        known_dims: Optional[List[str]],
+        known_channel_names: Optional[List[str]],
     ) -> Tuple[List[str], Dict[str, Union[List[str], types.ArrayLike]]]:
         """
         Unpack image data into assumed dims and coords.
@@ -261,8 +294,24 @@ class DefaultReader(Reader):
         ----------
         image_data: types.ArrayLike
             The image data to unpack dims and coords for.
+
         metadata: Dict
             The EXIF, XMP, etc metadata dictionary.
+
+        scene_id: str
+            The scene id for this image.
+            For this reader this is always the same but we need this to create
+            channel names.
+
+        known_dims: Optional[List[str]]
+            Optional list of known dimensions to use instead of guess.
+            Unlike other readers, this reader doesn't have any idea as to many-scene
+            so we can just have a single List[str] instead of a List[List[str]].
+
+        known_channel_names: Optional[List[str]]
+            Optional list of known channel names to use instead of None.
+            Unlike other readers, this reader doesn't pull metadata so it would
+            normally generate OME channel names.
 
         Returns
         -------
@@ -271,11 +320,61 @@ class DefaultReader(Reader):
         coords: Dict[str, Union[List[str], types.ArrayLike]]
             If possible, the coordinates for dimensions in the image data.
         """
-        # Guess dims
-        dims = [c for c in DefaultReader._guess_dim_order(image_data.shape)]
+        # Guess dims or use provided dims
+        if known_dims is not None:
+            if len(known_dims) != len(image_data.shape):
+                raise ValueError(
+                    f"Provided dimension string does not have the same amount of "
+                    f"dimensions as the read image. "
+                    f"Read image shape: {image_data.shape}, "
+                    f"Provided dimension string: {known_dims}"
+                )
+
+            dims = known_dims
+
+        else:
+            dims = [c for c in DefaultReader._guess_dim_order(image_data.shape)]
 
         # Use dims for coord determination
         coords: Dict[str, Union[List[str], np.ndarray]] = {}
+
+        # Create or use channel names
+        if known_channel_names:
+            # Provided channel names but no channel dim
+            if DimensionNames.Channel not in dims:
+                raise ValueError(
+                    f"Received channel names for array without channel dimension. "
+                    f"Read image shape: {image_data.shape}, "
+                    f"Provided (or guessed) dimensions: {dims}, "
+                    f"Provided channel names: {known_channel_names}"
+                )
+
+            # Provided different length channel names and
+            if (
+                len(known_channel_names)
+                != image_data.shape[dims.index(DimensionNames.Channel)]
+            ):
+                raise ValueError(
+                    f"Provided channel names list does not match the size of "
+                    f"channel dimension for the provided array. "
+                    f"Read image shape: {image_data.shape}, "
+                    f"Channel dimension size: "
+                    f"{image_data.shape[dims.index[DimensionNames.Channel]]}, "
+                    f"Provided channel names: {known_channel_names}"
+                )
+
+            # Passed all checks, use the channel names
+            coords[DimensionNames.Channel] = known_channel_names
+
+        # Otherwise simply generate OME default
+        else:
+            if DimensionNames.Channel in dims:
+                coords[DimensionNames.Channel] = [
+                    metadata_utils.generate_ome_channel_id(
+                        image_id=scene_id, channel_id=i
+                    )
+                    for i in range(image_data.shape[dims.index(DimensionNames.Channel)])
+                ]
 
         # Handle typical RGB and RGBA from Samples
         if DimensionNames.Samples in dims:
@@ -318,7 +417,7 @@ class DefaultReader(Reader):
                 image_length = self._get_image_length(
                     fs=self._fs,
                     path=self._path,
-                    format=self.extension,
+                    extension=self.extension,
                     mode=self.imageio_read_mode,
                 )
 
@@ -328,7 +427,7 @@ class DefaultReader(Reader):
                         self._get_image_data(
                             fs=self._fs,
                             path=self._path,
-                            format=self.extension,
+                            extension=self.extension,
                             mode=self.imageio_read_mode,
                             index=0,
                         )
@@ -340,7 +439,7 @@ class DefaultReader(Reader):
                     sample = self._get_image_data(
                         fs=self._fs,
                         path=self._path,
-                        format=self.extension,
+                        extension=self.extension,
                         mode=self.imageio_read_mode,
                         index=0,
                     )
@@ -357,7 +456,7 @@ class DefaultReader(Reader):
                             delayed(self._get_image_data)(
                                 fs=self._fs,
                                 path=self._path,
-                                format=self.extension,
+                                extension=self.extension,
                                 mode=self.imageio_read_mode,
                                 index=indices[0],
                             ),
@@ -379,7 +478,13 @@ class DefaultReader(Reader):
                 metadata = reader.get_meta_data()
 
                 # Create extra metadata from assumptions based off image data
-                dims, coords = self._unpack_dims_and_coords(image_data, metadata)
+                dims, coords = self._unpack_dims_and_coords(
+                    image_data=image_data,
+                    metadata=metadata,
+                    scene_id=self.current_scene,
+                    known_dims=self.known_dims,
+                    known_channel_names=self.known_channel_names,
+                )
 
                 return xr.DataArray(
                     image_data,
@@ -413,7 +518,7 @@ class DefaultReader(Reader):
             image_length = self._get_image_length(
                 fs=self._fs,
                 path=self._path,
-                format=self.extension,
+                extension=self.extension,
                 mode=self.imageio_read_mode,
             )
 
@@ -434,7 +539,13 @@ class DefaultReader(Reader):
             metadata = reader.get_meta_data()
 
             # Create extra metadata from assumptions based off image data
-            dims, coords = self._unpack_dims_and_coords(image_data, metadata)
+            dims, coords = self._unpack_dims_and_coords(
+                image_data=image_data,
+                metadata=metadata,
+                scene_id=self.current_scene,
+                known_dims=self.known_dims,
+                known_channel_names=self.known_channel_names,
+            )
 
             return xr.DataArray(
                 image_data,

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -44,10 +44,10 @@ class DefaultReader(Reader):
     image: types.PathLike
         Path to image file to construct Reader for.
     dim_order: Optional[str]
-            Optional string of dimension short names for the image to use
-            instead of guess.
-            Must provide the same number of dimensions as read.
-            Default: None (guess)
+        Optional string of dimension short names for the image to use
+        instead of guess.
+        Must provide the same number of dimensions as read.
+        Default: None (guess)
     channel_names: Optional[List[str]]
         Optional list of channel names.
         Must provide the same number of channels as the read channel dimension.

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -13,10 +13,10 @@ from fsspec.spec import AbstractFileSystem
 
 from .. import constants, exceptions, transforms, types
 from ..dimensions import (
-    DEFAULT_CHUNK_BY_DIMS,
+    DEFAULT_CHUNK_DIMS,
     DEFAULT_DIMENSION_ORDER_LIST,
     DEFAULT_DIMENSION_ORDER_LIST_WITH_MOSAIC_TILES,
-    REQUIRED_CHUNK_BY_DIMS,
+    REQUIRED_CHUNK_DIMS,
     DimensionNames,
 )
 from ..utils import io_utils
@@ -43,9 +43,9 @@ class LifReader(Reader):
     ----------
     image: types.PathLike
         Path to image file to construct Reader for.
-    chunk_by_dims: Union[str, List[str]]
+    chunk_dims: Union[str, List[str]]
         Which dimensions to create chunks for.
-        Default: DEFAULT_CHUNK_BY_DIMS
+        Default: DEFAULT_CHUNK_DIMS
         Note: Dimensions.SpatialY, Dimensions.SpatialX, and DimensionNames.Samples,
         will always be added to the list if not present during dask array
         construction.
@@ -68,16 +68,16 @@ class LifReader(Reader):
     def __init__(
         self,
         image: types.PathLike,
-        chunk_by_dims: Union[str, List[str]] = DEFAULT_CHUNK_BY_DIMS,
+        chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
     ):
         # Expand details of provided image
         self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
 
         # Store params
-        if isinstance(chunk_by_dims, str):
-            chunk_by_dims = list(chunk_by_dims)
+        if isinstance(chunk_dims, str):
+            chunk_dims = list(chunk_dims)
 
-        self.chunk_by_dims = chunk_by_dims
+        self.chunk_dims = chunk_dims
 
         # Delayed storage
         self._px_sizes: Optional[types.PhysicalPixelSizes] = None
@@ -250,12 +250,12 @@ class LifReader(Reader):
             The fully constructed and fully delayed image as a Dask Array object.
         """
         # Always add the plane dimensions if not present already
-        for dim in REQUIRED_CHUNK_BY_DIMS:
-            if dim not in self.chunk_by_dims:
-                self.chunk_by_dims.append(dim)
+        for dim in REQUIRED_CHUNK_DIMS:
+            if dim not in self.chunk_dims:
+                self.chunk_dims.append(dim)
 
         # Safety measure / "feature"
-        self.chunk_by_dims = [d.upper() for d in self.chunk_by_dims]
+        self.chunk_dims = [d.upper() for d in self.chunk_dims]
 
         # Construct the delayed dask array
         selected_scene = lif.get_image(self.current_scene_index)
@@ -285,7 +285,7 @@ class LifReader(Reader):
         chunk_dim_order = []
         chunk_shape = []
         for dim, size in zip(selected_scene_dims, selected_scene_shape):
-            if dim in self.chunk_by_dims:
+            if dim in self.chunk_dims:
                 chunk_dim_order.append(dim)
                 chunk_shape.append(size)
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -14,7 +14,7 @@ from tifffile.tifffile import TiffFile, TiffFileError, TiffTag, TiffTags
 from xmlschema import XMLSchemaValidationError
 
 from .. import constants, exceptions, transforms, types
-from ..dimensions import DEFAULT_CHUNK_BY_DIMS, DEFAULT_DIMENSION_ORDER, DimensionNames
+from ..dimensions import DEFAULT_CHUNK_DIMS, DEFAULT_DIMENSION_ORDER, DimensionNames
 from ..metadata import utils as metadata_utils
 from ..types import PhysicalPixelSizes
 from ..utils import io_utils
@@ -40,9 +40,9 @@ class OmeTiffReader(TiffReader):
     ----------
     image: types.PathLike
         Path to image file to construct Reader for.
-    chunk_by_dims: List[str]
+    chunk_dims: List[str]
         Which dimensions to create chunks for.
-        Default: DEFAULT_CHUNK_BY_DIMS
+        Default: DEFAULT_CHUNK_DIMS
         Note: Dimensions.SpatialY, Dimensions.SpatialX, and DimensionNames.Samples,
         will always be added to the list if not present during dask array
         construction.
@@ -108,7 +108,7 @@ class OmeTiffReader(TiffReader):
     def __init__(
         self,
         image: types.PathLike,
-        chunk_by_dims: Union[str, List[str]] = DEFAULT_CHUNK_BY_DIMS,
+        chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
         clean_metadata: bool = True,
         **kwargs: Any,
     ):
@@ -116,10 +116,10 @@ class OmeTiffReader(TiffReader):
         self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
 
         # Store params
-        if isinstance(chunk_by_dims, str):
-            chunk_by_dims = list(chunk_by_dims)
+        if isinstance(chunk_dims, str):
+            chunk_dims = list(chunk_dims)
 
-        self.chunk_by_dims = chunk_by_dims
+        self.chunk_dims = chunk_dims
         self.clean_metadata = clean_metadata
 
         # Enforce valid image

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -239,7 +239,7 @@ class TiffReader(Reader):
         if isinstance(self.known_channel_names[0], list):
             scene_channels = self.known_channel_names[self.current_scene_index]
         elif all(isinstance(c, str) for c in self.known_channel_names):
-            scene_channels = self.known_channel_names
+            scene_channels = self.known_channel_names  # type: ignore
         else:
             return None
 
@@ -262,7 +262,7 @@ class TiffReader(Reader):
                 f"{self.known_channel_names}",
             )
 
-        return scene_channels
+        return scene_channels  # type: ignore
 
     @staticmethod
     def _get_coords(

--- a/aicsimageio/tests/readers/test_array_like_reader.py
+++ b/aicsimageio/tests/readers/test_array_like_reader.py
@@ -16,8 +16,8 @@ from ..image_container_test_utils import run_image_container_checks
 
 @pytest.mark.parametrize(
     "image, "
-    "known_dims, "
-    "known_channel_names, "
+    "dim_order, "
+    "channel_names, "
     "set_scene, "
     "expected_scenes, "
     "expected_shape, "
@@ -142,7 +142,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CZYX",
             ["Channel:0:0"],
         ),
-        # Check no channel names provided 3D but known dims forces channel dim
+        # Check no channel names provided 3D but dim_order forces channel dim
         # these check that channel names are created for all
         # and specifically for xr that channel names are overwritten
         (
@@ -185,7 +185,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CYX",
             ["Channel:0:0"],
         ),
-        # Test many scene, same known_dims, first scene
+        # Test many scene, same dim_order, first scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             "CYX",
@@ -232,7 +232,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CYX",
             ["Channel:0:0"],
         ),
-        # Test many scene, same known_dims, second scene
+        # Test many scene, same dim_order, second scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             "CYX",
@@ -279,7 +279,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CYX",
             ["Channel:1:0", "Channel:1:1"],
         ),
-        # Test many scene, same known_channels, first scene
+        # Test many scene, same channel_names, first scene
         (
             [np.random.rand(2, 1, 1, 1), np.random.rand(2, 2, 2, 2)],
             None,
@@ -326,7 +326,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CZYX",
             ["A", "B"],
         ),
-        # Test many scene, same known_channels, second scene
+        # Test many scene, same channel_names, second scene
         (
             [np.random.rand(2, 1, 1, 1), np.random.rand(2, 2, 2, 2)],
             None,
@@ -373,7 +373,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CZYX",
             ["A", "B"],
         ),
-        # Test many scene, different known_dims, first scene
+        # Test many scene, different dim_order, first scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             [None, "CYX"],
@@ -420,7 +420,7 @@ from ..image_container_test_utils import run_image_container_checks
             "ZYX",
             None,
         ),
-        # Test many scene, different known_dims, second scene
+        # Test many scene, different dim_order, second scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             [None, "CYX"],
@@ -467,7 +467,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CYX",
             ["Channel:1:0", "Channel:1:1"],
         ),
-        # Test many scene, different known_dims, different channel_names, first scene
+        # Test many scene, different dim_order, different channel_names, first scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             [None, "CYX"],
@@ -514,7 +514,7 @@ from ..image_container_test_utils import run_image_container_checks
             "ZYX",
             None,
         ),
-        # Test many scene, different known_dims, different channel_names, second scene
+        # Test many scene, different dim_order, different channel_names, second scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             [None, "CYX"],
@@ -656,7 +656,7 @@ from ..image_container_test_utils import run_image_container_checks
             "ABD",
             None,
         ),
-        # Test that we can support many dimensions if known dims is provided
+        # Test that we can support many dimensions if dim_order is provided
         (
             np.random.rand(1, 2, 3, 4, 5, 6, 7, 8),
             "ABCDEFGH",
@@ -715,7 +715,7 @@ from ..image_container_test_utils import run_image_container_checks
             "CZYX",
             ["A"],
         ),
-        # Test mismatching mapping of arrays to known dims
+        # Test mismatching mapping of arrays to dim_order
         pytest.param(
             [np.random.rand(1, 1)],
             ["YX", "BAD"],
@@ -738,7 +738,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
         ),
-        # Test mismatching mapping of arrays to known channel names
+        # Test mismatching mapping of arrays to channel_names
         pytest.param(
             [np.random.rand(1, 1, 1, 1)],
             None,
@@ -797,7 +797,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             marks=pytest.mark.raises(exceptions=ValueError),
         ),
-        # Test that without known dims and with more than five dims, it raises an error
+        # Test that without dim_order and with more than five dims, it raises an error
         # Our guess dim order only support up to five dims
         pytest.param(
             np.random.rand(1, 2, 3, 4, 5, 6),
@@ -827,8 +827,8 @@ from ..image_container_test_utils import run_image_container_checks
 )
 def test_arraylike_reader(
     image: Union[types.MetaArrayLike, List[types.MetaArrayLike]],
-    known_dims: Optional[Union[str, List[str]]],
-    known_channel_names: Optional[Union[List[str], List[List[str]]]],
+    dim_order: Optional[Union[str, List[str]]],
+    channel_names: Optional[Union[List[str], List[List[str]]]],
     set_scene: str,
     expected_scenes: Tuple[str, ...],
     expected_shape: Tuple[int, ...],
@@ -837,7 +837,7 @@ def test_arraylike_reader(
 ) -> None:
     # Init
     image_container = ArrayLikeReader(
-        image, known_dims=known_dims, known_channel_names=known_channel_names
+        image, dim_order=dim_order, channel_names=channel_names
     )
 
     run_image_container_checks(

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -114,18 +114,18 @@ def test_lif_reader(
 
 
 @pytest.mark.parametrize("filename", ["s_1_t_1_c_2_z_1.lif", "s_1_t_4_c_2_z_1.lif"])
-@pytest.mark.parametrize("chunk_by_dims", ["ZYX", "TYX", "CYX"])
+@pytest.mark.parametrize("chunk_dims", ["ZYX", "TYX", "CYX"])
 @pytest.mark.parametrize("get_dims", ["ZYX", "TYX"])
 def test_sanity_check_correct_indexing(
     filename: str,
-    chunk_by_dims: str,
+    chunk_dims: str,
     get_dims: str,
 ) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri, chunk_by_dims=chunk_by_dims)
+    reader = LifReader(uri, chunk_dims=chunk_dims)
     lif_img = LifFile(uri).get_image(0)
 
     # Pull a chunk from LifReader

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -630,6 +630,7 @@ def test_roundtrip_save_all_scenes(
     "expected_channel_names, "
     "expected_shape",
     [
+        # DefaultReader
         # First check to show nothing changes
         (
             "example.gif",
@@ -660,16 +661,6 @@ def test_roundtrip_save_all_scenes(
             ["Red", "Green", "Blue", "Alpha"],
             (1, 4, 72, 268, 268),
         ),
-        # Check setting both with list of dims
-        (
-            "example.gif",
-            "Image:0",
-            ["Z", "Y", "X", "C"],
-            ["Red", "Green", "Blue", "Alpha"],
-            "TCZYX",
-            ["Red", "Green", "Blue", "Alpha"],
-            (1, 4, 72, 268, 268),
-        ),
         # Check providing too many dims
         pytest.param(
             "example.gif",
@@ -679,7 +670,7 @@ def test_roundtrip_save_all_scenes(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=ValueError),
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
         ),
         # Check providing too many channels
         pytest.param(
@@ -690,7 +681,7 @@ def test_roundtrip_save_all_scenes(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=ValueError),
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
         ),
         # Check providing channels but no channel dim
         pytest.param(
@@ -701,7 +692,124 @@ def test_roundtrip_save_all_scenes(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=ValueError),
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+        ),
+        ######################################
+        # TiffReader
+        # First check to show nothing changes
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            None,
+            None,
+            "TCZYX",
+            ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
+            (10, 3, 1, 325, 475),
+        ),
+        # Check just dims to see default channel name creation
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            "ZCYX",
+            None,
+            "TCZYX",
+            ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
+            (1, 3, 10, 325, 475),
+        ),
+        # Check setting both as simple definitions
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            "ZCYX",
+            ["A", "B", "C"],
+            "TCZYX",
+            ["A", "B", "C"],
+            (1, 3, 10, 325, 475),
+        ),
+        # Check setting channels as a list of lists definitions
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            "ZCYX",
+            [["A", "B", "C"]],
+            "TCZYX",
+            ["A", "B", "C"],
+            (1, 3, 10, 325, 475),
+        ),
+        # Check setting dims as list of dims
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            ["ZCYX"],
+            ["A", "B", "C"],
+            "TCZYX",
+            ["A", "B", "C"],
+            (1, 3, 10, 325, 475),
+        ),
+        # Check setting dims as list of None (scene has unknown dims)
+        (
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            [None],
+            ["A", "B", "C"],
+            "TCZYX",
+            ["A", "B", "C"],
+            (10, 3, 1, 325, 475),
+        ),
+        # Check providing too many dims
+        pytest.param(
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            "ABCDEFG",
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+        ),
+        # Check providing too many channels
+        pytest.param(
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            None,
+            ["A", "B", "C", "D"],
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+        ),
+        # Check providing channels but no channel dim
+        pytest.param(
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            "TZYX",
+            ["A", "B", "C"],
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+        ),
+        # Check number of scenes dims list matches n scenes
+        pytest.param(
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            ["ABC", "DEF", "GHI"],
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+        ),
+        # Check number of scenes channels list matches n scenes
+        pytest.param(
+            "s_1_t_10_c_3_z_1.tiff",
+            "Image:0",
+            None,
+            [["A", "B", "C"], ["D", "E", "F"]],
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
         ),
     ],
 )

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -840,7 +840,7 @@ def test_set_coords(
 
 
 @pytest.mark.parametrize(
-    "filename, known_reader, extra_kwargs, expected_dims, expected_shape",
+    "filename, set_reader, extra_kwargs, expected_dims, expected_shape",
     [
         (
             "actk.ome.tiff",
@@ -876,9 +876,9 @@ def test_set_coords(
         ),
     ],
 )
-def test_set_known_reader(
+def test_set_reader(
     filename: str,
-    known_reader: types.ReaderType,
+    set_reader: types.ReaderType,
     extra_kwargs: Dict[str, Any],
     expected_dims: str,
     expected_shape: Tuple[int, ...],
@@ -887,7 +887,7 @@ def test_set_known_reader(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Init
-    img = AICSImage(uri, known_reader=known_reader, **extra_kwargs)
+    img = AICSImage(uri, reader=set_reader, **extra_kwargs)
 
     # Assert basics
     assert img.dims.order == expected_dims

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -298,8 +298,8 @@ def test_multi_scene_aicsimage(
 
 @pytest.mark.parametrize(
     "image, "
-    "known_dims, "
-    "known_channel_names, "
+    "dim_order, "
+    "channel_names, "
     "set_scene, "
     "expected_scenes, "
     "expected_shape, "
@@ -351,7 +351,7 @@ def test_multi_scene_aicsimage(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:0:0"],
         ),
-        # Test many scene, same known_dims, second scene
+        # Test many scene, same dim_order, second scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             "CYX",
@@ -375,7 +375,7 @@ def test_multi_scene_aicsimage(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:1:0", "Channel:1:1"],
         ),
-        # Test many scene, different known_dims, different channel_names, second scene
+        # Test many scene, different dim_order, different channel_names, second scene
         (
             [np.random.rand(1, 1, 1), np.random.rand(2, 2, 2)],
             [None, "CYX"],
@@ -474,7 +474,7 @@ def test_multi_scene_aicsimage(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:0:0"],
         ),
-        # Test that we can support many dimensions if known dims is provided
+        # Test that we can support many dimensions if dims is provided
         (
             np.random.rand(1, 2, 3, 4, 5, 6, 7, 8),
             "ABCDEFGH",
@@ -511,7 +511,7 @@ def test_multi_scene_aicsimage(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:1:0", "Channel:1:1", "Channel:1:2", "Channel:1:3"],
         ),
-        # Test that without known dims and with more than five dims, it raises an error
+        # Test that without dims and with more than five dims, it raises an error
         # Our guess dim order only support up to five dims
         pytest.param(
             np.random.rand(1, 2, 3, 4, 5, 6),
@@ -541,8 +541,8 @@ def test_multi_scene_aicsimage(
 )
 def test_aicsimage_from_array(
     image: Union[types.MetaArrayLike, List[types.MetaArrayLike]],
-    known_dims: Optional[str],
-    known_channel_names: Optional[List[str]],
+    dim_order: Optional[str],
+    channel_names: Optional[List[str]],
     set_scene: str,
     expected_scenes: Tuple[str, ...],
     expected_shape: Tuple[int, ...],
@@ -550,9 +550,7 @@ def test_aicsimage_from_array(
     expected_channel_names: List[str],
 ) -> None:
     # Init
-    image_container = AICSImage(
-        image, known_dims=known_dims, known_channel_names=known_channel_names
-    )
+    image_container = AICSImage(image, dim_order=dim_order, channel_names=channel_names)
 
     run_image_container_checks(
         image_container=image_container,
@@ -813,7 +811,7 @@ def test_roundtrip_save_all_scenes(
         ),
     ],
 )
-def test_set_known_coords(
+def test_set_coords(
     filename: str,
     set_scene: str,
     set_dims: Optional[Union[str, List[str]]],
@@ -830,7 +828,7 @@ def test_set_known_coords(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Init
-    img = AICSImage(uri, known_dims=set_dims, known_channel_names=set_channel_names)
+    img = AICSImage(uri, dim_order=set_dims, channel_names=set_channel_names)
 
     # Set scene
     img.set_scene(set_scene)
@@ -863,7 +861,7 @@ def test_set_known_coords(
         (
             "actk.ome.tiff",
             readers.TiffReader,
-            {"known_dims": "CTYX"},
+            {"dim_order": "CTYX"},
             dimensions.DEFAULT_DIMENSION_ORDER,
             (65, 6, 1, 233, 345),
         ),

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -884,7 +884,7 @@ def test_set_known_reader(
     extra_kwargs: Dict[str, Any],
     expected_dims: str,
     expected_shape: Tuple[int, ...],
-):
+) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, LOCAL)
 

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -108,7 +108,7 @@ class OmeTiffWriter(Writer):
         >>> image = numpy.ndarray([1, 10, 3, 1024, 2048])
         ... OmeTiffWriter.save(image, "file.ome.tif")
 
-        Write data with a known dimension order into OME-Tiff
+        Write data with a dimension order into OME-Tiff
 
         >>> image = numpy.ndarray([10, 3, 1024, 2048])
         ... OmeTiffWriter.save(image, "file.ome.tif", dim_order="ZCYX")
@@ -144,7 +144,7 @@ class OmeTiffWriter(Writer):
                         f"but the provided list of dimension_order is of different "
                         f"length. "
                         f"Number of provided scenes: {num_images}, "
-                        f"Number of provided known dimension strings: "
+                        f"Number of provided dimension strings: "
                         f"{len(dim_order)}"
                     )
             if isinstance(image_name, list):
@@ -154,7 +154,7 @@ class OmeTiffWriter(Writer):
                         f"but the provided list of image_names is of different "
                         f"length. "
                         f"Number of provided scenes: {num_images}, "
-                        f"Number of provided known dimension strings: {len(image_name)}"
+                        f"Number of provided dimension strings: {len(image_name)}"
                     )
             if isinstance(physical_pixel_sizes, list):
                 if len(physical_pixel_sizes) != num_images:
@@ -163,7 +163,7 @@ class OmeTiffWriter(Writer):
                         f"but the provided list of image_names is of different "
                         f"length. "
                         f"Number of provided scenes: {num_images}, "
-                        f"Number of provided known dimension strings: "
+                        f"Number of provided dimension strings: "
                         f"{len(physical_pixel_sizes)}"
                     )
 
@@ -175,7 +175,7 @@ class OmeTiffWriter(Writer):
                             f"but the provided list of channel_names is of different "
                             f"length. "
                             f"Number of provided scenes: {num_images}, "
-                            f"Number of provided known dimension strings: "
+                            f"Number of provided dimension strings: "
                             f"{len(channel_names)}"
                         )
             if channel_colors is not None:
@@ -186,7 +186,7 @@ class OmeTiffWriter(Writer):
                             f"but the provided list of channel_colors is of different "
                             f"length. "
                             f"Number of provided scenes: {num_images}, "
-                            f"Number of provided known dimension strings: "
+                            f"Number of provided dimension strings: "
                             f"{len(channel_colors)}"
                         )
 


### PR DESCRIPTION
## Description

Adds `known_dims` and `known_channel_names` which follow the same spec as `ArrayLikeReader` to `TiffReader` and `DefaultReader` (with the exception that `DefaultReader` doesn't allow multi-scene, so no `List[*]`. Additionally adds `known_reader` to `AICSImage` to get around two issues related to "from remote, extra io when determining reader" and anywhere where specifying the reader due to validation / checking / user desired specificity.

To further address the "from remote, extra io when determining reader" issue, I moved ome.tiff and tiff to the top of the format dict. The expectation being that the majority of the files this library encounters is TIFFs so make those the fastest to validate and read. (This is such a tiny optimization but :shrug: )

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #199

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
