### PR TITLE
bugfix/remove-unused-lif-code

### DIFF
--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -537,24 +537,10 @@ class LifReader(Reader):
         ny: int,
         nx: int,
     ) -> types.ArrayLike:
-        # Create empty array
-        arr_shape_list = []
-        for dim, size in zip(dims, data.shape):
-            if dim not in [
-                DimensionNames.MosaicTile,
-                DimensionNames.SpatialY,
-                DimensionNames.SpatialX,
-            ]:
-                arr_shape_list.append(size)
-            elif dim == DimensionNames.SpatialY:
-                arr_shape_list.append(size * ny)
-            elif dim == DimensionNames.SpatialX:
-                arr_shape_list.append(size * nx)
-
         # Fill all tiles
-        rows: List[np.ndarray] = []
+        rows: List[types.ArrayLike] = []
         for row_i in range(ny):
-            row: List[np.ndarray] = []
+            row: List[types.ArrayLike] = []
             for col_i in range(nx):
                 # Calc m_index
                 m_index = (row_i * nx) + col_i


### PR DESCRIPTION
## Description

As Jamie was working on `CziReader` he asked me some questions about how I did tile stitching in `LifReader`. In looking at his questions it looks like there were simply mistakes in typing + extra code that was ultimately unused in the stitch tiles function.

Nice finds @heeler

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
