### PR TITLE
feature/mosaic-tile-single-position-request-and-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,26 +226,21 @@ from aicsimageio import AICSImage
 img = AICSImage("my_file.ome.tiff")
 
 # Get the first ten seconds (not frames)
-first_ten_seconds = img.xarray_data[:10]  # returns an xarray.DataArray
+first_ten_seconds = img.xarray_data.loc[:10]  # returns an xarray.DataArray
 
 # Get the first ten major units (usually micrometers, not indices) in Z
-first_ten_mm_in_z = img.xarray_data[:, :, :10]
+first_ten_mm_in_z = img.xarray_data.loc[:, :, :10]
 
 # Get the first ten major units (usually micrometers, not indices) in Y
-first_ten_mm_in_y = img.xarray_data[:, :, :, :10]
+first_ten_mm_in_y = img.xarray_data.loc[:, :, :, :10]
 
 # Get the first ten major units (usually micrometers, not indices) in X
-first_ten_mm_in_x = img.xarray_data[:, :, :, :, :10]
+first_ten_mm_in_x = img.xarray_data.loc[:, :, :, :, :10]
 ```
 
-See
-[xarray.DataArray documentation](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html#xarray.DataArray)
-for more details.
-
-**Note:** As a reminder, the `.data` and `.dask_data` attributes, and the
-`.get_image_data` and `.get_image_dask_data` functions only allow indexing
-by plane index. If you want to retrieve data by spatial-temporal coordinates you
-must use `xarray`.
+See `xarray`
+["Indexing and Selecting Data" Documentation](http://xarray.pydata.org/en/stable/indexing.html)
+for more information.
 
 ### Cloud IO Support
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Readers that support mosaic tile stitching:
 #### AICSImage
 
 If the file format reader supports stitching mosaic tiles together, the
-`AICSImage` object will pull and use that data.
+`AICSImage` object will use the stitched image data.
 
 ```python
 img = AICSImage("very-large-mosaic.lif")

--- a/README.md
+++ b/README.md
@@ -146,12 +146,29 @@ Readers that support mosaic tile stitching:
 #### AICSImage
 
 If the file format reader supports stitching mosaic tiles together, the
-`AICSImage` object will use the stitched image data.
+`AICSImage` object will default to stitching the tiles back together.
 
 ```python
 img = AICSImage("very-large-mosaic.lif")
 img.dims.order  # T, C, Z, big Y, big X, (S optional)
 img.dask_data  # Dask chunks fall on tile boundaries, pull YX chunks out of the image
+```
+
+This behavior can be manually turned off:
+
+```python
+img = AICSImage("very-large-mosaic.lif", reconstruct_mosaic=False)
+img.dims.order  # M (tile index), T, C, Z, small Y, small X, (S optional)
+img.dask_data  # Chunks use normal ZYX
+```
+
+If the reader does not support stitching tiles together the M tile index will be
+available on the `AICSImage` object:
+
+```python
+img = AICSImage("some-unsupport-mosaic-stitching-format.ext")
+img.dims.order  # M (tile index), T, C, Z, small Y, small X, (S optional)
+img.dask_data  # Chunks use normal ZYX
 ```
 
 #### Reader
@@ -166,6 +183,20 @@ reader = LifReader("ver-large-mosaic.lif")
 reader.dims.order  # M, T, C, Z, tile size Y, tile size X, (S optional)
 reader.dask_data  # normal operations, can use M dimension to select individual tiles
 reader.mosaic_dask_data  # returns stitched mosaic - T, C, Z, big Y, big, X, (S optional)
+```
+
+#### Single Tile Absolute Positioning
+
+There are functions available on both the `AICSImage` and `Reader` objects
+to help with single tile positioning:
+
+```python
+img = AICSImage("very-large-mosaic.lif")
+img.mosaic_tile_dims  # Returns a Dimensions object with just Y and X dim sizes
+img.mosaic_tile_dims.Y  # 512 (for example)
+
+# Get the tile start indices (top left corner of tile)
+y_start_index, x_start_index = img.get_mosaic_tile_position(12)
 ```
 
 ### Metadata Reading

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If the reader does not support stitching tiles together the M tile index will be
 available on the `AICSImage` object:
 
 ```python
-img = AICSImage("some-unsupport-mosaic-stitching-format.ext")
+img = AICSImage("some-unsupported-mosaic-stitching-format.ext")
 img.dims.order  # M (tile index), T, C, Z, small Y, small X, (S optional)
 img.dask_data  # Chunks use normal ZYX
 ```
@@ -176,7 +176,7 @@ img.dask_data  # Chunks use normal ZYX
 If the file format reader detects mosaic tiles in the image, the `Reader` object
 will store the tiles as a dimension.
 
-If implemented, the `Reader` can also return the stitched image.
+If tile stitching is implemented, the `Reader` can also return the stitched image.
 
 ```python
 reader = LifReader("ver-large-mosaic.lif")

--- a/README.md
+++ b/README.md
@@ -135,6 +135,39 @@ function will not load any piece of the imaging data into memory until you speci
 call `.compute` on the returned Dask array. In doing so, you will only then load the
 selected chunk in-memory.
 
+### Mosaic Image Reading
+
+Read stitched data or single tiles as a dimension.
+
+Readers that support mosaic tile stitching:
+
+-   `LifReader`
+
+#### AICSImage
+
+If the file format reader supports stitching mosaic tiles together, the
+`AICSImage` object will pull and use that data.
+
+```python
+img = AICSImage("very-large-mosaic.lif")
+img.dims.order  # T, C, Z, big Y, big X, (S optional)
+img.dask_data  # Dask chunks fall on tile boundaries, pull YX chunks out of the image
+```
+
+#### Reader
+
+If the file format reader detects mosaic tiles in the image, the `Reader` object
+will store the tiles as a dimension.
+
+If implemented, the `Reader` can also return the stitched image.
+
+```python
+reader = LifReader("ver-large-mosaic.lif")
+reader.dims.order  # M, T, C, Z, tile size Y, tile size X, (S optional)
+reader.dask_data  # normal operations, can use M dimension to select individual tiles
+reader.mosaic_dask_data  # returns stitched mosaic - T, C, Z, big Y, big, X, (S optional)
+```
+
 ### Metadata Reading
 
 ```python

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -698,7 +698,7 @@ class AICSImage:
 
     def get_mosaic_tile_position(self, M: int) -> Optional[Tuple[int, int]]:
         """
-        Get the top left point for a single mosaic tile relative to the whole mosaic.
+        Get the absolute position of the top left point for a single mosaic tile.
         Returns None if the image is not a mosaic.
 
         Parameters

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -32,6 +32,18 @@ class AICSImage:
     reader: Optional[types.ReaderType]
         The Reader class to specifically use for reading the provided image.
         Default: None (find matching reader)
+    reconstruct_mosaic: bool
+        Boolean for setting that data for this object to the reconstructed / stitched
+        mosaic image.
+        Default: True (reconstruct the mosaic image from tiles)
+        Notes: If True and image is a mosaic, data will be fully reconstructed and
+        stitched array.
+        If True and base reader doesn't support tile stitching, data won't be stitched
+        and instead will have an `M` dimension for tiles.
+        If False and image is a mosaic, data won't be stitched and instead will have an
+        `M` dimension for tiles.
+        If image is not a mosaic, data won't be stitched or have an `M` dimension for
+        tiles.
     kwargs: Any
         Extra keyword arguments that will be passed down to the reader subclass.
 
@@ -74,6 +86,22 @@ class AICSImage:
     internally. Useful when reading from remote sources to reduce network round trips.
 
     >>> img = AICSImage("malformed_metadata.ome.tiff", reader=readers.TiffReader)
+
+    Data for a mosaic file is returned pre-stitched (if the base reader supports it).
+
+    >>> img = AICSImage("big_mosaic.czi")
+    ... img.dims  # <Dimensions [T: 40, C: 3, Z: 1, Y: 30000, X: 45000]>
+
+    Data for mosaic file can be explicitly returned as tiles.
+    This is the same data just each tile is it's
+
+    >>> img = AICSImage("big_mosaic.czi", reconstruct_mosaic=False)
+    ... img.dims  # <Dimensions [M: 150, T: 40, C: 3, Z: 1, Y: 200, X: 300]>
+
+    Data is mosaic file but reader doesn't support tile stitching.
+
+    >>> img = AICSImage("unsupported_mosaic.ext")
+    ... img.dims  # <Dimensions [M: 100, T: 1, C: 2, Z: 1, Y: 400, X: 400]>
 
     Notes
     -----
@@ -160,6 +188,7 @@ class AICSImage:
         self,
         image: types.ImageLike,
         reader: Optional[ReaderType] = None,
+        reconstruct_mosaic: bool = True,
         **kwargs: Any,
     ):
         if reader is None:
@@ -171,6 +200,9 @@ class AICSImage:
 
         # Init and store reader
         self._reader = ReaderClass(image, **kwargs)
+
+        # Store delayed modifiers
+        self._reconstruct_mosaic = reconstruct_mosaic
 
         # Lazy load data from reader and reformat to standard dimensions
         self._xarray_dask_data: Optional[xr.DataArray] = None
@@ -268,9 +300,18 @@ class AICSImage:
         self,
         arr: xr.DataArray,
     ) -> xr.DataArray:
-        # Determine if we include Samples dim or not
-        if dimensions.DimensionNames.Samples in arr.dims:
+        # Determine if we need to add optionally-standard dims
+        if (
+            dimensions.DimensionNames.Samples in arr.dims
+            and dimensions.DimensionNames.MosaicTile in arr.dims
+        ):
+            return_dims = (
+                dimensions.DEFAULT_DIMENSION_ORDER_WITH_MOSAIC_TILES_AND_SAMPLES
+            )
+        elif dimensions.DimensionNames.Samples in arr.dims:
             return_dims = dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES
+        elif dimensions.DimensionNames.MosaicTile in arr.dims:
+            return_dims = dimensions.DEFAULT_DIMENSION_ORDER_WITH_MOSAIC_TILES
         else:
             return_dims = dimensions.DEFAULT_DIMENSION_ORDER
 
@@ -316,7 +357,14 @@ class AICSImage:
         If the image contains mosaic tiles, data is returned already stitched together.
         """
         if self._xarray_dask_data is None:
-            if dimensions.DimensionNames.MosaicTile in self.reader.dims.order:
+            if (
+                # Does the user want to get stitched mosaic
+                self._reconstruct_mosaic
+                # Does the data have a tile dim
+                and dimensions.DimensionNames.MosaicTile in self.reader.dims.order
+                # Does the reader support stitching
+                and self.reader.mosaic_xarray_dask_data is not None
+            ):
                 self._xarray_dask_data = (
                     self._transform_data_array_to_aics_image_standard(
                         self.reader.mosaic_xarray_dask_data
@@ -346,7 +394,14 @@ class AICSImage:
         Recommended to use `xarray_dask_data` for large mosaic images.
         """
         if self._xarray_data is None:
-            if dimensions.DimensionNames.MosaicTile in self.reader.dims.order:
+            if (
+                # Does the user want to get stitched mosaic
+                self._reconstruct_mosaic
+                # Does the data have a tile dim
+                and dimensions.DimensionNames.MosaicTile in self.reader.dims.order
+                # Does the reader support stitching
+                and self.reader.mosaic_xarray_dask_data is not None
+            ):
                 self._xarray_data = self._transform_data_array_to_aics_image_standard(
                     self.reader.mosaic_xarray_data
                 )
@@ -624,6 +679,35 @@ class AICSImage:
         metadata for unit information.
         """
         return self.reader.physical_pixel_sizes
+
+    def get_mosaic_tile_position(self, M: int) -> Tuple[int, int]:
+        """
+        Get the top left point for a single mosaic tile relative to the whole mosaic.
+
+        Parameters
+        ----------
+        M: int
+            The index for the mosaic tile to retrieve position information for.
+
+        Returns
+        -------
+        top: int
+            The Y coordinate for the tile position.
+        left: int
+            The X coordinate for the tile position.
+        """
+        return self.reader.get_mosaic_tile_position(M)
+
+    @property
+    def mosaic_tile_dims(self) -> Optional[dimensions.Dimensions]:
+        """
+        Returns
+        -------
+        tile_dims: Optional[Dimensions]
+            The dimensions for each tile in the mosaic image.
+            If the image is not a mosaic image, returns None.
+        """
+        return self.reader.mosaic_tile_dims
 
     def save(
         self,

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -93,7 +93,8 @@ class AICSImage:
     ... img.dims  # <Dimensions [T: 40, C: 3, Z: 1, Y: 30000, X: 45000]>
 
     Data for mosaic file can be explicitly returned as tiles.
-    This is the same data just each tile is it's
+    This is the same data as a reconstructed mosaic except that the tiles are
+    stored in their own dimension (M).
 
     >>> img = AICSImage("big_mosaic.czi", reconstruct_mosaic=False)
     ... img.dims  # <Dimensions [M: 150, T: 40, C: 3, Z: 1, Y: 200, X: 300]>
@@ -696,14 +697,16 @@ class AICSImage:
         """
         return self.reader.physical_pixel_sizes
 
-    def get_mosaic_tile_position(self, M: int) -> Optional[Tuple[int, int]]:
+    def get_mosaic_tile_position(
+        self, mosaic_tile_index: int
+    ) -> Optional[Tuple[int, int]]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
         Returns None if the image is not a mosaic.
 
         Parameters
         ----------
-        M: int
+        mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
 
         Returns
@@ -713,7 +716,7 @@ class AICSImage:
         left: int
             The X coordinate for the tile position.
         """
-        return self.reader.get_mosaic_tile_position(M)
+        return self.reader.get_mosaic_tile_position(mosaic_tile_index)
 
     @property
     def mosaic_tile_dims(self) -> Optional[dimensions.Dimensions]:

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -641,13 +641,13 @@ class LifReader(Reader):
 
         return self._px_sizes  # type: ignore
 
-    def get_mosaic_tile_position(self, M: int) -> Tuple[int, int]:
+    def get_mosaic_tile_position(self, mosaic_tile_index: int) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
 
         Parameters
         ----------
-        M: int
+        mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
 
         Returns
@@ -669,7 +669,9 @@ class LifReader(Reader):
 
         # LIFs are packed from bottom right to top left
         # To counter: subtract 1 + M from list index to get from back of list
-        index_y, index_x, _, _ = self._scene_short_info["mosaic_position"][-(M + 1)]
+        index_y, index_x, _, _ = self._scene_short_info["mosaic_position"][
+            -(mosaic_tile_index + 1)
+        ]
 
         return (
             (index_y * self.dims.Y) - index_y,  # type: ignore

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -643,7 +643,7 @@ class LifReader(Reader):
 
     def get_mosaic_tile_position(self, M: int) -> Tuple[int, int]:
         """
-        Get the top left point for a single mosaic tile relative to the whole mosaic.
+        Get the absolute position of the top left point for a single mosaic tile.
 
         Parameters
         ----------

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -667,7 +667,11 @@ class LifReader(Reader):
         if DimensionNames.MosaicTile not in self.dims.order:
             raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
 
-        # Unpack the target mosaic position
-        index_x, index_y, _, _ = self._scene_short_info["mosaic_position"][M]
+        # LIFs are packed from bottom right to top left
+        # To counter: subtract 1 + M from list index to get from back of list
+        index_y, index_x, _, _ = self._scene_short_info["mosaic_position"][-(M + 1)]
 
-        return index_y * self.dims.Y, index_x * self.dims.X
+        return (
+            (index_y * self.dims.Y) - index_y,
+            (index_x * self.dims.X) - index_x,
+        )

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -80,7 +80,7 @@ class LifReader(Reader):
         self.chunk_dims = chunk_dims
 
         # Delayed storage
-        self._scene_short_info: Optional[Dict[str, Any]] = None
+        self._scene_short_info: Dict[str, Any] = {}
         self._px_sizes: Optional[types.PhysicalPixelSizes] = None
 
         # Enforce valid image
@@ -672,6 +672,6 @@ class LifReader(Reader):
         index_y, index_x, _, _ = self._scene_short_info["mosaic_position"][-(M + 1)]
 
         return (
-            (index_y * self.dims.Y) - index_y,
-            (index_x * self.dims.X) - index_x,
+            (index_y * self.dims.Y) - index_y,  # type: ignore
+            (index_x * self.dims.X) - index_x,  # type: ignore
         )

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -696,9 +696,10 @@ class Reader(ABC):
         """
         return PhysicalPixelSizes(1.0, 1.0, 1.0)
 
-    def get_mosaic_tile_position(self, M: int) -> Tuple[int, int]:
+    def get_mosaic_tile_position(self, M: int) -> Optional[Tuple[int, int]]:
         """
         Get the top left point for a single mosaic tile relative to the whole mosaic.
+        Returns None if the image is not a mosaic.
 
         Parameters
         ----------
@@ -719,7 +720,7 @@ class Reader(ABC):
         IndexError
             No matching mosaic tile index found.
         """
-        return NotImplementedError()
+        raise NotImplementedError()
 
     @property
     def mosaic_tile_dims(self) -> Optional[Dimensions]:

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -698,7 +698,7 @@ class Reader(ABC):
 
     def get_mosaic_tile_position(self, M: int) -> Optional[Tuple[int, int]]:
         """
-        Get the top left point for a single mosaic tile relative to the whole mosaic.
+        Get the absolute position of the top left point for a single mosaic tile.
         Returns None if the image is not a mosaic.
 
         Parameters

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -264,12 +264,19 @@ class Reader(ABC):
             The fully stitched together image. Contains all the dimensions of the image
             with the YX expanded to the full mosaic.
 
+        Raises
+        ------
+        NotImplementedError
+            Reader or format doesn't support reconstructing mosaic tiles.
+
         Notes
         -----
         Implementers can determine how to chunk the array.
         Most common is to chunk by tile.
         """
-        pass
+        raise NotImplementedError(
+            "This reader does not support reconstructing mosaic images."
+        )
 
     def _get_stitched_mosaic(self) -> xr.DataArray:
         """
@@ -281,8 +288,15 @@ class Reader(ABC):
         mosaic: np.ndarray
             The fully stitched together image. Contains all the dimensions of the image
             with the YX expanded to the full mosaic.
+
+        Raises
+        ------
+        NotImplementedError
+            Reader or format doesn't support reconstructing mosaic tiles.
         """
-        pass
+        raise NotImplementedError(
+            "This reader does not support reconstructing mosaic images."
+        )
 
     @property
     def xarray_dask_data(self) -> xr.DataArray:
@@ -681,6 +695,45 @@ class Reader(ABC):
         metadata for unit information.
         """
         return PhysicalPixelSizes(1.0, 1.0, 1.0)
+
+    def get_mosaic_tile_position(self, M: int) -> Tuple[int, int]:
+        """
+        Get the top left point for a single mosaic tile relative to the whole mosaic.
+
+        Parameters
+        ----------
+        M: int
+            The index for the mosaic tile to retrieve position information for.
+
+        Returns
+        -------
+        top: int
+            The Y coordinate for the tile position.
+        left: int
+            The X coordinate for the tile position.
+
+        Raises
+        ------
+        UnexpectedShapeError
+            The image has no mosaic dimension available.
+        IndexError
+            No matching mosaic tile index found.
+        """
+        return NotImplementedError()
+
+    @property
+    def mosaic_tile_dims(self) -> Optional[Dimensions]:
+        """
+        Returns
+        -------
+        tile_dims: Optional[Dimensions]
+            The dimensions for each tile in the mosaic image.
+            If the image is not a mosaic image, returns None.
+        """
+        if DimensionNames.MosaicTile in self.dims.order:
+            return Dimensions("YX", (self.dims.Y, self.dims.X))
+
+        return None
 
     def __str__(self) -> str:
         return (

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -696,14 +696,16 @@ class Reader(ABC):
         """
         return PhysicalPixelSizes(1.0, 1.0, 1.0)
 
-    def get_mosaic_tile_position(self, M: int) -> Optional[Tuple[int, int]]:
+    def get_mosaic_tile_position(
+        self, mosaic_tile_index: int
+    ) -> Optional[Tuple[int, int]]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
         Returns None if the image is not a mosaic.
 
         Parameters
         ----------
-        M: int
+        mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
 
         Returns

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -732,7 +732,7 @@ class Reader(ABC):
             If the image is not a mosaic image, returns None.
         """
         if DimensionNames.MosaicTile in self.dims.order:
-            return Dimensions("YX", (self.dims.Y, self.dims.X))
+            return Dimensions("YX", (self.dims.Y, self.dims.X))  # type: ignore
 
         return None
 

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -264,8 +264,8 @@ def test_lif_reader_mosaic_tile_inspection(
     reader.set_scene(set_scene)
 
     # Check basics
-    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]
-    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]
+    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]  # type: ignore
+    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]  # type: ignore
 
     # Pull tile info for compare
     tile_y_pos, tile_x_pos = reader.get_mosaic_tile_position(select_tile_index)
@@ -281,8 +281,8 @@ def test_lif_reader_mosaic_tile_inspection(
         :,
         :,
         :,
-        tile_y_pos : (tile_y_pos + reader.mosaic_tile_dims.Y),
-        tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),
+        tile_y_pos : (tile_y_pos + reader.mosaic_tile_dims.Y),  # type: ignore
+        tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),  # type: ignore
     ].compute()
 
     # Remove the first Y and X pixels

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -191,3 +191,105 @@ def test_lif_reader_mosaic_stitching(
         tiles_set_scene=tiles_set_scene,
         stitched_set_scene=stitched_set_scene,
     )
+
+
+@pytest.mark.parametrize(
+    "filename, "
+    "set_scene, "
+    "expected_tile_dims, "
+    "select_tile_index, "
+    "expected_tile_top_left",
+    [
+        (
+            "tiled.lif",
+            "TileScan_002",
+            (512, 512),
+            0,
+            (5110, 7154),
+        ),
+        (
+            "tiled.lif",
+            "TileScan_002",
+            (512, 512),
+            50,
+            (3577, 4599),
+        ),
+        (
+            "tiled.lif",
+            "TileScan_002",
+            (512, 512),
+            3,
+            (5110, 5621),
+        ),
+        (
+            "tiled.lif",
+            "TileScan_002",
+            (512, 512),
+            164,
+            (0, 0),
+        ),
+        pytest.param(
+            "tiled.lif",
+            "TileScan_002",
+            (512, 512),
+            999,
+            None,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            "merged-tiles.lif",
+            "TileScan_002_Merging",
+            None,
+            None,
+            None,
+            # The value returned from all of the calls is None
+            # Which when trying to operate on will raise an AttributeError
+            # Because None doesn't have a Y or X attribute for example
+            marks=pytest.mark.raises(exception=AttributeError),
+        ),
+    ],
+)
+def test_lif_reader_mosaic_tile_inspection(
+    filename: str,
+    set_scene: str,
+    expected_tile_dims: Tuple[int, int],
+    select_tile_index: int,
+    expected_tile_top_left: Tuple[int, int],
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Construct reader
+    reader = LifReader(uri)
+    reader.set_scene(set_scene)
+
+    # Check basics
+    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]
+    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]
+
+    # Pull tile info for compare
+    tile_y_pos, tile_x_pos = reader.get_mosaic_tile_position(select_tile_index)
+    assert tile_y_pos == expected_tile_top_left[0]
+    assert tile_x_pos == expected_tile_top_left[1]
+
+    # Pull actual pixel data to compare
+    tile_from_m_index = reader.get_image_dask_data(
+        reader.dims.order.replace(dimensions.DimensionNames.MosaicTile, ""),
+        M=select_tile_index,
+    ).compute()
+    tile_from_position = reader.mosaic_xarray_dask_data[
+        :,
+        :,
+        :,
+        tile_y_pos : (tile_y_pos + reader.mosaic_tile_dims.Y),
+        tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),
+    ].compute()
+
+    # Remove the first Y and X pixels
+    # The stitched tiles overlap each other by 1px each so this is just
+    # ignoring what would be overlap / cleaned up
+    tile_from_m_index = tile_from_m_index[:, :, :, 1:, 1:]
+    tile_from_position = tile_from_position[:, :, :, 1:, 1:]
+
+    # Assert equal
+    np.testing.assert_array_equal(tile_from_m_index, tile_from_position)

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -892,3 +892,75 @@ def test_set_reader(
     # Assert basics
     assert img.dims.order == expected_dims
     assert img.shape == expected_shape
+
+
+@pytest.mark.parametrize(
+    "filename, "
+    "reconstruct_mosaic, "
+    "set_scene, "
+    "expected_shape, "
+    "expected_mosaic_tile_dims, "
+    "specific_tile_index",
+    [
+        (
+            "tiled.lif",
+            True,
+            "TileScan_002",
+            (1, 4, 1, 5622, 7666),
+            (512, 512),
+            0,
+        ),
+        (
+            "tiled.lif",
+            False,
+            "TileScan_002",
+            (165, 1, 4, 1, 512, 512),
+            (512, 512),
+            0,
+        ),
+        pytest.param(
+            "tiled.lif",
+            False,
+            "TileScan_002",
+            (165, 1, 4, 1, 512, 512),
+            (512, 512),
+            999,
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        pytest.param(
+            "actk.ome.tiff",
+            True,
+            "Image:0",
+            (1, 6, 65, 233, 345),
+            None,
+            0,
+            # AttributeError raises not because of error in rollback
+            # but because cannot access Y or X from
+            # None return from `mosaic_tile_dims` because
+            # image is not a mosaic tiled image
+            marks=pytest.mark.raises(exception=AttributeError),
+        ),
+    ],
+)
+def test_mosaic_passthrough(
+    filename: str,
+    reconstruct_mosaic: bool,
+    set_scene: str,
+    expected_shape: Tuple[int, ...],
+    expected_mosaic_tile_dims: Tuple[int, int],
+    specific_tile_index: int,
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Init
+    img = AICSImage(uri, reconstruct_mosaic=reconstruct_mosaic)
+    img.set_scene(set_scene)
+
+    # Assert basics
+    assert img.shape == expected_shape
+    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]
+    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]
+
+    # Ensure that regardless of stitched or not, we can get tile position
+    img.get_mosaic_tile_position(specific_tile_index)

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -959,8 +959,8 @@ def test_mosaic_passthrough(
 
     # Assert basics
     assert img.shape == expected_shape
-    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]
-    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]
+    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]  # type: ignore
+    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]  # type: ignore
 
     # Ensure that regardless of stitched or not, we can get tile position
     img.get_mosaic_tile_position(specific_tile_index)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ test_requirements = [
     *all_formats,
     "black>=19.10b0",
     "codecov>=2.1.4",
-    "distributed~=2.9.0",
+    "distributed>=2021.4.1",
     "docutils>=0.10,<0.16",
     "flake8>=3.8.3",
     "flake8-debugger>=3.2.1",
@@ -33,7 +33,7 @@ test_requirements = [
     "pytest>=5.4.3",
     "pytest-cov>=2.9.0",
     "pytest-raises>=0.11",
-    "s3fs~=0.5.1",
+    "s3fs>=2021.4.0",
 ]
 
 dev_requirements = [
@@ -54,8 +54,8 @@ dev_requirements = [
 ]
 
 requirements = [
-    "dask[array]>=2021.1.0",
-    "fsspec~=0.8.4",
+    "dask[array]>=2021.4.1",
+    "fsspec>=2021.4.0",
     "imagecodecs>=2020.5.30",
     "numpy~=1.16",
     "ome-types~=0.2.4",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as readme_file:
 
 format_libs = {
     "base-imageio": "imageio[ffmpeg]~=2.9.0",
-    "lif": "readlif~=0.5.1",
+    "lif": "readlif~=0.6.1",
 }
 
 all_formats = [v for v in format_libs.values()]


### PR DESCRIPTION
## Description

ORIGINAL DESCRIPTION:
I will try to get to #228 this weekend / next week but until then I thought I would at least add some docs for mosaic file support / tile stitched and raw reading.

UPDATED:
This adds a couple of functions to help users with requesting single tiles and their positions from mosaic images. Additionally cleans up the actual mosaic file init to be a bit nicer of a user expected and flow with `reconstruct_mosaic` parameter.

Finally this also massively improves the docs for mosaic handling + some other incorrect docs I found while testing this.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Docs (and extended features) for #228 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
