### PR TITLE
bugfix/setup-coords-for-stitched-lifs

### DIFF
--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -605,6 +605,22 @@ class LifReader(Reader):
                 DimensionNames.SpatialX,
             ]
         }
+
+        # Add expanded Y and X coords
+        scale_x, scale_y, _, _ = selected_scene.info["scale"]
+        if scale_y is not None:
+            coords[DimensionNames.SpatialY] = np.arange(
+                0,
+                stitched.shape[-2] * scale_y,
+                scale_y,
+            )
+        if scale_x is not None:
+            coords[DimensionNames.SpatialX] = np.arange(
+                0,
+                stitched.shape[-1] * scale_x,
+                scale_x,
+            )
+
         attrs = copy(self.xarray_dask_data.attrs)
 
         return xr.DataArray(

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -293,3 +293,53 @@ def test_lif_reader_mosaic_tile_inspection(
 
     # Assert equal
     np.testing.assert_array_equal(tile_from_m_index, tile_from_position)
+
+
+@pytest.mark.parametrize(
+    "filename, "
+    "expected_tile_y_coords, "
+    "expected_tile_x_coords, "
+    "expected_mosaic_y_coords, "
+    "expected_mosaic_x_coords",
+    [
+        (
+            "tiled.lif",
+            np.arange(0, 2552.176156654795, 4.984719055966396),
+            np.arange(0, 2552.176156654795, 4.984719055966396),
+            np.arange(0, 28024.09053264308, 4.984719055966396),
+            np.arange(0, 38212.85628303839, 4.984719055966396),
+        ),
+    ],
+)
+def test_lif_reader_mosaic_coords(
+    filename: str,
+    expected_tile_y_coords: np.ndarray,
+    expected_tile_x_coords: np.ndarray,
+    expected_mosaic_y_coords: np.ndarray,
+    expected_mosaic_x_coords: np.ndarray,
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Construct reader
+    reader = LifReader(uri)
+
+    # Check tile y and x min max
+    np.testing.assert_array_equal(
+        reader.xarray_dask_data.coords[dimensions.DimensionNames.SpatialY].data,
+        expected_tile_y_coords,
+    )
+    np.testing.assert_array_equal(
+        reader.xarray_dask_data.coords[dimensions.DimensionNames.SpatialX].data,
+        expected_tile_x_coords,
+    )
+
+    # Check mosaic y and x min max
+    np.testing.assert_array_equal(
+        reader.mosaic_xarray_dask_data.coords[dimensions.DimensionNames.SpatialY].data,
+        expected_mosaic_y_coords,
+    )
+    np.testing.assert_array_equal(
+        reader.mosaic_xarray_dask_data.coords[dimensions.DimensionNames.SpatialX].data,
+        expected_mosaic_x_coords,
+    )


### PR DESCRIPTION
## Description

Discovered while working on presentation. LifReader mosaic stitching _was_ properly removing the unstitched Y and X coordinates but wasn't adding the corrected Y and X coordinates.

@heeler I believe you were mirroring this bit in your CziReader code and you will likely have to make this change there too.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
