### PR TITLE
bugfix/always-use-synch-for-tiff-zarr-compute

### DIFF
--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -161,6 +161,13 @@ class TiffReader(Reader):
                 )
             )
             arr = arr.transpose(transpose_indices)
+
+            # By setting the compute call to always use a "synchronous" scheduler,
+            # it informs Dask not to look for an existing scheduler / client
+            # and instead simply read the data using the current thread / process.
+            #
+            # In doing so, we shouldn't run into any worker data transfer and handoff
+            # _during_ a read.
             return arr[retrieve_indices].compute(scheduler="synchronous")
 
     def _get_tiff_tags(self, tiff: TiffFile) -> TiffTags:

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -161,7 +161,7 @@ class TiffReader(Reader):
                 )
             )
             arr = arr.transpose(transpose_indices)
-            return arr[retrieve_indices].compute()
+            return arr[retrieve_indices].compute(scheduler="synchronous")
 
     def _get_tiff_tags(self, tiff: TiffFile) -> TiffTags:
         return tiff.series[self.current_scene_index].pages[0].tags

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import time
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
-from distributed import Client, LocalCluster
 import numpy as np
 import pytest
 import xarray as xr
+from distributed import Client, LocalCluster
 from ome_types import OME
 
 from aicsimageio import AICSImage, dimensions, exceptions, readers, types

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -1033,5 +1033,6 @@ def test_parallel_read(
     assert out.shape == expected_shape
 
     # Shutdown and then safety measure timeout
-    client.shutdown()
+    cluster.close()
+    client.close()
     time.sleep(5)

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -4,9 +4,11 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from tempfile import TemporaryDirectory
+import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
+from distributed import Client, LocalCluster
 import numpy as np
 import pytest
 import xarray as xr
@@ -964,3 +966,72 @@ def test_mosaic_passthrough(
 
     # Ensure that regardless of stitched or not, we can get tile position
     img.get_mosaic_tile_position(specific_tile_index)
+
+
+@pytest.mark.parametrize(
+    "filename, set_scene, get_dims, get_specific_dims, expected_shape",
+    [
+        # Check normal volumetric data
+        (
+            "3d-cell-viewer.ome.tiff",
+            "Image:0",
+            "CZYX",
+            {"C": [0, 1, 2, 3]},
+            (4, 74, 1024, 1024),
+        ),
+        (
+            "s_1_t_1_c_2_z_1_RGB.tiff",
+            "Image:0",
+            "CYXS",
+            {},
+            (2, 32, 32, 3),
+        ),
+        (
+            "s_1_t_4_c_2_z_1.lif",
+            "b2_001_Crop001_Resize001",
+            "TYX",
+            {},
+            (4, 614, 614),
+        ),
+        # Check mosaic chunk handling
+        (
+            "tiled.lif",
+            "TileScan_002",
+            "CYX",
+            {"Y": slice(0, 2000), "X": slice(0, 2000)},
+            (4, 2000, 2000),
+        ),
+    ],
+)
+@pytest.mark.parametrize("chunk_dims", ["YX", "ZYX"])
+@pytest.mark.parametrize("processes", [True, False])
+def test_parallel_read(
+    filename: str,
+    set_scene: str,
+    chunk_dims: str,
+    processes: bool,
+    get_dims: str,
+    get_specific_dims: Dict[str, Union[int, slice, range, Tuple[int, ...], List[int]]],
+    expected_shape: Tuple[int, ...],
+) -> None:
+    """
+    This test ensures that our produced dask array can be read in parallel.
+    """
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Init image
+    img = AICSImage(uri, chunk_dims=chunk_dims)
+    img.set_scene(set_scene)
+
+    # Init cluster
+    cluster = LocalCluster(processes=processes)
+    client = Client(cluster)
+
+    # Select data
+    out = img.get_image_dask_data(get_dims, **get_specific_dims).compute()
+    assert out.shape == expected_shape
+
+    # Shutdown and then safety measure timeout
+    client.shutdown()
+    time.sleep(5)


### PR DESCRIPTION
## Description

Found during working on dask summit talk.

When attempting to parallel process an image with processes and not threads, the dask scheduler / cluster was raising a "Closed" error (I forget the exact error call).

What was happening was that because the `da.from_zarr` was creating an entirely new dask array _during an existing `compute()` process call_, the zarr array get item + compute was attempting to use the multi-processing client, but during processing switching / worker data transfer, the return value of the zarr get item was attempting to return to a now closed task.

By setting the compute call to always use a "synchronous" scheduler, it informs Dask to not look for an existing scheduler / client and instead simply read the data using the current thread / process. 

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.

Added tests for all readers and under multiple parameters for parallel reads.

- [x] Provide or update documentation for any feature added by your pull request.

Added comment right about compute call in TiffReader in shorthand of why we use synchronous.

Thanks for contributing!
