### PR TITLE
bugfix/imagecodecs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "dask>=2.9.0",
     "distributed>=2.9.3",
     "numpy>=1.16",
-    "imagecodecs>=2020.5.30",
+    "imagecodecs==2021.4.28",
     "imageio>=2.3.0",
     "readlif==0.3.1",
     "lxml>=4.4.2",


### PR DESCRIPTION
## Description
Latest version of `imagecodecs` is failing installation on Mac OS. This PR pins `imagecodecs` to the previous version.

## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
