### PR TITLE
admin/4.0-release-prep-and-benchmark-upgrades

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+presentations/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-presentations/* linguist-documentation
+presentations/** linguist-documentation

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,7 @@
     "dvcs": "git",
     "environment_type": "virtualenv",
     "install_command": [
-        "in-dir={env_dir} python -mpip install {build_dir}[dev]"
+        "in-dir={env_dir} python -mpip install {build_dir}[benchmark]"
     ],
     "show_commit_url": "http://github.com/AllenCellModeling/aicsimageio/commit/",
     "pythons": ["3.9"],

--- a/benchmarks/benchmark_chunk_sizes.py
+++ b/benchmarks/benchmark_chunk_sizes.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import dask.array as da
 import random
 from pathlib import Path
 
@@ -20,26 +21,74 @@ LOCAL_RESOURCES_DIR = (
 
 
 class ChunkSuite(_ImageContainerTimeSuite):
+    # This suite measures the effect that changing the default chunk dims
+    # has on the duration of various reads.
+    # We would expect that processing speed can be optimized based off of the
+    # dimensions of the file and what the user is trying to do with said file.
+    # i.e. If the user wants to nrmalize each channel and make a max projection
+    # through Z, then the default of 'ZYX' is preferred over just 'YX'.
+    # During this suite we not only benchmark the above example but also
+    # file reading under the various chunk configurations as a monitor
+    # for general read performance.
 
     params = (
+        [
+            str(LOCAL_RESOURCES_DIR / "actk.ome.tiff"),
+            str(LOCAL_RESOURCES_DIR / "pipeline-4.ome.tiff"),
+            str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),
+            str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
+        ],
+        # We don't go above chunking by three dims because it would be rare
+        # to do so... if you can read four-plus dims in a single chunk why can't you
+        # just read in the whole image at once.
+        # We also use CYX here to show that chunking with the _wrong_ dimensions can
+        # result in longer processing times.
         [
             "YX",
             "ZYX",
             "CYX",
-            "CZYX",
         ],
-        sorted(
-            [
-                str(f)
-                for f in [
-                    LOCAL_RESOURCES_DIR / "actk.ome.tiff",
-                    LOCAL_RESOURCES_DIR / "pipeline-4.ome.tiff",
-                    LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff",
-                    LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff",
-                ]
-            ]
-        ),
     )
+
+    def time_norm_and_project(self, img_path, chunk_dims):
+        """
+        Benchmark how long a norm and project through Z takes
+        under various chunk dims configurations.
+        """
+        # Init image container
+        r = self.ImageContainer(img_path, chunk_dims=chunk_dims)
+
+        # Store all delayed projections
+        projs = []
+
+        # Only run the first
+        selected_channels = random.sample(r.channel_names, 2)
+        for i, channel_name in enumerate(r.channel_names):
+            if channel_name in selected_channels:
+                # Select each channel
+                data = r.get_image_dask_data("ZYX", C=i)
+
+                # Get percentile norm by values
+                min_px_val, max_px_val = da.percentile(
+                    data.flatten(),
+                    [50.0, 99.8],
+                ).compute()
+
+                # Norm
+                normed = (data - min_px_val) / (max_px_val - min_px_val)
+
+                # Clip any values outside of 0 and 1
+                clipped = da.clip(normed, 0, 1)
+
+                # Scale them between 0 and 255
+                scaled = clipped * 255
+
+                # Create max project
+                projs.append(scaled.max(axis=0))
+
+        # Compute all projections
+        projs = da.stack(projs)
+        projs.compute()
 
     def setup(self, img_path, chunk_dims):
         random.seed(42)

--- a/benchmarks/benchmark_chunk_sizes.py
+++ b/benchmarks/benchmark_chunk_sizes.py
@@ -33,8 +33,6 @@ class ChunkSuite(_ImageContainerTimeSuite):
 
     params = (
         [
-            str(LOCAL_RESOURCES_DIR / "actk.ome.tiff"),
-            str(LOCAL_RESOURCES_DIR / "pipeline-4.ome.tiff"),
             str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),
             str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
         ],

--- a/benchmarks/benchmark_chunk_sizes.py
+++ b/benchmarks/benchmark_chunk_sizes.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import random
+from pathlib import Path
+
+from aicsimageio import AICSImage
+
+from .benchmark_image_containers import _ImageContainerTimeSuite
+
+###############################################################################
+
+# We only benchmark against local files as remote files are covered by unit tests
+# and are generally slower than local but scale at a similar rate.
+LOCAL_RESOURCES_DIR = (
+    Path(__file__).parent.parent / "aicsimageio" / "tests" / "resources"
+)
+
+###############################################################################
+
+
+class ChunkSuite(_ImageContainerTimeSuite):
+
+    params = (
+        [
+            "YX",
+            "ZYX",
+            "CYX",
+            "CZYX",
+        ],
+        sorted(
+            [
+                str(f)
+                for f in [
+                    LOCAL_RESOURCES_DIR / "actk.ome.tiff",
+                    LOCAL_RESOURCES_DIR / "pipeline-4.ome.tiff",
+                    LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff",
+                    LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff",
+                ]
+            ]
+        ),
+    )
+
+    def setup(self, img_path, chunk_dims):
+        random.seed(42)
+        self.ImageContainer = AICSImage

--- a/benchmarks/benchmark_chunk_sizes.py
+++ b/benchmarks/benchmark_chunk_sizes.py
@@ -59,7 +59,7 @@ class ChunkSuite(_ImageContainerTimeSuite):
         # Store all delayed projections
         projs = []
 
-        # Only run the first
+        # Only run a random sample of two channels instead of all
         selected_channels = random.sample(r.channel_names, 2)
         for i, channel_name in enumerate(r.channel_names):
             if channel_name in selected_channels:

--- a/benchmarks/benchmark_chunk_sizes.py
+++ b/benchmarks/benchmark_chunk_sizes.py
@@ -25,7 +25,7 @@ class ChunkSuite(_ImageContainerTimeSuite):
     # has on the duration of various reads.
     # We would expect that processing speed can be optimized based off of the
     # dimensions of the file and what the user is trying to do with said file.
-    # i.e. If the user wants to nrmalize each channel and make a max projection
+    # i.e. If the user wants to normalize each channel and make a max projection
     # through Z, then the default of 'ZYX' is preferred over just 'YX'.
     # During this suite we not only benchmark the above example but also
     # file reading under the various chunk configurations as a monitor

--- a/benchmarks/benchmark_image_containers.py
+++ b/benchmarks/benchmark_image_containers.py
@@ -150,7 +150,11 @@ class DefaultReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
 class TiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
     params = [
-        sorted([str(f) for f in LOCAL_RESOURCES_DIR.glob("*.tiff")]),
+        str(
+            LOCAL_RESOURCES_DIR
+            / "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif"
+        ),
+        str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
     ]
 
     def setup(self, img_path):
@@ -160,7 +164,9 @@ class TiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
 class OmeTiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
     params = [
-        sorted([str(f) for f in LOCAL_RESOURCES_DIR.glob("*.ome.tiff")]),
+        str(LOCAL_RESOURCES_DIR / "actk.ome.tiff"),
+        str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),
+        str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
     ]
 
     def setup(self, img_path):

--- a/benchmarks/benchmark_image_containers.py
+++ b/benchmarks/benchmark_image_containers.py
@@ -5,7 +5,7 @@ import random
 from pathlib import Path
 
 from aicsimageio import AICSImage, readers
-from aicsimageio.dimensions import DimensionNames
+from aicsimageio.dimensions import DEFAULT_CHUNK_DIMS, DimensionNames
 
 ###############################################################################
 
@@ -61,25 +61,34 @@ class _ImageContainerTimeSuite:
         DimensionNames.Samples,
     ]
 
-    def time_init(self, img_path):
+    def time_init(self, img_path, chunk_dims=None):
         """
         Benchmark how long it takes to validate a file and finish general setup.
         """
-        self.ImageContainer(img_path)
+        if chunk_dims is None:
+            chunk_dims = DEFAULT_CHUNK_DIMS
 
-    def time_delayed_array_construct(self, img_path):
+        self.ImageContainer(img_path, chunk_dims=chunk_dims)
+
+    def time_delayed_array_construct(self, img_path, chunk_dims=None):
         """
         Benchmark how long it takes to construct the delayed dask array for a file.
         """
-        self.ImageContainer(img_path).dask_data
+        if chunk_dims is None:
+            chunk_dims = DEFAULT_CHUNK_DIMS
 
-    def time_random_single_chunk_read(self, img_path):
+        self.ImageContainer(img_path, chunk_dims=chunk_dims).dask_data
+
+    def time_random_single_chunk_read(self, img_path, chunk_dims=None):
         """
         Benchmark how long it takes to read a single chunk out of a file.
 
         I.E. "Pull just the Brightfield channel z-stack.
         """
-        r = self.ImageContainer(img_path)
+        if chunk_dims is None:
+            chunk_dims = DEFAULT_CHUNK_DIMS
+
+        r = self.ImageContainer(img_path, chunk_dims=chunk_dims)
 
         random_index_selections = {}
         for dim, size in zip(r.dims.order, r.dims.shape):
@@ -91,13 +100,16 @@ class _ImageContainerTimeSuite:
         )
         r.get_image_dask_data(valid_dims_to_return, **random_index_selections).compute()
 
-    def time_random_many_chunk_read(self, img_path):
+    def time_random_many_chunk_read(self, img_path, chunk_dims=None):
         """
         Open a file, get many chunks out of the file at once.
 
         I.E. "Pull the DNA and Nucleus channel z-stacks, for the middle 50% timepoints".
         """
-        r = self.ImageContainer(img_path)
+        if chunk_dims is None:
+            chunk_dims = DEFAULT_CHUNK_DIMS
+
+        r = self.ImageContainer(img_path, chunk_dims=chunk_dims)
 
         random_index_selections = {}
         for dim, size in zip(r.dims.order, r.dims.shape):
@@ -133,7 +145,7 @@ class DefaultReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
     def setup(self, img_path):
         random.seed(42)
-        self.ImageContainer = readers.DefaultReader
+        self.ImageContainer = readers.default_reader.DefaultReader
 
 
 class TiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
@@ -143,7 +155,7 @@ class TiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
     def setup(self, img_path):
         random.seed(42)
-        self.ImageContainer = readers.TiffReader
+        self.ImageContainer = readers.tiff_reader.TiffReader
 
 
 class OmeTiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
@@ -153,7 +165,7 @@ class OmeTiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
     def setup(self, img_path):
         random.seed(42)
-        self.ImageContainer = readers.OmeTiffReader
+        self.ImageContainer = readers.ome_tiff_reader.OmeTiffReader
 
 
 class LifReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
@@ -163,7 +175,7 @@ class LifReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
     def setup(self, img_path):
         random.seed(42)
-        self.ImageContainer = readers.LifReader
+        self.ImageContainer = readers.lif_reader.LifReader
 
 
 class AICSImageSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):

--- a/benchmarks/benchmark_image_containers.py
+++ b/benchmarks/benchmark_image_containers.py
@@ -150,11 +150,13 @@ class DefaultReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
 class TiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
     params = [
-        str(
-            LOCAL_RESOURCES_DIR
-            / "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif"
-        ),
-        str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
+        [
+            str(
+                LOCAL_RESOURCES_DIR
+                / "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif"
+            ),
+            str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
+        ]
     ]
 
     def setup(self, img_path):
@@ -164,9 +166,11 @@ class TiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
 
 class OmeTiffReaderSuite(_ImageContainerTimeSuite, _ImageContainerMemorySuite):
     params = [
-        str(LOCAL_RESOURCES_DIR / "actk.ome.tiff"),
-        str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),
-        str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
+        [
+            str(LOCAL_RESOURCES_DIR / "actk.ome.tiff"),
+            str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),
+            str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
+        ]
     ]
 
     def setup(self, img_path):

--- a/benchmarks/benchmark_lib.py
+++ b/benchmarks/benchmark_lib.py
@@ -2,8 +2,19 @@
 # -*- coding: utf-8 -*-
 
 """
-Benchmarks for general library operations.
+Benchmarks for general library operations and comparisons against other libraries.
 """
+
+from dask_image.imread import imread
+from aicsimageio import imread_dask
+
+from .benchmark_image_containers import LOCAL_RESOURCES_DIR
+
+###############################################################################
+
+PIPELINE_4_OME_TIFF = str(LOCAL_RESOURCES_DIR / "pipeline-4.ome.tiff")
+
+###############################################################################
 
 
 class LibSuite:
@@ -12,3 +23,18 @@ class LibSuite:
         Benchmark how long it takes to import the library as a whole.
         """
         import aicsimageio  # noqa: F401
+
+
+class LibCompareSuite:
+    """
+    Compare aicsimageio against other "just-in-time" image reading libs.
+    """
+
+    def time_aicsimageio_chunk_zyx(self):
+        imread_dask(PIPELINE_4_OME_TIFF, chunk_dims="ZYX").compute()
+
+    def time_aicsimageio_chunk_yx(self):
+        imread_dask(PIPELINE_4_OME_TIFF, chunk_dims="YX").compute()
+
+    def time_dask_image(self):
+        imread(PIPELINE_4_OME_TIFF).compute()

--- a/benchmarks/benchmark_lib.py
+++ b/benchmarks/benchmark_lib.py
@@ -12,7 +12,7 @@ from .benchmark_image_containers import LOCAL_RESOURCES_DIR
 
 ###############################################################################
 
-PIPELINE_4_OME_TIFF = str(LOCAL_RESOURCES_DIR / "pipeline-4.ome.tiff")
+VARIANCE_CFE_OME_TIFF = str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff")
 
 ###############################################################################
 
@@ -31,10 +31,10 @@ class LibCompareSuite:
     """
 
     def time_aicsimageio_chunk_zyx(self):
-        imread_dask(PIPELINE_4_OME_TIFF, chunk_dims="ZYX").compute()
+        imread_dask(VARIANCE_CFE_OME_TIFF, chunk_dims="ZYX").compute()
 
     def time_aicsimageio_chunk_yx(self):
-        imread_dask(PIPELINE_4_OME_TIFF, chunk_dims="YX").compute()
+        imread_dask(VARIANCE_CFE_OME_TIFF, chunk_dims="YX").compute()
 
     def time_dask_image(self):
-        imread(PIPELINE_4_OME_TIFF).compute()
+        imread(VARIANCE_CFE_OME_TIFF).compute()

--- a/benchmarks/benchmark_lib.py
+++ b/benchmarks/benchmark_lib.py
@@ -8,9 +8,7 @@ Benchmarks for general library operations and comparisons against other librarie
 from functools import partial
 
 from aicsimageio import imread_dask as aicsimageio_imread
-from dask.array.image import imread as dask_array_imread
 from dask_image.imread import imread as dask_image_imread
-import pims
 
 from .benchmark_image_containers import LOCAL_RESOURCES_DIR
 
@@ -21,7 +19,7 @@ ACTK_OME_TIFF = str(LOCAL_RESOURCES_DIR / "actk.ome.tiff")
 ###############################################################################
 
 
-class LibSuite:
+class LibInitSuite:
     def time_base_import(self):
         """
         Benchmark how long it takes to import the library as a whole.
@@ -37,15 +35,12 @@ class LibCompareSuite:
     FUNC_LOOKUP = {
         "aicsimageio-default-chunks": partial(aicsimageio_imread, chunk_dims="ZYX"),
         "aicsimageio-plane-chunks": partial(aicsimageio_imread, chunk_dims="YX"),
-        "dask-array-imread-default": dask_array_imread,
         "dask-image-imread-default": dask_image_imread,
     }
 
     params = [
         "aicsimageio-default-chunks",
         "aicsimageio-plane-chunks",
-        "dask-array-imread-default",
-        "dask-array-imread-pims",
         "dask-image-imread-default",
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,11 @@ dev_requirements = [
     "wheel>=0.34.2",
 ]
 
+benchmark_requirements = [
+    *dev_requirements,
+    "dask-image~=0.6.0",
+]
+
 requirements = [
     "dask[array]>=2021.4.1",
     "fsspec>=2021.4.0",
@@ -70,6 +75,7 @@ extra_requirements = {
     "setup": setup_requirements,
     "test": test_requirements,
     "dev": dev_requirements,
+    "benchmark": benchmark_requirements,
     **format_libs,
     "all": all_formats,
 }

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ dev_requirements = [
 benchmark_requirements = [
     *dev_requirements,
     "dask-image~=0.6.0",
+    "pims",  # no pin because it's pulled from dask-image
+    "scikit-image~=0.18.1",
 ]
 
 requirements = [

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,6 @@ dev_requirements = [
 benchmark_requirements = [
     *dev_requirements,
     "dask-image~=0.6.0",
-    "pims",  # no pin because it's pulled from dask-image
-    "scikit-image~=0.18.1",
 ]
 
 requirements = [


### PR DESCRIPTION
## Description

Makes GitHub igore Jupyter Notebook from lang detection because.... this repo isn't jupyter, a single file is...

More importantly, it cleans up and expands benchmarking. A whole new suite for benchmarking how `chunk_dims` affects both IO and processing performance. And adds a `LibCompareSuite` for comparing aicsimageio against other "just-in-time" image reading libs.

In many cases I reduced the number of files benchmarked because our benchmarks currently take ~36 minutes to run... generally just because it is running ALOT of TIFF-like image benchmarks. We don't need to run every file.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #242 
Related: https://github.com/dask/dask-image/issues/181
Related: https://github.com/dask/dask-image/issues/229

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
