### PR TITLE
bugfix/fix-tiff-no-description-offset

### DIFF
--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -334,7 +334,7 @@ class TiffReader(Reader):
 
             if description_offset == 0:
                 # Nothing was found
-                return bytearray("")
+                return bytearray("", "utf8")
             else:
                 buffer_reader.buffer.seek(description_offset, 0)
                 return bytearray(buffer_reader.buffer.read(description_length))


### PR DESCRIPTION
This is a very small fix to reading tif files with zero description_offset. The issue is explained in #243.

Resolves #243 
