### PR TITLE
feature/default-to-pixel-size-none

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -469,8 +469,7 @@ class CziReader(Reader):
         # I can find a single "TimeSpan" in our data but unsure how multi-scene handles
 
         # Create physical pixel sizes
-        # TODO: fix typing as part of GH#238
-        px_sizes = types.PhysicalPixelSizes(scale_z, scale_y, scale_x)  # type: ignore
+        px_sizes = types.PhysicalPixelSizes(scale_z, scale_y, scale_x)
 
         return coords, px_sizes
 

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -409,11 +409,7 @@ class LifReader(Reader):
             )
 
         # Create physical pixal sizes
-        px_sizes = types.PhysicalPixelSizes(
-            scale_z if scale_z is not None else 1.0,
-            scale_y if scale_y is not None else 1.0,
-            scale_x if scale_x is not None else 1.0,
-        )
+        px_sizes = types.PhysicalPixelSizes(scale_z, scale_y, scale_x)
 
         return coords, px_sizes
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -421,8 +421,4 @@ class OmeTiffReader(TiffReader):
         y = self.metadata.images[self.current_scene_index].pixels.physical_size_y
         x = self.metadata.images[self.current_scene_index].pixels.physical_size_x
 
-        return PhysicalPixelSizes(
-            z if z is not None else 1.0,
-            y if y is not None else 1.0,
-            x if x is not None else 1.0,
-        )
+        return PhysicalPixelSizes(z, y, x)

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -694,7 +694,7 @@ class Reader(ABC):
         We currently do not handle unit attachment to these values. Please see the file
         metadata for unit information.
         """
-        return PhysicalPixelSizes(1.0, 1.0, 1.0)
+        return PhysicalPixelSizes(None, None, None)
 
     def get_mosaic_tile_position(
         self, mosaic_tile_index: int

--- a/aicsimageio/tests/image_container_test_utils.py
+++ b/aicsimageio/tests/image_container_test_utils.py
@@ -52,7 +52,9 @@ def run_image_container_checks(
     expected_dtype: np.dtype,
     expected_dims_order: str,
     expected_channel_names: Optional[List[str]],
-    expected_physical_pixel_sizes: Tuple[float, float, float],
+    expected_physical_pixel_sizes: Tuple[
+        Optional[float], Optional[float], Optional[float]
+    ],
     expected_metadata_type: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]],
 ) -> Union[AICSImage, Reader]:
     """
@@ -143,7 +145,9 @@ def run_image_file_checks(
     expected_dtype: np.dtype,
     expected_dims_order: str,
     expected_channel_names: Optional[List[str]],
-    expected_physical_pixel_sizes: Tuple[float, float, float],
+    expected_physical_pixel_sizes: Tuple[
+        Optional[float], Optional[float], Optional[float]
+    ],
     expected_metadata_type: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]],
 ) -> Union[AICSImage, Reader]:
     # Init container

--- a/aicsimageio/tests/readers/test_array_like_reader.py
+++ b/aicsimageio/tests/readers/test_array_like_reader.py
@@ -849,7 +849,7 @@ def test_arraylike_reader(
         expected_dtype=np.dtype(np.float64),
         expected_dims_order=expected_dims,
         expected_channel_names=expected_channel_names,
-        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+        expected_physical_pixel_sizes=(None, None, None),
         # we allow both None and Dict because the user can pass an already initialized
         # xarray DataArray which has metadata as a dict
         expected_metadata_type=(

--- a/aicsimageio/tests/readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/test_default_reader.py
@@ -70,7 +70,7 @@ def test_default_reader(
         expected_dtype=np.dtype(np.uint8),
         expected_dims_order=expected_dims_order,
         expected_channel_names=None,
-        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+        expected_physical_pixel_sizes=(None, None, None),
         expected_metadata_type=dict,
     )
 

--- a/aicsimageio/tests/readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/test_lif_reader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import xml.etree.ElementTree as ET
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import pytest
@@ -37,7 +37,7 @@ from ..image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"],
-            (1.0, 3.076923076923077, 3.076923076923077),
+            (None, 3.076923076923077, 3.076923076923077),
         ),
         (
             "s_1_t_4_c_2_z_1.lif",
@@ -47,7 +47,7 @@ from ..image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray--TL-PH--EMP_BF", "Green--FLUO--GFP"],
-            (1.0, 2.9485556406398508, 2.9485556406398508),
+            (None, 2.9485556406398508, 2.9485556406398508),
         ),
         (
             "tiled.lif",
@@ -57,7 +57,7 @@ from ..image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_MOSAIC_TILES,
             ["Gray", "Red", "Green", "Cyan"],
-            (1.0, 4.984719055966396, 4.984719055966396),
+            (None, 4.984719055966396, 4.984719055966396),
         ),
         pytest.param(
             "example.txt",
@@ -92,7 +92,9 @@ def test_lif_reader(
     expected_dtype: np.dtype,
     expected_dims_order: str,
     expected_channel_names: List[str],
-    expected_physical_pixel_sizes: Tuple[float, float, float],
+    expected_physical_pixel_sizes: Tuple[
+        Optional[float], Optional[float], Optional[float]
+    ],
 ) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, host)

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -37,7 +37,7 @@ from ..image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Bright"],
-            (1.0, 1.0833333333333333, 1.0833333333333333),
+            (None, 1.0833333333333333, 1.0833333333333333),
         ),
         (
             "s_1_t_1_c_10_z_1.ome.tiff",
@@ -47,7 +47,7 @@ from ..image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             [f"C:{i}" for i in range(10)],  # This is the actual metadata
-            (1.0, 1.0, 1.0),
+            (None, None, None),
         ),
         (
             # This is actually an OME-TIFF file
@@ -60,7 +60,7 @@ from ..image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0", "Channel:0:1"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -335,7 +335,7 @@ def test_multi_scene_ome_tiff_reader(
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["EGFP", "mCher", "PGC"],
-            (1.0, 0.9082107048835328, 0.9082107048835328),
+            (None, 0.9082107048835328, 0.9082107048835328),
         ),
         (
             "variable_scene_shape_first_scene_pyramid.ome.tiff",
@@ -345,7 +345,7 @@ def test_multi_scene_ome_tiff_reader(
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:1:0"],
-            (1.0, 0.9082107048835328, 0.9082107048835328),
+            (None, 0.9082107048835328, 0.9082107048835328),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -174,7 +174,7 @@ def test_tiff_reader(
         expected_dtype=expected_dtype,
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
-        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+        expected_physical_pixel_sizes=(None, None, None),
         expected_metadata_type=str,
     )
 
@@ -273,6 +273,6 @@ def test_micromanager_ome_tiff_binary_file() -> None:
         # because we swap the dimensions into "standard" order
         expected_dims_order="TZCYX",
         expected_channel_names=["Channel:0:0", "Channel:0:1", "Channel:0:2"],
-        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+        expected_physical_pixel_sizes=(None, None, None),
         expected_metadata_type=str,
     )

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -53,7 +53,7 @@ from .image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             dict,
         ),
         (
@@ -64,7 +64,7 @@ from .image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             dict,
         ),
         (
@@ -75,7 +75,7 @@ from .image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             dict,
         ),
         #######################################################################
@@ -88,7 +88,7 @@ from .image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             str,
         ),
         (
@@ -99,7 +99,7 @@ from .image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             str,
         ),
         #######################################################################
@@ -112,7 +112,7 @@ from .image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             [f"C:{i}" for i in range(10)],  # This is the actual metadata
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             OME,
         ),
         (
@@ -126,7 +126,7 @@ from .image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0", "Channel:0:1"],
-            (1.0, 1.0, 1.0),
+            (None, None, None),
             OME,
         ),
         (
@@ -168,7 +168,7 @@ from .image_container_test_utils import (
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray--TL-PH--EMP_BF", "Green--FLUO--GFP"],
-            (1.0, 2.9485556406398508, 2.9485556406398508),
+            (None, 2.9485556406398508, 2.9485556406398508),
             ET.Element,
         ),
         (
@@ -179,7 +179,7 @@ from .image_container_test_utils import (
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray", "Red", "Green", "Cyan"],
-            (1.0, 4.984719055966396, 4.984719055966396),
+            (None, 4.984719055966396, 4.984719055966396),
             ET.Element,
         ),
         #######################################################################
@@ -601,7 +601,7 @@ def test_aicsimage_from_array(
         expected_dtype=np.dtype(np.float64),
         expected_dims_order=expected_dims,
         expected_channel_names=expected_channel_names,
-        expected_physical_pixel_sizes=(1.0, 1.0, 1.0),
+        expected_physical_pixel_sizes=(None, None, None),
         # we allow both None and Dict because the user can pass an already initialized
         # xarray DataArray which has metadata as a dict
         expected_metadata_type=(

--- a/aicsimageio/tests/writers/test_ome_tiff_writer.py
+++ b/aicsimageio/tests/writers/test_ome_tiff_writer.py
@@ -291,8 +291,14 @@ def test_ome_tiff_writer_multiscene(
 
 
 @pytest.mark.parametrize(
-    "array_data, write_dim_order, pixel_size, channel_names, channel_colors, "
-    "read_shapes, read_dim_order, expected_pixel_size",
+    "array_data, "
+    "write_dim_order, "
+    "pixel_size, "
+    "channel_names, "
+    "channel_colors, "
+    "read_shapes, "
+    "read_dim_order, "
+    "expected_pixel_size",
     [
         (
             [np.random.rand(5, 16, 16)],
@@ -303,6 +309,16 @@ def test_ome_tiff_writer_multiscene(
             [(1, 1, 5, 16, 16)],
             ["TCZYX"],
             [(1.0, 2.0, 3.0)],
+        ),
+        (
+            [np.random.rand(5, 16, 16)],
+            None,
+            [types.PhysicalPixelSizes(None, 2.0, 3.0)],
+            ["C0"],
+            None,
+            [(1, 1, 5, 16, 16)],
+            ["TCZYX"],
+            [(None, 2.0, 3.0)],
         ),
         (
             [np.random.rand(2, 16, 16), np.random.rand(2, 12, 12)],
@@ -320,7 +336,7 @@ def test_ome_tiff_writer_multiscene(
     ],
 )
 @pytest.mark.parametrize("filename", ["e.ome.tiff"])
-def test_ome_tiff_writer_channel_names(
+def test_ome_tiff_writer_common_metadata(
     array_data: List[types.ArrayLike],
     write_dim_order: List[Optional[str]],
     pixel_size: List[types.PhysicalPixelSizes],

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -3,7 +3,7 @@
 
 from abc import ABCMeta
 from pathlib import Path
-from typing import List, NamedTuple, Union
+from typing import List, NamedTuple, Optional, Union
 
 import dask.array as da
 import numpy as np
@@ -23,6 +23,6 @@ ReaderType = ABCMeta
 
 # Image Utility Types
 class PhysicalPixelSizes(NamedTuple):
-    Z: float
-    Y: float
-    X: float
+    Z: Optional[float]
+    Y: Optional[float]
+    X: Optional[float]

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -204,7 +204,7 @@ class OmeTiffWriter(Writer):
             physical_pixel_sizes = [physical_pixel_sizes] * num_images
         elif physical_pixel_sizes is None:
             physical_pixel_sizes = [
-                types.PhysicalPixelSizes(1.0, 1.0, 1.0)
+                types.PhysicalPixelSizes(None, None, None)
             ] * num_images
         if channel_names is None or isinstance(channel_names[0], int):
             channel_names = [channel_names] * num_images  # type: ignore
@@ -419,7 +419,7 @@ class OmeTiffWriter(Writer):
         dimension_order: str = DEFAULT_DIMENSION_ORDER,
         image_name: Optional[str] = "I0",
         physical_pixel_sizes: types.PhysicalPixelSizes = types.PhysicalPixelSizes(
-            1.0, 1.0, 1.0
+            None, None, None
         ),
         channel_names: List[str] = None,
         channel_colors: List[int] = None,
@@ -563,7 +563,7 @@ class OmeTiffWriter(Writer):
             image_name = [None] * num_images
         if physical_pixel_sizes is None:
             physical_pixel_sizes = [
-                types.PhysicalPixelSizes(1.0, 1.0, 1.0)
+                types.PhysicalPixelSizes(None, None, None)
             ] * num_images
         if channel_colors is None:
             channel_colors = [None] * num_images

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -90,7 +90,6 @@ class OmeTiffWriter(Writer):
                 List[types.PhysicalPixelSizes]]]
             List of numbers representing the physical pixel sizes in Z, Y, X in microns
             Default: None
-            If None is given, pixel size will be (1.0, 1.0, 1.0) for all images
         channel_colors: Optional[Union[List[int], List[Optional[List[int]]]]]
             List of rgb color values per channel. These must be values compatible with
             the OME spec.


### PR DESCRIPTION
## Description

In discussing pixel size handling and coordinate planes, Dan and I came to the agreement that because the OME metadata model allows for pixel sizes to be optional, then we should make our defaults for pixel size be optional as well.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #238 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
