### PR TITLE
bugfix/support-rgb-mosaic-czi

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -584,7 +584,6 @@ class CziReader(Reader):
         #   contiguous regions of interests in a mosaic image).
 
         # Store the mosaic array shape
-        # Store the chunk shape
         arr_shape_list = []
 
         ordered_dims_present = [
@@ -600,11 +599,11 @@ class CziReader(Reader):
             if dim is DimensionNames.SpatialX:
                 arr_shape_list.append(mosaic_bbox.w)
             if dim is DimensionNames.Samples:
-                arr_shape_list.append(data_dims_shape[dim][1])
+                arr_shape_list.append(data_dims_shape[CZI_SAMPLES_DIM_CHAR][1])
 
         ans = None
         if isinstance(data, da.Array):
-            ans = da.empty(
+            ans = da.zeros(
                 shape=tuple(arr_shape_list),
                 dtype=data.dtype,
             )
@@ -616,7 +615,6 @@ class CziReader(Reader):
             tile_dims = tile_info.dimension_coordinates
             tile_dims.pop(CZI_SCENE_DIM_CHAR, None)
             tile_dims.pop(CZI_BLOCK_DIM_CHAR, None)
-            # *** TODO: Need to map A to S here too
             data_indexes = [
                 tile_dims[t_dim]
                 for t_dim in tile_dims.keys()
@@ -696,15 +694,17 @@ class CziReader(Reader):
 
             # Add expanded Y and X coords
             if self.physical_pixel_sizes.Y is not None:
+                dim_y_index = dims.index(DimensionNames.SpatialY)
                 coords[DimensionNames.SpatialY] = np.arange(
                     0,
-                    stitched.shape[-2] * self.physical_pixel_sizes.Y,
+                    stitched.shape[dim_y_index] * self.physical_pixel_sizes.Y,
                     self.physical_pixel_sizes.Y,
                 )
             if self.physical_pixel_sizes.X is not None:
+                dim_x_index = dims.index(DimensionNames.SpatialX)
                 coords[DimensionNames.SpatialX] = np.arange(
                     0,
-                    stitched.shape[-1] * self.physical_pixel_sizes.X,
+                    stitched.shape[dim_x_index] * self.physical_pixel_sizes.X,
                     self.physical_pixel_sizes.X,
                 )
 


### PR DESCRIPTION
## Description

Was writting up some release highlights and wanted to show off CZI mosaic stitching. Along the way I figured I should try to find a massive mosaic CZI to test and show off with. Well I found one and it was RGB so had to patch some minor bugs.

If you would like to try out this branch locally that is all good here is what I did to test out the speed of pulling chunks of the mosaic:

I found this file for testing: https://forum.image.sc/t/opening-large-czi-files-tiled-tiff-files/8648

```python
In [1]: from aicsimageio import AICSImage

In [2]: img = AICSImage("/home/maxfield/Downloads/2017_08_03__0006.czi")

In [3]: %timeit img.dask_data[:, :, :, 700:1400, 1000:2000].compute().shape
322 ms ± 6.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %time img.data.shape
CPU times: user 23.7 s, sys: 1.12 s, total: 24.8 s
Wall time: 3.78 s
Out[4]: (1, 1, 1, 24968, 26074, 3)
```

This was just a sanity check to ensure that we really are only pulling selected tiles out as needed.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.

I don't believe that the file I found and used for testing locally is "open access" and so don't want to store it on our bucket.
If we ever get a mosaic RGB CZI we can add the file to the param suite.

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
