### PR TITLE
bugfix/coords-and-floating-point-math-and-czi-scene-naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ clean:  ## clean all build, python, and testing files
 build: ## run tox / run tests and lint
 	tox
 
+test-local: ## run tests but only against local files
+	pytest aicsimageio -k "not REMOTE"
+
 gen-docs: ## generate Sphinx HTML documentation, including API docs
 	rm -f docs/aicsimageio*.rst
 	rm -f docs/modules.rst

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -463,6 +463,11 @@ class CziReader(Reader):
             scale_z = float(scale_ze.text.split("E")[0])
 
         # Handle Spatial Dimensions
+        # In general, we have learned that floating point math is hard....
+        # This block of code used to use `np.arange` with floats as parameters and
+        # it was causing errors. To solve, we generate the range with ints and then
+        # multiply by a float across the entire range to get the proper coords.
+        # See: https://github.com/AllenCellModeling/aicsimageio/issues/249
         for scale, dim_name in [
             (scale_z, DimensionNames.SpatialZ),
             (scale_y, DimensionNames.SpatialY),

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -133,6 +133,16 @@ class CziReader(Reader):
                 xpath_str = "./Metadata/Information/Image/Dimensions/S/Scenes/Scene"
                 meta_scenes = czi.meta.findall(xpath_str)
                 scene_names: List[str] = []
+
+                # Some "scenes" may have the same name but each scene has a sub-scene
+                # "Shape" with a name.
+                #
+                # An example of this is where someone images a 96 well plate with each 
+                # well being it's own scene but they name every scene the samevalue.
+                # The sub-scene "Shape" elements have actual names of each well.
+                #
+                # If we didn't do this, the produced list would have 96 of the same
+                # string name making it impossible to switch scenes.
                 for meta_scene in meta_scenes:
                     shape = meta_scene.find("Shape")
                     if shape is not None:

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -458,10 +458,13 @@ class CziReader(Reader):
             (scale_x, DimensionNames.SpatialX),
         ]:
             if scale is not None and dim_name in dims_shape:
-                coords[dim_name] = np.arange(
-                    0,
-                    dims_shape[dim_name][1] * scale,
-                    scale,
+                dim_size = dims_shape[dim_name][1] - dims_shape[dim_name][0]
+                coords[dim_name] = (
+                    np.arange(
+                        0,
+                        dim_size,
+                    )
+                    * scale
                 )
 
         # Time
@@ -695,17 +698,21 @@ class CziReader(Reader):
             # Add expanded Y and X coords
             if self.physical_pixel_sizes.Y is not None:
                 dim_y_index = dims.index(DimensionNames.SpatialY)
-                coords[DimensionNames.SpatialY] = np.arange(
-                    0,
-                    stitched.shape[dim_y_index] * self.physical_pixel_sizes.Y,
-                    self.physical_pixel_sizes.Y,
+                coords[DimensionNames.SpatialY] = (
+                    np.arange(
+                        0,
+                        stitched.shape[dim_y_index],
+                    )
+                    * self.physical_pixel_sizes.Y
                 )
             if self.physical_pixel_sizes.X is not None:
                 dim_x_index = dims.index(DimensionNames.SpatialX)
-                coords[DimensionNames.SpatialX] = np.arange(
-                    0,
-                    stitched.shape[dim_x_index] * self.physical_pixel_sizes.X,
-                    self.physical_pixel_sizes.X,
+                coords[DimensionNames.SpatialX] = (
+                    np.arange(
+                        0,
+                        stitched.shape[dim_x_index],
+                    )
+                    * self.physical_pixel_sizes.X
                 )
 
             attrs = copy(self.xarray_dask_data.attrs)

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -132,7 +132,18 @@ class CziReader(Reader):
                 czi = CziFile(open_resource)
                 xpath_str = "./Metadata/Information/Image/Dimensions/S/Scenes/Scene"
                 meta_scenes = czi.meta.findall(xpath_str)
-                scene_names = [x.get("Name") for x in meta_scenes]
+                scene_names: List[str] = []
+                for meta_scene in meta_scenes:
+                    shape = meta_scene.find("Shape")
+                    if shape is not None:
+                        shape_name = shape.get("Name")
+                        scene_name = meta_scene.get("Name")
+                        combined_scene_name = f"{scene_name}-{shape_name}"
+                    else:
+                        combined_scene_name = meta_scene.get("Name")
+
+                    scene_names.append(combined_scene_name)
+
                 # If the scene is implicit just assign it name Scene:0
                 if len(scene_names) < 1:
                     scene_names = [metadata.utils.generate_ome_image_id(0)]

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -137,7 +137,7 @@ class CziReader(Reader):
                 # Some "scenes" may have the same name but each scene has a sub-scene
                 # "Shape" with a name.
                 #
-                # An example of this is where someone images a 96 well plate with each 
+                # An example of this is where someone images a 96 well plate with each
                 # well being it's own scene but they name every scene the samevalue.
                 # The sub-scene "Shape" elements have actual names of each well.
                 #

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -382,30 +382,38 @@ class LifReader(Reader):
 
         # Handle Spatial Dimensions
         if scale_z is not None:
-            coords[DimensionNames.SpatialZ] = np.arange(
-                0,
-                image_short_info["dims"].z * scale_z,
-                scale_z,
+            coords[DimensionNames.SpatialZ] = (
+                np.arange(
+                    0,
+                    image_short_info["dims"].z,
+                )
+                * scale_z
             )
         if scale_y is not None:
-            coords[DimensionNames.SpatialY] = np.arange(
-                0,
-                image_short_info["dims"].y * scale_y,
-                scale_y,
+            coords[DimensionNames.SpatialY] = (
+                np.arange(
+                    0,
+                    image_short_info["dims"].y,
+                )
+                * scale_y
             )
         if scale_x is not None:
-            coords[DimensionNames.SpatialX] = np.arange(
-                0,
-                image_short_info["dims"].x * scale_x,
-                scale_x,
+            coords[DimensionNames.SpatialX] = (
+                np.arange(
+                    0,
+                    image_short_info["dims"].x,
+                )
+                * scale_x
             )
 
         # Time
         if scale_t is not None:
-            coords[DimensionNames.Time] = np.arange(
-                0,
-                image_short_info["dims"].t * scale_t,
-                scale_t,
+            coords[DimensionNames.Time] = (
+                np.arange(
+                    0,
+                    image_short_info["dims"].t,
+                )
+                * scale_t
             )
 
         # Create physical pixal sizes
@@ -605,16 +613,20 @@ class LifReader(Reader):
         # Add expanded Y and X coords
         scale_x, scale_y, _, _ = selected_scene.info["scale"]
         if scale_y is not None:
-            coords[DimensionNames.SpatialY] = np.arange(
-                0,
-                stitched.shape[-2] * scale_y,
-                scale_y,
+            coords[DimensionNames.SpatialY] = (
+                np.arange(
+                    0,
+                    stitched.shape[-2],
+                )
+                * scale_y
             )
         if scale_x is not None:
-            coords[DimensionNames.SpatialX] = np.arange(
-                0,
-                stitched.shape[-1] * scale_x,
-                scale_x,
+            coords[DimensionNames.SpatialX] = (
+                np.arange(
+                    0,
+                    stitched.shape[-1],
+                )
+                * scale_x
             )
 
         attrs = copy(self.xarray_dask_data.attrs)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -3,7 +3,7 @@
 
 import xml.etree.ElementTree as ET
 from copy import copy
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Hashable, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -349,7 +349,7 @@ class LifReader(Reader):
         xml: ET.Element, image_short_info: Dict[str, Any], scene_index: int
     ) -> Tuple[Dict[str, Any], types.PhysicalPixelSizes]:
         # Create coord dict
-        coords = {}
+        coords: Dict[str, Any] = {}
 
         # Get all images
         img_sets = xml.findall(".//Image")
@@ -381,44 +381,23 @@ class LifReader(Reader):
         scale_x, scale_y, scale_z, scale_t = image_short_info["scale"]
 
         # Handle Spatial Dimensions
-        # In general, we have learned that floating point math is hard....
-        # This block of code used to use `np.arange` with floats as parameters and
-        # it was causing errors. To solve, we generate the range with ints and then
-        # multiply by a float across the entire range to get the proper coords.
-        # See: https://github.com/AllenCellModeling/aicsimageio/issues/249
         if scale_z is not None:
-            coords[DimensionNames.SpatialZ] = (
-                np.arange(
-                    0,
-                    image_short_info["dims"].z,
-                )
-                * scale_z
+            coords[DimensionNames.SpatialZ] = Reader._generate_coord_array(
+                0, image_short_info["dims"].z, scale_z
             )
         if scale_y is not None:
-            coords[DimensionNames.SpatialY] = (
-                np.arange(
-                    0,
-                    image_short_info["dims"].y,
-                )
-                * scale_y
+            coords[DimensionNames.SpatialY] = Reader._generate_coord_array(
+                0, image_short_info["dims"].y, scale_y
             )
         if scale_x is not None:
-            coords[DimensionNames.SpatialX] = (
-                np.arange(
-                    0,
-                    image_short_info["dims"].x,
-                )
-                * scale_x
+            coords[DimensionNames.SpatialX] = Reader._generate_coord_array(
+                0, image_short_info["dims"].x, scale_x
             )
 
         # Time
         if scale_t is not None:
-            coords[DimensionNames.Time] = (
-                np.arange(
-                    0,
-                    image_short_info["dims"].t,
-                )
-                * scale_t
+            coords[DimensionNames.Time] = Reader._generate_coord_array(
+                0, image_short_info["dims"].t, scale_t
             )
 
         # Create physical pixal sizes
@@ -604,7 +583,7 @@ class LifReader(Reader):
         dims = [
             d for d in self.xarray_dask_data.dims if d is not DimensionNames.MosaicTile
         ]
-        coords = {
+        coords: Dict[Hashable, Any] = {
             d: v
             for d, v in self.xarray_dask_data.coords.items()
             if d
@@ -618,20 +597,12 @@ class LifReader(Reader):
         # Add expanded Y and X coords
         scale_x, scale_y, _, _ = selected_scene.info["scale"]
         if scale_y is not None:
-            coords[DimensionNames.SpatialY] = (
-                np.arange(
-                    0,
-                    stitched.shape[-2],
-                )
-                * scale_y
+            coords[DimensionNames.SpatialY] = Reader._generate_coord_array(
+                0, stitched.shape[-2], scale_y
             )
         if scale_x is not None:
-            coords[DimensionNames.SpatialX] = (
-                np.arange(
-                    0,
-                    stitched.shape[-1],
-                )
-                * scale_x
+            coords[DimensionNames.SpatialX] = Reader._generate_coord_array(
+                0, stitched.shape[-1], scale_x
             )
 
         attrs = copy(self.xarray_dask_data.attrs)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -381,6 +381,11 @@ class LifReader(Reader):
         scale_x, scale_y, scale_z, scale_t = image_short_info["scale"]
 
         # Handle Spatial Dimensions
+        # In general, we have learned that floating point math is hard....
+        # This block of code used to use `np.arange` with floats as parameters and
+        # it was causing errors. To solve, we generate the range with ints and then
+        # multiply by a float across the entire range to get the proper coords.
+        # See: https://github.com/AllenCellModeling/aicsimageio/issues/249
         if scale_z is not None:
             coords[DimensionNames.SpatialZ] = (
                 np.arange(

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -223,6 +223,11 @@ class OmeTiffReader(TiffReader):
                 )
 
         # Handle Spatial Dimensions
+        # In general, we have learned that floating point math is hard....
+        # This block of code used to use `np.arange` with floats as parameters and
+        # it was causing errors. To solve, we generate the range with ints and then
+        # multiply by a float across the entire range to get the proper coords.
+        # See: https://github.com/AllenCellModeling/aicsimageio/issues/249
         if scene_meta.pixels.physical_size_z is not None:
             coords[DimensionNames.SpatialZ] = (
                 np.arange(

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -200,10 +200,12 @@ class OmeTiffReader(TiffReader):
         # Time
         # If global linear timescale we can np.linspace with metadata
         if scene_meta.pixels.time_increment is not None:
-            coords[DimensionNames.Time] = np.arange(
-                0,
-                scene_meta.pixels.size_t * scene_meta.pixels.time_increment,
-                scene_meta.pixels.time_increment,
+            coords[DimensionNames.Time] = (
+                np.arange(
+                    0,
+                    scene_meta.pixels.size_t,
+                )
+                * scene_meta.pixels.time_increment
             )
         # If non global linear timescale, we need to create an array of every plane
         # time value
@@ -222,24 +224,30 @@ class OmeTiffReader(TiffReader):
 
         # Handle Spatial Dimensions
         if scene_meta.pixels.physical_size_z is not None:
-            coords[DimensionNames.SpatialZ] = np.arange(
-                0,
-                scene_meta.pixels.size_z * scene_meta.pixels.physical_size_z,
-                scene_meta.pixels.physical_size_z,
+            coords[DimensionNames.SpatialZ] = (
+                np.arange(
+                    0,
+                    scene_meta.pixels.size_z,
+                )
+                * scene_meta.pixels.physical_size_z
             )
 
         if scene_meta.pixels.physical_size_y is not None:
-            coords[DimensionNames.SpatialY] = np.arange(
-                0,
-                scene_meta.pixels.size_y * scene_meta.pixels.physical_size_y,
-                scene_meta.pixels.physical_size_y,
+            coords[DimensionNames.SpatialY] = (
+                np.arange(
+                    0,
+                    scene_meta.pixels.size_y,
+                )
+                * scene_meta.pixels.physical_size_y
             )
 
         if scene_meta.pixels.physical_size_x is not None:
-            coords[DimensionNames.SpatialX] = np.arange(
-                0,
-                scene_meta.pixels.size_x * scene_meta.pixels.physical_size_x,
-                scene_meta.pixels.physical_size_x,
+            coords[DimensionNames.SpatialX] = (
+                np.arange(
+                    0,
+                    scene_meta.pixels.size_x,
+                )
+                * scene_meta.pixels.physical_size_x
             )
 
         return dims, coords

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -200,12 +200,8 @@ class OmeTiffReader(TiffReader):
         # Time
         # If global linear timescale we can np.linspace with metadata
         if scene_meta.pixels.time_increment is not None:
-            coords[DimensionNames.Time] = (
-                np.arange(
-                    0,
-                    scene_meta.pixels.size_t,
-                )
-                * scene_meta.pixels.time_increment
+            coords[DimensionNames.Time] = TiffReader._generate_coord_array(
+                0, scene_meta.pixels.size_t, scene_meta.pixels.time_increment
             )
         # If non global linear timescale, we need to create an array of every plane
         # time value
@@ -223,36 +219,17 @@ class OmeTiffReader(TiffReader):
                 )
 
         # Handle Spatial Dimensions
-        # In general, we have learned that floating point math is hard....
-        # This block of code used to use `np.arange` with floats as parameters and
-        # it was causing errors. To solve, we generate the range with ints and then
-        # multiply by a float across the entire range to get the proper coords.
-        # See: https://github.com/AllenCellModeling/aicsimageio/issues/249
         if scene_meta.pixels.physical_size_z is not None:
-            coords[DimensionNames.SpatialZ] = (
-                np.arange(
-                    0,
-                    scene_meta.pixels.size_z,
-                )
-                * scene_meta.pixels.physical_size_z
+            coords[DimensionNames.SpatialZ] = TiffReader._generate_coord_array(
+                0, scene_meta.pixels.size_z, scene_meta.pixels.physical_size_z
             )
-
         if scene_meta.pixels.physical_size_y is not None:
-            coords[DimensionNames.SpatialY] = (
-                np.arange(
-                    0,
-                    scene_meta.pixels.size_y,
-                )
-                * scene_meta.pixels.physical_size_y
+            coords[DimensionNames.SpatialY] = TiffReader._generate_coord_array(
+                0, scene_meta.pixels.size_y, scene_meta.pixels.physical_size_y
             )
-
         if scene_meta.pixels.physical_size_x is not None:
-            coords[DimensionNames.SpatialX] = (
-                np.arange(
-                    0,
-                    scene_meta.pixels.size_x,
-                )
-                * scene_meta.pixels.physical_size_x
+            coords[DimensionNames.SpatialX] = TiffReader._generate_coord_array(
+                0, scene_meta.pixels.size_x, scene_meta.pixels.physical_size_x
             )
 
         return dims, coords

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -3,7 +3,7 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -679,6 +679,37 @@ class Reader(ABC):
             return list(self.xarray_dask_data[DimensionNames.Channel].values)
 
         return None
+
+    @staticmethod
+    def _generate_coord_array(
+        start: Union[int, float], stop: Union[int, float], step_size: Union[int, float]
+    ) -> np.ndarray:
+        """
+        Generate an np.ndarray for coordinate values.
+
+        Parameters
+        ----------
+        start: Union[int, float]
+            The start value.
+        stop: Union[int, float]
+            The stop value.
+        step_size: Union[int, float]
+            How large each step should be.
+
+        Returns
+        -------
+        coords: np.ndarray
+            The coordinate array.
+
+        Notes
+        -----
+        In general, we have learned that floating point math is hard....
+        This block of code used to use `np.arange` with floats as parameters and
+        it was causing errors. To solve, we generate the range with ints and then
+        multiply by a float across the entire range to get the proper coords.
+        See: https://github.com/AllenCellModeling/aicsimageio/issues/249
+        """
+        return np.arange(start, stop) * step_size
 
     @property
     def physical_pixel_sizes(self) -> PhysicalPixelSizes:


### PR DESCRIPTION
## Description

Resolving all issues found in the file provided in #249 

1. The floating point math in `np.arange`, basically, across the board it is "safer" to create the array with integers and then multiply by the physical pixel size rather than creating the coord array with the start and stop as floats.
2. The provided file was a good test case for 96 scenes (or just "lots" of scenes) and when I tried to test I found that the scene names were all the same.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #249 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
