### PR TITLE
docs/fix-physical-pixel-sizes-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ from aicsimageio import AICSImage
 img = AICSImage("my_file.tiff")  # selects the first scene found
 img.metadata  # returns the metadata object for this file format (XML, JSON, etc.)
 img.channel_names  # returns a list of string channel names found in the metadata
-img.physical_pixel_size.Z  # returns the Z dimension pixel size as found in the metadata
-img.physical_pixel_size.Y  # returns the Y dimension pixel size as found in the metadata
-img.physical_pixel_size.X  # returns the X dimension pixel size as found in the metadata
+img.physical_pixel_sizes.Z  # returns the Z dimension pixel size as found in the metadata
+img.physical_pixel_sizes.Y  # returns the Y dimension pixel size as found in the metadata
+img.physical_pixel_sizes.X  # returns the X dimension pixel size as found in the metadata
 ```
 
 ### Xarray Coordinate Plane Attachment


### PR DESCRIPTION
## Description

I got a very lovely message on image.sc:

> Hi Jackson!
>
> I’ve been using AICSimageio for a while now and its fantastic as I often work with both .lifs and .czi!
>
> I kept running into problems with not being able to get physical_pixel_size values with .czi files.
>
>>    img.physical_pixel_size.Z # returns the Z dimension pixel size as found in the metadata
>>    img.physical_pixel_size.Y # returns the Y dimension pixel size as found in the metadata
>>    img.physical_pixel_size.X # returns the X dimension pixel size as found in the metadata
>
> I finally figured it out just now from going through the czi_reader.py in the latest release that its actually `img.physical_pixel_sizes`

> Just wanted to let you know that it would be a quick fix to either update the docs or change that in the next release!

So this just updates the docs to be accurate.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
