### PR TITLE
docs/add-missing-czi-reading-to-mosaic-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Read stitched data or single tiles as a dimension.
 Readers that support mosaic tile stitching:
 
 -   `LifReader`
+-   `CziReader`
 
 #### AICSImage
 


### PR DESCRIPTION
## Description

Noted during #255, `CziReader` wasn't listed as supported for mosaic tile stitching.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
