### PR TITLE
fix channel_names array expansion test

### DIFF
--- a/aicsimageio/tests/writers/test_ome_tiff_writer.py
+++ b/aicsimageio/tests/writers/test_ome_tiff_writer.py
@@ -301,6 +301,26 @@ def test_ome_tiff_writer_multiscene(
     "expected_pixel_size",
     [
         (
+            np.random.rand(1, 2, 5, 16, 16),
+            "TCZYX",
+            None,
+            ["C0", "C1"],
+            None,
+            [(1, 2, 5, 16, 16)],
+            ["TCZYX"],
+            [(None, None, None)],
+        ),
+        (
+            [np.random.rand(1, 2, 5, 16, 16), np.random.rand(1, 2, 4, 15, 15)],
+            "TCZYX",
+            None,
+            ["C0", "C1"],
+            None,
+            [(1, 2, 5, 16, 16), (1, 2, 4, 15, 15)],
+            ["TCZYX", "TCZYX"],
+            [(None, None, None), (None, None, None)],
+        ),
+        (
             [np.random.rand(5, 16, 16)],
             None,
             [types.PhysicalPixelSizes(1.0, 2.0, 3.0)],

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -203,7 +203,7 @@ class OmeTiffWriter(Writer):
             physical_pixel_sizes = [
                 types.PhysicalPixelSizes(None, None, None)
             ] * num_images
-        if channel_names is None or isinstance(channel_names[0], int):
+        if channel_names is None or isinstance(channel_names[0], str):
             channel_names = [channel_names] * num_images  # type: ignore
         if channel_colors is None or isinstance(channel_colors[0], int):
             channel_colors = [channel_colors] * num_images  # type: ignore


### PR DESCRIPTION
## Description
Fix #264
Channel names were testing against int, which prevented the array from being expanded properly.
