### PR TITLE
bugfix/missing-tiff-description-tag

### DIFF
--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -444,16 +444,22 @@ class TiffReader(Reader):
                     channel_names=channels,
                 )
 
-                return xr.DataArray(
-                    image_data,
-                    dims=dims,
-                    coords=coords,  # type: ignore
-                    attrs={
+                # Try accepted processed metadata
+                try:
+                    attrs = {
                         constants.METADATA_UNPROCESSED: tiff_tags,
                         constants.METADATA_PROCESSED: tiff_tags[
                             TIFF_IMAGE_DESCRIPTION_TAG_INDEX
                         ].value,
-                    },
+                    }
+                except KeyError:
+                    attrs = {constants.METADATA_UNPROCESSED: tiff_tags}
+
+                return xr.DataArray(
+                    image_data,
+                    dims=dims,
+                    coords=coords,  # type: ignore
+                    attrs=attrs,
                 )
 
     def _read_immediate(self) -> xr.DataArray:
@@ -493,14 +499,20 @@ class TiffReader(Reader):
                     channel_names=channels,
                 )
 
-                return xr.DataArray(
-                    image_data,
-                    dims=dims,
-                    coords=coords,  # type: ignore
-                    attrs={
+                # Try accepted processed metadata
+                try:
+                    attrs = {
                         constants.METADATA_UNPROCESSED: tiff_tags,
                         constants.METADATA_PROCESSED: tiff_tags[
                             TIFF_IMAGE_DESCRIPTION_TAG_INDEX
                         ].value,
-                    },
+                    }
+                except KeyError:
+                    attrs = {constants.METADATA_UNPROCESSED: tiff_tags}
+
+                return xr.DataArray(
+                    image_data,
+                    dims=dims,
+                    coords=coords,  # type: ignore
+                    attrs=attrs,
                 )


### PR DESCRIPTION
## Description

@donovanr's TIFFs are weird and don't have a TIFF description tag (270), so this is to catch that possibility.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #263 

- [ ] Provide relevant tests for your feature or bug fix.

Data is private but mypy succeeds so should be okay! It's nice to know mypy can act as a backup when data is private ngl.

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
