### PR TITLE
feature/allow-set-scene-by-index

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -264,38 +264,31 @@ class AICSImage:
         """
         return self.scenes.index(self.current_scene)
 
-    def set_scene(self, scene_id: str) -> None:
+    def set_scene(self, scene_id: Union[str, int]) -> None:
         """
         Set the operating scene.
 
         Parameters
         ----------
-        scene_id: str
-            The scene id to set as the operating scene.
+        scene_id: Union[str, int]
+            The scene id (if string) or scene index (if integer)
+            to set as the operating scene.
 
         Raises
         ------
         IndexError
-            The provided scene id is not found in the available scene id list
+            The provided scene id or index is not found in the available scene id list.
+        TypeError
+            The provided value wasn't a string (scene id) or integer (scene index).
         """
-        # Only need to run when the scene id is different from current scene
-        if scene_id != self.reader.current_scene:
+        # Update current scene on the base Reader
+        # This clears the base Reader's cache
+        self.reader.set_scene(scene_id)
 
-            # Validate scene id
-            if scene_id not in self.scenes:
-                raise IndexError(
-                    f"Scene id: {scene_id} "
-                    f"is not present in available image scenes: {self.scenes}"
-                )
-
-            # Update current scene on the base Reader
-            # This clears the base Reader's cache
-            self.reader.set_scene(scene_id)
-
-            # Reset the data stored in the AICSImage object
-            self._xarray_dask_data = None
-            self._xarray_data = None
-            self._dims = None
+        # Reset the data stored in the AICSImage object
+        self._xarray_dask_data = None
+        self._xarray_data = None
+        self._dims = None
 
     def _transform_data_array_to_aics_image_standard(
         self,

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -215,7 +215,7 @@ class Reader(ABC):
                 # Update current scene
                 self._current_scene_index = self.scenes.index(scene_id)
 
-                # Reset set for future read
+                # Reset self for future read
                 self._reset_self()
 
         # Handle index

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -41,7 +41,7 @@ class Reader(ABC):
     _dims: Optional[Dimensions] = None
     _metadata: Optional[Any] = None
     _scenes: Optional[Tuple[str, ...]] = None
-    _current_scene: Optional[str] = None
+    _current_scene_index: int = 0
     # Do not default because they aren't used by all readers
     _fs: AbstractFileSystem
     _path: str
@@ -162,10 +162,7 @@ class Reader(ABC):
         scene: str
             The current operating scene.
         """
-        if self._current_scene is None:
-            self._current_scene = self.scenes[0]
-
-        return self._current_scene
+        return self.scenes[self._current_scene_index]
 
     @property
     def current_scene_index(self) -> int:
@@ -175,42 +172,76 @@ class Reader(ABC):
         scene_index: int
             The current operating scene index in the file.
         """
-        return self.scenes.index(self.current_scene)
+        return self._current_scene_index
 
-    def set_scene(self, scene_id: str) -> None:
+    def _reset_self(self) -> None:
+        # Reset the data stored in the Reader object
+        self._xarray_dask_data = None
+        self._xarray_data = None
+        self._mosaic_xarray_dask_data = None
+        self._mosaic_xarray_data = None
+        self._dims = None
+        self._metadata = None
+
+    def set_scene(self, scene_id: Union[str, int]) -> None:
         """
         Set the operating scene.
 
         Parameters
         ----------
-        scene_id: str
-            The scene id to set as the operating scene.
+        scene_id: Union[str, int]
+            The scene id (if string) or scene index (if integer)
+            to set as the operating scene.
 
         Raises
         ------
         IndexError
-            The provided scene id is not found in the available scene id list
+            The provided scene id or index is not found in the available scene id list.
+        TypeError
+            The provided value wasn't a string (scene id) or integer (scene index).
         """
-        # Only need to run when the scene id is different from current scene
-        if scene_id != self.current_scene:
+        # Route to int or str setting
+        if isinstance(scene_id, str):
+            # Only need to run when the scene id is different from current scene
+            if scene_id != self.current_scene:
 
-            # Validate scene id
-            if scene_id not in self.scenes:
-                raise IndexError(
-                    f"Scene id: {scene_id} "
-                    f"is not present in available image scenes: {self.scenes}"
-                )
+                # Validate scene id
+                if scene_id not in self.scenes:
+                    raise IndexError(
+                        f"Scene id: '{scene_id}' "
+                        f"is not present in available image scenes: {self.scenes}"
+                    )
 
-            # Update current scene
-            self._current_scene = scene_id
+                # Update current scene
+                self._current_scene_index = self.scenes.index(scene_id)
 
-            # Reset the data stored in the Reader object
-            self._xarray_dask_data = None
-            self._xarray_data = None
-            self._mosaic_xarray_dask_data = None
-            self._mosaic_xarray_data = None
-            self._dims = None
-            self._metadata = None
+                # Reset set for future read
+                self._reset_self()
+
+        # Handle index
+        elif isinstance(scene_id, int):
+            # Only need to run when scene index is different from current scene
+            if scene_id != self.current_scene_index:
+
+                # Validate scene index
+                if scene_id >= len(self.scenes):
+                    raise IndexError(
+                        f"Scene index: {scene_id} "
+                        f"is greater than the number of available scenes "
+                        f"present in the file."
+                    )
+
+                # Update current scene
+                self._current_scene_index = scene_id
+
+                # Reset set for future read
+                self._reset_self()
+
+        else:
+            raise TypeError(
+                f"Must provide either a string (for scene id) "
+                f"or integer (for scene index). Provided: {scene_id} ({type(scene_id)}."
+            )
 
     @abstractmethod
     def _read_delayed(self) -> xr.DataArray:

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -311,6 +311,21 @@ def test_aicsimage(
             "P1",
             (1, 3, 5, 325, 475),
         ),
+        (
+            "s_3_t_1_c_3_z_5.czi",
+            1,
+            (1, 3, 5, 325, 475),
+            2,
+            (1, 3, 5, 325, 475),
+        ),
+        pytest.param(
+            "s_3_t_1_c_3_z_5.czi",
+            ["this is not a scene id"],
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=TypeError),
+        ),
     ],
 )
 def test_multi_scene_aicsimage(


### PR DESCRIPTION
## Description

Allows setting scene by index. The required a small bit of extra changes where we now store current scene index instead of current scene as the basis for scene management.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #259 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
