### PR TITLE
bugfix/ome-tiff-ome-not-set

### DIFF
--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -137,7 +137,9 @@ class OmeTiffReader(TiffReader):
                 )
 
                 # Get and store scenes
-                self._scenes = tuple(image_meta.id for image_meta in self._ome.images)
+                self._scenes: Tuple[str, ...] = tuple(
+                    image_meta.id for image_meta in self._ome.images
+                )
 
                 # Log a warning stating that if this is a MM OME-TIFF, don't read
                 # many series

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -128,9 +128,17 @@ class OmeTiffReader(TiffReader):
                 self.__class__.__name__, self._path
             )
 
-        # Warn of other behaviors
+        # Get ome-types object and warn of other behaviors
         with self._fs.open(self._path) as open_resource:
             with TiffFile(open_resource) as tiff:
+                # Get and store OME
+                self._ome = self._get_ome(
+                    tiff.pages[0].description, self.clean_metadata
+                )
+
+                # Get and store scenes
+                self._scenes = tuple(image_meta.id for image_meta in self._ome.images)
+
                 # Log a warning stating that if this is a MM OME-TIFF, don't read
                 # many series
                 if tiff.is_micromanager:
@@ -145,16 +153,6 @@ class OmeTiffReader(TiffReader):
 
     @property
     def scenes(self) -> Tuple[str, ...]:
-        if self._scenes is None:
-            with self._fs.open(self._path) as open_resource:
-                with TiffFile(open_resource) as tiff:
-                    self._ome = self._get_ome(
-                        tiff.pages[0].description, self.clean_metadata
-                    )
-                    self._scenes = tuple(
-                        image_meta.id for image_meta in self._ome.images
-                    )
-
         return self._scenes
 
     @staticmethod

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -277,6 +277,28 @@ def test_aicsimage(
 
 
 @pytest.mark.parametrize(
+    "filename, expected_shape",
+    [
+        ("example.png", (1, 1, 1, 800, 537, 4)),
+        ("s_1_t_10_c_3_z_1.tiff", (10, 3, 1, 325, 475)),
+        ("s_1_t_1_c_10_z_1.ome.tiff", (1, 10, 1, 1736, 1776)),
+        ("s_1_t_4_c_2_z_1.lif", (4, 2, 1, 614, 614)),
+        ("RGB-8bit.czi", (1, 1, 1, 624, 924, 3)),
+    ]
+)
+def test_no_scene_prop_access(
+    filename: str,
+    expected_shape: Tuple[int, ...],
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Construct image and check no scene call with property access
+    img = AICSImage(uri)
+    assert img.shape == expected_shape
+
+
+@pytest.mark.parametrize(
     "filename, "
     "first_scene_id, "
     "first_scene_shape, "

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -284,7 +284,7 @@ def test_aicsimage(
         ("s_1_t_1_c_10_z_1.ome.tiff", (1, 10, 1, 1736, 1776)),
         ("s_1_t_4_c_2_z_1.lif", (4, 2, 1, 614, 614)),
         ("RGB-8bit.czi", (1, 1, 1, 624, 924, 3)),
-    ]
+    ],
 )
 def test_no_scene_prop_access(
     filename: str,


### PR DESCRIPTION
## Description

Regression from v4.0.3 -> v4.0.4

During `set_scene` from index changes in #272, we changed how we are setting up the inital `_scenes` storage. This generally didn't affect any readers at all because most readers don't need to inspect scenes to work. `OmeTiffReader` however was doing some metadata setting during scene construction.

This moves it's scene construction and metadata management to the reader init.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #283 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
