### PR TITLE
admin/bump-min-tifffile

### DIFF
--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
+from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
 from ome_types import from_xml
 from ome_types.model.ome import OME
@@ -143,12 +144,13 @@ class OmeTiffReader(TiffReader):
 
                 # Log a warning stating that if this is a MM OME-TIFF, don't read
                 # many series
-                if tiff.is_micromanager:
+                if tiff.is_micromanager and not isinstance(self._fs, LocalFileSystem):
                     log.warning(
-                        "Multi-image (or scene) OME-TIFFs created by MicroManager "
-                        "have limited support for scene API. "
+                        "**Remote reading** (S3, GCS, HTTPS, etc.) of multi-image "
+                        "(or scene) OME-TIFFs created by MicroManager has limited "
+                        "support with the scene API. "
                         "It is recommended to use independent AICSImage or Reader "
-                        "objects for each file instead of the `set_scene` API. "
+                        "objects for each remote file instead of the `set_scene` API. "
                         "Track progress on support here: "
                         "https://github.com/AllenCellModeling/aicsimageio/issues/196"
                     )

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -137,7 +137,9 @@ class OmeTiffReader(TiffReader):
                 )
 
                 # Get and store scenes
-                self._scenes = tuple(image_meta.id for image_meta in self._ome.images)
+                self._scenes: Tuple[str, ...] = tuple(
+                    image_meta.id for image_meta in self._ome.images
+                )
 
                 # Log a warning stating that if this is a MM OME-TIFF, don't read
                 # many series

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -128,9 +128,17 @@ class OmeTiffReader(TiffReader):
                 self.__class__.__name__, self._path
             )
 
-        # Warn of other behaviors
+        # Get ome-types object and warn of other behaviors
         with self._fs.open(self._path) as open_resource:
             with TiffFile(open_resource) as tiff:
+                # Get and store OME
+                self._ome = self._get_ome(
+                    tiff.pages[0].description, self.clean_metadata
+                )
+
+                # Get and store scenes
+                self._scenes = tuple(image_meta.id for image_meta in self._ome.images)
+
                 # Log a warning stating that if this is a MM OME-TIFF, don't read
                 # many series
                 if tiff.is_micromanager:
@@ -145,16 +153,6 @@ class OmeTiffReader(TiffReader):
 
     @property
     def scenes(self) -> Tuple[str, ...]:
-        if self._scenes is None:
-            with self._fs.open(self._path) as open_resource:
-                with TiffFile(open_resource) as tiff:
-                    self._ome = self._get_ome(
-                        tiff.pages[0].description, self.clean_metadata
-                    )
-                    self._scenes = tuple(
-                        image_meta.id for image_meta in self._ome.images
-                    )
-
         return self._scenes
 
     @staticmethod

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -16,7 +16,7 @@ from ome_types import OME
 
 from aicsimageio import AICSImage, dimensions, exceptions, readers, types
 
-from .conftest import LOCAL, get_resource_full_path
+from .conftest import LOCAL, REMOTE, get_resource_full_path
 from .image_container_test_utils import (
     run_image_container_checks,
     run_image_file_checks,
@@ -1124,6 +1124,84 @@ def test_parallel_read(
     # Select data
     out = img.get_image_dask_data(get_dims, **get_specific_dims).compute()
     assert out.shape == expected_shape
+
+    # Shutdown and then safety measure timeout
+    cluster.close()
+    client.close()
+    time.sleep(5)
+
+
+@pytest.mark.parametrize(
+    "filename, "
+    "host, "
+    "first_scene, "
+    "expected_first_chunk_shape, "
+    "second_scene, "
+    "expected_second_chunk_shape",
+    [
+        (
+            "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif",
+            LOCAL,
+            0,
+            (50, 5, 256, 256),
+            1,
+            (50, 5, 256, 256),
+        ),
+        (
+            "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif",
+            LOCAL,
+            1,
+            (50, 5, 256, 256),
+            0,
+            (50, 5, 256, 256),
+        ),
+        pytest.param(
+            "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif",
+            REMOTE,
+            1,  # Start with second scene to trigger error faster
+            (50, 5, 256, 256),
+            0,
+            (50, 5, 256, 256),
+            marks=pytest.mark.raises(exceptions=IndexError),
+        ),
+    ],
+)
+@pytest.mark.parametrize("processes", [True, False])
+def test_parallel_multifile_tiff_read(
+    filename: str,
+    host: str,
+    first_scene: int,
+    expected_first_chunk_shape: Tuple[int, ...],
+    second_scene: int,
+    expected_second_chunk_shape: Tuple[int, ...],
+    processes: bool,
+) -> None:
+    """
+    This test ensures that we can serialize and read 'multi-file multi-scene' formats.
+    See: https://github.com/AllenCellModeling/aicsimageio/issues/196
+
+    We specifically test with a Distributed cluster to ensure that we serialize and
+    read properly from each file.
+    """
+    # Construct full filepath
+    uri = get_resource_full_path(filename, host)
+
+    # Init image
+    img = AICSImage(uri)
+
+    # Init cluster
+    cluster = LocalCluster(processes=processes)
+    client = Client(cluster)
+
+    # Select data
+    img.set_scene(first_scene)
+    first_out = img.get_image_dask_data("TZYX").compute()
+    assert first_out.shape == expected_first_chunk_shape
+
+    # Update scene and select data
+    img.set_scene(second_scene)
+    second_out = img.get_image_dask_data("TZYX").compute()
+    assert second_out.shape == expected_second_chunk_shape
 
     # Shutdown and then safety measure timeout
     cluster.close()

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -277,6 +277,28 @@ def test_aicsimage(
 
 
 @pytest.mark.parametrize(
+    "filename, expected_shape",
+    [
+        ("example.png", (1, 1, 1, 800, 537, 4)),
+        ("s_1_t_10_c_3_z_1.tiff", (10, 3, 1, 325, 475)),
+        ("s_1_t_1_c_10_z_1.ome.tiff", (1, 10, 1, 1736, 1776)),
+        ("s_1_t_4_c_2_z_1.lif", (4, 2, 1, 614, 614)),
+        ("RGB-8bit.czi", (1, 1, 1, 624, 924, 3)),
+    ]
+)
+def test_no_scene_prop_access(
+    filename: str,
+    expected_shape: Tuple[int, ...],
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Construct image and check no scene call with property access
+    img = AICSImage(uri)
+    assert img.shape == expected_shape
+
+
+@pytest.mark.parametrize(
     "filename, "
     "first_scene_id, "
     "first_scene_shape, "

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -284,7 +284,7 @@ def test_aicsimage(
         ("s_1_t_1_c_10_z_1.ome.tiff", (1, 10, 1, 1736, 1776)),
         ("s_1_t_4_c_2_z_1.lif", (4, 2, 1, 614, 614)),
         ("RGB-8bit.czi", (1, 1, 1, 624, 924, 3)),
-    ]
+    ],
 )
 def test_no_scene_prop_access(
     filename: str,

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ requirements = [
     "imagecodecs>=2020.5.30",
     "numpy~=1.16",
     "ome-types~=0.2.4",
-    "tifffile>=2021.2.1",
+    "tifffile>=2021.6.6",
     "toolz~=0.11.0",
     "xarray~=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types


### PR DESCRIPTION
## Description

Thanks to @cgohlke release of `tifffile` 2021.6.6, we can now support **LOCAL** multi-file, multi-scene, micromanager produced files. Remote reads to these still fails but new support is in a general a good thing, especially if we can just bump our `tifffile` dep version.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #280 
Related #196 

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
