### PR TITLE
bugfix/use-dict-of-tiff-tags

### DIFF
--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -331,7 +331,7 @@ class OmeTiffReader(TiffReader):
         with self._fs.open(self._path) as open_resource:
             with TiffFile(open_resource) as tiff:
                 # Get unprocessed metadata from tags
-                tiff_tags = self._get_tiff_tags()
+                tiff_tags = self._get_tiff_tags(tiff)
 
                 # Unpack dims and coords from OME
                 dims, coords = self._get_dims_and_coords_from_ome(
@@ -373,7 +373,7 @@ class OmeTiffReader(TiffReader):
         with self._fs.open(self._path) as open_resource:
             with TiffFile(open_resource) as tiff:
                 # Get unprocessed metadata from tags
-                tiff_tags = self._get_tiff_tags()
+                tiff_tags = self._get_tiff_tags(tiff)
 
                 # Unpack dims and coords from OME
                 dims, coords = self._get_dims_and_coords_from_ome(

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -331,7 +331,7 @@ class OmeTiffReader(TiffReader):
         with self._fs.open(self._path) as open_resource:
             with TiffFile(open_resource) as tiff:
                 # Get unprocessed metadata from tags
-                tiff_tags = self._get_tiff_tags(tiff)
+                tiff_tags = self._get_tiff_tags()
 
                 # Unpack dims and coords from OME
                 dims, coords = self._get_dims_and_coords_from_ome(
@@ -373,7 +373,7 @@ class OmeTiffReader(TiffReader):
         with self._fs.open(self._path) as open_resource:
             with TiffFile(open_resource) as tiff:
                 # Get unprocessed metadata from tags
-                tiff_tags = self._get_tiff_tags(tiff)
+                tiff_tags = self._get_tiff_tags()
 
                 # Unpack dims and coords from OME
                 dims, coords = self._get_dims_and_coords_from_ome(

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -168,15 +168,13 @@ class TiffReader(Reader):
                 # handoff _during_ a read.
                 return arr[retrieve_indices].compute(scheduler="synchronous")
 
-    def _get_tiff_tags(self) -> TiffTags:
-        with self._fs.open(self._path) as open_resource:
-            with TiffFile(open_resource) as tiff:
-                unprocessed_tags = tiff.series[self.current_scene_index].pages[0].tags
+    def _get_tiff_tags(self, tiff: TiffFile) -> TiffTags:
+        unprocessed_tags = tiff.series[self.current_scene_index].pages[0].tags
 
-                # Create dict of tag and value
-                tags: Dict[int, str] = {}
-                for code, tag in unprocessed_tags.items():
-                    tags[code] = tag.value
+        # Create dict of tag and value
+        tags: Dict[int, str] = {}
+        for code, tag in unprocessed_tags.items():
+            tags[code] = tag.value
 
         return tags
 
@@ -438,7 +436,7 @@ class TiffReader(Reader):
                 image_data = self._create_dask_array(tiff, dims)
 
                 # Get unprocessed metadata from tags
-                tiff_tags = self._get_tiff_tags()
+                tiff_tags = self._get_tiff_tags(tiff)
 
                 # Get channel names for this scene or generate
                 channels = self._get_channel_names_for_scene(image_data.shape, dims)
@@ -493,7 +491,7 @@ class TiffReader(Reader):
                 image_data = tiff.series[self.current_scene_index].asarray()
 
                 # Get unprocessed metadata from tags
-                tiff_tags = self._get_tiff_tags()
+                tiff_tags = self._get_tiff_tags(tiff)
 
                 # Get channel names for this scene or generate
                 channels = self._get_channel_names_for_scene(image_data.shape, dims)


### PR DESCRIPTION
## Description

Build failing due to new `tifffile` release that made `TiffTag` objects hold onto a reference to the open file handle. Since we explictly don't want any open file handles so that we can serialize and deserialize the `AICSImage` / `Reader` objects, we can no longer use the `TiffTag` object.

Instead I made a `Dict[int, str]` for the tags:

```
{
    270: "some description",
    ...
}
```

Also, I added Gohlke's recommendation of changing how we are creating the zarr array.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

See conversation here: https://github.com/cgohlke/tifffile/issues/97

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
