### PR TITLE
admin/loosen-any-non-zero-semver-deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,14 +68,14 @@ requirements = [
     "dask[array]>=2021.4.1",
     "fsspec>=2021.4.0",
     "imagecodecs>=2020.5.30",
-    "lxml~=4.6.3",
+    "lxml~=4.6",
     "numpy~=1.16",
-    "ome-types~=0.2.7",
+    "ome-types~=0.2",
     "tifffile>=2021.6.6",
     "toolz~=0.11.0",
     "xarray~=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types
-    "zarr~=2.6.1",
+    "zarr~=2.6",
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ requirements = [
     "numpy~=1.16",
     "ome-types~=0.2",
     "tifffile>=2021.6.6",
-    "toolz~=0.11.0",
     "xarray~=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr~=2.6",


### PR DESCRIPTION
## Description

Got a ping from @joshmoore regarding `zarr` version conflicts posted on image.sc: https://forum.image.sc/t/incompatible-version-of-zarr-for-ome-zarr-and-aicsimageio/56152

We can solve this and other future issues like it by loosening the version pins associated with non-version-zero-sem-ver deps (i.e. 0.x.x).

The format means: `~=a.b` anything greater than or equal to `a.b` and less than `a+1`

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.

Tests are failing because #293 hasn't merged yet.

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
