### PR TITLE
add TOX_WORK_DIR env var option to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = py37, py38, py39, lint
-skip_missing_interpreters = True
+skip_missing_interpreters = true
 toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py37, py38, py39, lint
+skip_missing_interpreters = True
+toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv:lint]
 skip_install = true
@@ -11,7 +13,7 @@ passenv =
     AWS_*
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
-    .[test]
+extras =
+    test
 commands =
     pytest --basetemp={envtmpdir} --cov-report xml --cov-report html --cov=aicsimageio aicsimageio/tests/ {posargs}


### PR DESCRIPTION
## Description

I wonder if you'd be ok with adding this (`toxworkdir={env:TOX_WORK_DIR:.tox}`) to the tox ini file.  tox doesn't work well if you have spaces in the path, and (for better or worse) I put a lot of things in my work dropbox that forces a damn space in the filepath.  This change will respect the environment variable `TOX_WORK_DIR` when creating the tox working dir, and otherwise use the default (`.tox` in the current directory).


## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
