### PR TITLE
feature/add native nd2 reader

### DIFF
--- a/aicsimageio/formats.py
+++ b/aicsimageio/formats.py
@@ -27,6 +27,7 @@ FORMAT_IMPLEMENTATIONS: Dict[str, str] = {
     "tif": "aicsimageio.readers.tiff_reader.TiffReader",
     "czi": "aicsimageio.readers.czi_reader.CziReader",
     "lif": "aicsimageio.readers.lif_reader.LifReader",
+    "nd2": "aicsimageio.readers.nd2_reader.ND2Reader",
     # BASE-IMAGEIO FORMATS (with tifffile + non-existant removals)
     #
     # Pulled using:
@@ -272,7 +273,7 @@ FORMAT_IMPLEMENTATIONS: Dict[str, str] = {
     "mvd2": "aicsimageio.readers.bioformats_reader.BioformatsReader",
     "naf": "aicsimageio.readers.bioformats_reader.BioformatsReader",
     "nd": "aicsimageio.readers.bioformats_reader.BioformatsReader",
-    "nd2": "aicsimageio.readers.bioformats_reader.BioformatsReader",
+    # "nd2": "aicsimageio.readers.bioformats_reader.BioformatsReader",
     "ndpi": "aicsimageio.readers.bioformats_reader.BioformatsReader",
     "ndpis": "aicsimageio.readers.bioformats_reader.BioformatsReader",
     "nii.gz": "aicsimageio.readers.bioformats_reader.BioformatsReader",

--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Tuple
+
+from fsspec.implementations.local import LocalFileSystem
+
+from .. import constants, exceptions
+from ..utils import io_utils
+from ..utils.cached_property import cached_property
+from ..utils.dask_proxy import DaskArrayProxy
+from .reader import Reader
+
+if TYPE_CHECKING:
+    import xarray as xr
+    from fsspec.spec import AbstractFileSystem
+    from ome_types import OME
+
+    from .. import types
+
+
+try:
+    import nd2
+except ImportError:
+    raise ImportError(
+        "The nd2 package is required for this reader. "
+        "Install with `pip install aicsimageio[nd2]`"
+    )
+
+
+class ND2Reader(Reader):
+    """Read NIS-Elements files using the Nikon nd2 SDK.
+
+    This reader requires `nd2` to be installed in the environment.
+
+    Parameters
+    ----------
+    image : Path or str
+        path to file
+
+    Raises
+    ------
+    exceptions.UnsupportedFileFormatError
+        If the file is not supported by bioformats.
+    """
+
+    @staticmethod
+    def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
+        from nd2._util import NEW_HEADER_MAGIC_NUM
+
+        with fs.open(path, "rb") as fh:
+            return int.from_bytes(fh.read(4), "little") == NEW_HEADER_MAGIC_NUM
+
+    def __init__(self, image: types.PathLike):
+        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        # Catch non-local file system
+        if not isinstance(self._fs, LocalFileSystem):
+            raise ValueError(
+                f"Cannot read Bioformats from non-local file system. "
+                f"Received URI: {self._path}, which points to {type(self._fs)}."
+            )
+
+        if not self._is_supported_image(self._fs, self._path):
+            raise exceptions.UnsupportedFileFormatError(
+                self.__class__.__name__, self._path
+            )
+
+    @property
+    def scenes(self) -> Tuple[str, ...]:
+        return ("Image:0",)  # TODO
+
+    def _read_delayed(self) -> xr.DataArray:
+        return self._xarr_reformat(delayed=True)
+
+    def _read_immediate(self) -> xr.DataArray:
+        return self._xarr_reformat(delayed=False)
+
+    def _xarr_reformat(self, delayed: bool) -> xr.DataArray:
+        with nd2.ND2File(self._path) as ndfile:
+            xarr = ndfile.to_xarray(delayed=delayed)
+            if delayed:
+                xarr.data = DaskArrayProxy(xarr.data, xarr.data._ctx)
+            xarr.attrs[constants.METADATA_UNPROCESSED] = xarr.attrs.pop("metadata")
+        return xarr
+
+    @cached_property
+    def ome_metadata(self) -> OME:
+        """Return OME object parsed by ome_types."""
+        from ..metadata.utils import bioformats_ome
+
+        return bioformats_ome(self._path)
+
+    @property
+    def physical_pixel_sizes(self) -> types.PhysicalPixelSizes:
+        """
+        Returns
+        -------
+        sizes: PhysicalPixelSizes
+            Using available metadata, the floats representing physical pixel sizes for
+            dimensions Z, Y, and X.
+
+        Notes
+        -----
+        We currently do not handle unit attachment to these values. Please see the file
+        metadata for unit information.
+        """
+        with nd2.ND2File(self._path) as nd2file:
+            return nd2file.pixel_size()

--- a/aicsimageio/tests/readers/test_nd2_reader.py
+++ b/aicsimageio/tests/readers/test_nd2_reader.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+
+from aicsimageio import dimensions, exceptions
+from aicsimageio.readers.nd2_reader import ND2Reader
+from aicsimageio.tests.image_container_test_utils import run_image_file_checks
+
+from ..conftest import get_resource_full_path, host
+
+
+@host
+@pytest.mark.parametrize(
+    "filename, "
+    "set_scene, "
+    "expected_scenes, "
+    "expected_shape, "
+    "expected_dtype, "
+    "expected_dims_order, "
+    "expected_channel_names, "
+    "expected_physical_pixel_sizes",
+    [
+        pytest.param(
+            "example.txt",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+        pytest.param(
+            "ND2_aryeh_but3_cont200-1.nd2",
+            "Image:0",
+            ("Image:0",),
+            (1, 2, 1, 1040, 1392),
+            np.dtype(">u2"),
+            dimensions.DEFAULT_DIMENSION_ORDER,
+            ["20phase", "20xDiO"],
+            (None, None, None),
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+        (
+            "ND2_jonas_header_test2.nd2",
+            "Image:0",
+            ("Image:0",),
+            (4, 5, 1, 520, 696),
+            np.uint16,
+            "TZCYX",
+            ["Jonas_DIC"],
+            [0.12863494437945, 0.12863494437945, 0.5],
+        ),
+        (
+            "ND2_maxime_BF007.nd2",
+            "Image:0",
+            ("Image:0",),
+            (1, 156, 164),
+            np.uint16,
+            "CYX",
+            ["405/488/561/633nm"],
+            [0.158389678930686, 0.158389678930686, 1.0],
+        ),
+    ],
+)
+def test_nd2_reader(
+    filename: str,
+    host: str,
+    set_scene: str,
+    expected_scenes: Tuple[str, ...],
+    expected_shape: Tuple[int, ...],
+    expected_dtype: np.dtype,
+    expected_dims_order: str,
+    expected_channel_names: List[str],
+    expected_physical_pixel_sizes: Tuple[float, float, float],
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, host)
+
+    # Run checks
+    run_image_file_checks(
+        ImageContainer=ND2Reader,
+        image=uri,
+        set_scene=set_scene,
+        expected_scenes=expected_scenes,
+        expected_current_scene=set_scene,
+        expected_shape=expected_shape,
+        expected_dtype=expected_dtype,
+        expected_dims_order=expected_dims_order,
+        expected_channel_names=expected_channel_names,
+        expected_physical_pixel_sizes=expected_physical_pixel_sizes,
+        expected_metadata_type=dict,
+    )

--- a/aicsimageio/tests/readers/test_nd2_reader.py
+++ b/aicsimageio/tests/readers/test_nd2_reader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import platform
 from typing import List, Tuple
 
 import numpy as np
@@ -14,6 +15,7 @@ from ..conftest import get_resource_full_path, host
 
 
 @host
+@pytest.mark.skipif(platform.system() == "Linux", reason="nd2 not yet ready for linux")
 @pytest.mark.parametrize(
     "filename, "
     "set_scene, "

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -210,14 +210,14 @@ from .image_container_test_utils import (
         # BioformatsReader
         (
             "ND2_jonas_header_test2.nd2",
-            "ND2_jonas_header_test2.nd2 (series 1)",
-            ("ND2_jonas_header_test2.nd2 (series 1)",),
+            "Image:0",
+            ("Image:0",),
             (4, 1, 5, 520, 696),
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
-            ["PSM_GFP"],
-            (0.5, 0.12863494437945, 0.12863494437945),
-            OME,
+            ["Jonas_DIC"],
+            [0.12863494437945, 0.12863494437945, 0.5],
+            dict,
         ),
         (
             "DV_siRNAi-HeLa_IN_02.r3d_D3D.dv",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]~=2.9.0", "Pillow~=8.2.0,!=8.3.0"],
     "lif": ["readlif~=0.6.1"],
     "czi": ["aicspylibczi~=3.0.2"],
+    "nd2": ["nd2"],
     "bioformats": ["bioformats_jar"],
 }
 


### PR DESCRIPTION
## Description
I've been working on a new "native" nd2 reader (based on the nikon nd2sdk) over at https://github.com/tlambert03/nd2
I've been very encouraged with how it's working so far, i find it's extracting more consistent metadata than the two existing python nd2 readers ([pims_nd2](https://github.com/soft-matter/pims_nd2) and [nd2reader](https://github.com/rbnvrw/nd2reader)), and it's got built-in dask/xarray support that marries nicely with this library (you can see how minimal the Reader wrapper here is).

I'll leave this as draft for now... (still need to build linux wheels for nd2) but things seem to be mostly working!

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] closes #142
- [x] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
