### PR TITLE
admin/add-bioformats-compare-bench

### DIFF
--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -67,7 +67,11 @@ class BioformatsReader(Reader):
         except Exception:
             return False
 
-    def __init__(self, image: types.PathLike):
+    def __init__(
+        self,
+        image: types.PathLike,
+        **kwargs: Any,
+    ):
         self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -88,6 +88,7 @@ class CziReader(Reader):
         image: types.PathLike,
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
         chunk_by_dims: Optional[Union[str, List[str]]] = None,
+        **kwargs: Any,
     ):
         # Expand details of provided image
         self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -69,6 +69,7 @@ class LifReader(Reader):
         self,
         image: types.PathLike,
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
+        **kwargs: Any,
     ):
         # Expand details of provided image
         self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)

--- a/benchmarks/benchmark_image_containers.py
+++ b/benchmarks/benchmark_image_containers.py
@@ -61,7 +61,7 @@ class _ImageContainerTimeSuite:
         DimensionNames.Samples,
     ]
 
-    def time_init(self, img_path, chunk_dims=None, **kwargs):
+    def time_init(self, img_path, chunk_dims=None, reader=None):
         """
         Benchmark how long it takes to validate a file and finish general setup.
         """
@@ -70,7 +70,7 @@ class _ImageContainerTimeSuite:
 
         self.ImageContainer(img_path, chunk_dims=chunk_dims)
 
-    def time_delayed_array_construct(self, img_path, chunk_dims=None, **kwargs):
+    def time_delayed_array_construct(self, img_path, chunk_dims=None, reader=None):
         """
         Benchmark how long it takes to construct the delayed dask array for a file.
         """
@@ -79,7 +79,7 @@ class _ImageContainerTimeSuite:
 
         self.ImageContainer(img_path, chunk_dims=chunk_dims).dask_data
 
-    def time_random_single_chunk_read(self, img_path, chunk_dims=None, **kwargs):
+    def time_random_single_chunk_read(self, img_path, chunk_dims=None, reader=None):
         """
         Benchmark how long it takes to read a single chunk out of a file.
 
@@ -100,7 +100,7 @@ class _ImageContainerTimeSuite:
         )
         r.get_image_dask_data(valid_dims_to_return, **random_index_selections).compute()
 
-    def time_random_many_chunk_read(self, img_path, chunk_dims=None, **kwargs):
+    def time_random_many_chunk_read(self, img_path, chunk_dims=None, reader=None):
         """
         Open a file, get many chunks out of the file at once.
 

--- a/benchmarks/benchmark_image_containers.py
+++ b/benchmarks/benchmark_image_containers.py
@@ -61,7 +61,7 @@ class _ImageContainerTimeSuite:
         DimensionNames.Samples,
     ]
 
-    def time_init(self, img_path, chunk_dims=None):
+    def time_init(self, img_path, chunk_dims=None, **kwargs):
         """
         Benchmark how long it takes to validate a file and finish general setup.
         """
@@ -70,7 +70,7 @@ class _ImageContainerTimeSuite:
 
         self.ImageContainer(img_path, chunk_dims=chunk_dims)
 
-    def time_delayed_array_construct(self, img_path, chunk_dims=None):
+    def time_delayed_array_construct(self, img_path, chunk_dims=None, **kwargs):
         """
         Benchmark how long it takes to construct the delayed dask array for a file.
         """
@@ -79,7 +79,7 @@ class _ImageContainerTimeSuite:
 
         self.ImageContainer(img_path, chunk_dims=chunk_dims).dask_data
 
-    def time_random_single_chunk_read(self, img_path, chunk_dims=None):
+    def time_random_single_chunk_read(self, img_path, chunk_dims=None, **kwargs):
         """
         Benchmark how long it takes to read a single chunk out of a file.
 
@@ -100,7 +100,7 @@ class _ImageContainerTimeSuite:
         )
         r.get_image_dask_data(valid_dims_to_return, **random_index_selections).compute()
 
-    def time_random_many_chunk_read(self, img_path, chunk_dims=None):
+    def time_random_many_chunk_read(self, img_path, chunk_dims=None, **kwargs):
         """
         Open a file, get many chunks out of the file at once.
 

--- a/benchmarks/benchmark_native.py
+++ b/benchmarks/benchmark_native.py
@@ -21,11 +21,11 @@ LOCAL_RESOURCES_DIR = (
 
 
 class NativePythonCompareSuite(_ImageContainerTimeSuite):
-    # This suite measures the effect of switching from Bioformats to a native Python
-    # file format reader can have.
-    # All readers will be different, but we do want to show the drawback of reading
-    # using a Java pipe.
-
+    # This suite compares the time it takes to do common operations for file formats
+    # covered by multiple readers
+    # (specifically, a native Python reader and the BioformatsReader).
+    # Where our native implementation is faster or slower than the Bioformats jpype
+    # implementation.
     params = (
         [
             str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),

--- a/benchmarks/benchmark_native.py
+++ b/benchmarks/benchmark_native.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import random
+from pathlib import Path
+
+from aicsimageio.readers.ome_tiff_reader import OmeTiffReader
+from aicsimageio.readers.bioformats_reader import BioformatsReader
+
+from .benchmark_image_containers import _ImageContainerTimeSuite
+
+###############################################################################
+
+# We only benchmark against local files as remote files are covered by unit tests
+# and are generally slower than local but scale at a similar rate.
+LOCAL_RESOURCES_DIR = (
+    Path(__file__).parent.parent / "aicsimageio" / "tests" / "resources"
+)
+
+###############################################################################
+
+
+class NativePythonCompareSuite(_ImageContainerTimeSuite):
+    # This suite measures the effect of switching from Bioformats to a native Python
+    # file format reader can have.
+    # All readers will be different, but we do want to show the drawback of reading
+    # using a Java pipe.
+
+    params = (
+        [
+            str(LOCAL_RESOURCES_DIR / "pre-variance-cfe.ome.tiff"),
+            str(LOCAL_RESOURCES_DIR / "variance-cfe.ome.tiff"),
+        ],
+        # We don't go above chunking by three dims because it would be rare
+        # to do so... if you can read four-plus dims in a single chunk why can't you
+        # just read in the whole image at once.
+        # We also use CYX here to show that chunking with the _wrong_ dimensions can
+        # result in longer processing times.
+        [
+            "YX",
+            "ZYX",
+            "CYX",
+        ],
+        [OmeTiffReader, BioformatsReader],
+    )
+
+    def setup(self, img_path, chunk_dims, reader):
+        random.seed(42)
+        self.ImageContainer = reader


### PR DESCRIPTION
## Description

I wanted to add a benchmark suite for comparing native readers against bioformats. Unfortunately the only files we have available that provide a decent set for comparing (>=200MB) are only OmeTiffs, no CZI or LIF.

Regardless, hopefully this should give us some nice insight into how the jpype compares to native Python.

tagging @tlambert03 

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
