### PR TITLE
feature/import-any-reader-from-readers

### DIFF
--- a/aicsimageio/readers/__init__.py
+++ b/aicsimageio/readers/__init__.py
@@ -35,7 +35,4 @@ def __getattr__(name: str) -> Type["Reader"]:
         path, clsname = _LOOKUP[name].rsplit(".", 1)
         mod = import_module(path, __name__)
         return getattr(mod, clsname)
-    raise ImportError(
-        f"cannot import name {name!r} from {__name__!r}({__file__}). "
-        f"Readers include: {__all__}"
-    )
+    raise AttributeError(f"module {__name__!r} has no attribute import name {name!r}")

--- a/aicsimageio/readers/__init__.py
+++ b/aicsimageio/readers/__init__.py
@@ -1,6 +1,41 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .array_like_reader import ArrayLikeReader  # noqa: F401
-from .ome_tiff_reader import OmeTiffReader  # noqa: F401
-from .tiff_reader import TiffReader  # noqa: F401
+from typing import TYPE_CHECKING, Type
+
+# To add a new reader add it both to TYPE_CHECKING and _READERS
+
+if TYPE_CHECKING:
+    from .array_like_reader import ArrayLikeReader  # noqa: F401
+    from .bioformats_reader import BioformatsReader  # noqa: F401
+    from .czi_reader import CziReader  # noqa: F401
+    from .lif_reader import LifReader  # noqa: F401
+    from .ome_tiff_reader import OmeTiffReader  # noqa: F401
+    from .reader import Reader
+    from .tiff_reader import TiffReader  # noqa: F401
+
+
+# add ".relativepath.ClassName"
+_READERS = (
+    ".array_like_reader.ArrayLikeReader",
+    ".bioformats_reader.BioformatsReader",
+    ".czi_reader.CziReader",
+    ".lif_reader.LifReader",
+    ".ome_tiff_reader.OmeTiffReader",
+    ".tiff_reader.TiffReader",
+)
+_LOOKUP = {k.rsplit(".", 1)[-1]: k for k in _READERS}
+__all__ = list(_LOOKUP)
+
+
+def __getattr__(name: str) -> Type[Reader]:
+    if name in _LOOKUP:
+        from importlib import import_module
+
+        path, clsname = _LOOKUP[name].rsplit(".", 1)
+        mod = import_module(path, __name__)
+        return getattr(mod, clsname)
+    raise ImportError(
+        f"cannot import name {name!r} from {__name__!r}({__file__}). "
+        f"Readers include: {__all__}"
+    )

--- a/aicsimageio/readers/__init__.py
+++ b/aicsimageio/readers/__init__.py
@@ -28,7 +28,7 @@ _LOOKUP = {k.rsplit(".", 1)[-1]: k for k in _READERS}
 __all__ = list(_LOOKUP)
 
 
-def __getattr__(name: str) -> Type[Reader]:
+def __getattr__(name: str) -> Type["Reader"]:
     if name in _LOOKUP:
         from importlib import import_module
 


### PR DESCRIPTION
This PR would let you import any sub-reader from `aicsimageio.readers`, without needed to have  them all installed, and with maintaining type hints and stuff:

```python
# works if it's installed, and provides the same error message
# as the nested package if it's not
from aicsimageio.readers import CziReader
```

## Description


## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
