### PR TITLE
admin/bump-readlif-for-multi-scene

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md") as readme_file:
 
 format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]>=2.9.0,<3", "Pillow>=8.2.0,!=8.3.0,<9"],
-    "lif": ["readlif>=0.6.1"],
+    "lif": ["readlif>=0.6.4"],
     "czi": ["aicspylibczi>=3.0.2"],
     "bioformats": ["bioformats_jar", "wrapt>=1.12"],
 }


### PR DESCRIPTION


## Description

`Readlif` has been update to better handle scene names that have a parent/child structure.
This change addresses the issue originally reported here: https://github.com/AllenCellModeling/aicsimageio/issues/277
Bumping the version requirement on `readlif` is a significant quality-of-life improvement for `aicsimageio` users, as well as the new multi-scene reading widget in `napari-aicsimageio`. For example, in the case of multi-well experiments, regions of interest may have the same names (R1, R1 ...), but the parent (well) names will differ (A1, B2, etc.). See:

<img width="1233" alt="Screen Shot 2021-10-03 at 5 56 54 PM" src="https://user-images.githubusercontent.com/76622105/135762011-b8a2bf29-ebf3-42b0-a40a-02b9769c6ce9.png">

You can see the scene names are "rich", including enclosing parent information, not just "R1", "R1_Merged".

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix. N/A
- [ ] Provide or update documentation for any feature added by your pull request. N/A

Thanks for contributing!
