### PR TITLE
admin/remove-bioformats-extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in P
     -   `CZI` -- (`pip install aicsimageio[czi]`)
     -   `LIF` -- (`pip install aicsimageio[lif]`)
     -   `PNG`, `GIF`, [etc.](https://github.com/imageio/imageio) -- (`pip install aicsimageio[base-imageio]`)
-    - Files supported by [Bio-Formats](https://docs.openmicroscopy.org/bio-formats/latest/supported-formats.html) -- (`pip install aicsimageio[bioformats]`)
+    - Files supported by [Bio-Formats](https://docs.openmicroscopy.org/bio-formats/latest/supported-formats.html) -- (`pip install aicsimageio bioformats_jar`)
 -   Supports writing metadata and imaging data for:
     -   `OME-TIFF`
     -   `PNG`, `GIF`, [etc.](https://github.com/imageio/imageio) -- (`pip install aicsimageio[base-imageio]`)
@@ -51,6 +51,7 @@ optionally installed using `[...]` syntax.
 -   For a single additional supported format (e.g. CZI), specific tag (e.g. `v4.0.0.dev6`): `pip install "aicsimageio[czi] @ git+https://github.com/AllenCellModeling/aicsimageio.git@v4.0.0.dev6"`
 -   For multiple additional supported formats: `pip install aicsimageio[czi,lif]`
 -   For all additional supported formats: `pip install aicsimageio[all]`
+-   Due to the GPL license, Bio-Formats support is not included with the `[all]` extra, and must be installed manually with `pip install aicsimageio bioformats_jar`
 
 ## Documentation
 
@@ -330,3 +331,5 @@ If you find `aicsimageio` useful, please cite this repository as:
 > AICSImageIO Contributors (2021). AICSImageIO: Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in Pure Python [Computer software]. GitHub. https://github.com/AllenCellModeling/aicsimageio
 
 _Free software: BSD-3-Clause_
+
+_(The Bio-Formats component is licensed under GPLv2 and is not included in this package)_

--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     raise ImportError(
         "bioformats_jar is required for this reader. "
-        "Install with `pip install aicsimageio[bioformats]`"
+        "Install with `pip install bioformats_jar`"
     )
 
 
@@ -219,6 +219,8 @@ class BioFile:
     automatically called when using the 'with' context manager.
 
     BioFile instances are not thread-safe.
+
+    Bio-Formats is licensed under GPLv2 and is not included in this package.
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]>=2.9.0,<3", "Pillow>=8.2.0,!=8.3.0,<9"],
     "lif": ["readlif>=0.6.4"],
     "czi": ["aicspylibczi>=3.0.2"],
-    "bioformats": ["bioformats_jar", "wrapt>=1.12"],
+    # "bioformats": ["bioformats_jar"],  # excluded for licensing reasons
 }
 
 all_formats: List[str] = []
@@ -37,9 +37,6 @@ for deps in format_libs.values():
     for dep in deps:
         all_formats.append(dep)
 
-setup_requirements = [
-    "pytest-runner>=5.2",
-]
 
 test_requirements = [
     *all_formats,
@@ -53,10 +50,10 @@ test_requirements = [
     "quilt3",  # no pin to avoid pip cycling (boto is really hard to manage)
     "s3fs[boto3]>=0.4.2",
     "tox>=3.15.2",
+    "bioformats_jar", # to test bioformats
 ]
 
 dev_requirements = [
-    *setup_requirements,
     *test_requirements,
     "asv>=0.4.2",
     "black>=19.10b0",
@@ -89,13 +86,13 @@ requirements = [
     "numpy>=1.16,<2",
     "ome-types>=0.2",
     "tifffile>=2021.6.6",
+    "wrapt>=1.12",
     "xarray>=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",
 ]
 
 extra_requirements = {
-    "setup": setup_requirements,
     "test": test_requirements,
     "dev": dev_requirements,
     "benchmark": benchmark_requirements,
@@ -141,7 +138,6 @@ setup(
         ]
     ),
     python_requires=">=3.7",
-    setup_requires=setup_requirements,
     test_suite="aicsimageio/tests",
     tests_require=test_requirements,
     extras_require=extra_requirements,

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ for deps in format_libs.values():
     for dep in deps:
         all_formats.append(dep)
 
+setup_requirements = [
+    "pytest-runner>=5.2",
+]
 
 test_requirements = [
     *all_formats,
@@ -54,6 +57,7 @@ test_requirements = [
 ]
 
 dev_requirements = [
+    *setup_requirements,
     *test_requirements,
     "asv>=0.4.2",
     "black>=19.10b0",
@@ -93,6 +97,7 @@ requirements = [
 ]
 
 extra_requirements = {
+    "setup": setup_requirements,
     "test": test_requirements,
     "dev": dev_requirements,
     "benchmark": benchmark_requirements,
@@ -138,6 +143,7 @@ setup(
         ]
     ),
     python_requires=">=3.7",
+    setup_requires=setup_requirements,
     test_suite="aicsimageio/tests",
     tests_require=test_requirements,
     extras_require=extra_requirements,


### PR DESCRIPTION
## Description

As per request from the OME team, this removes the `[bioformats]` extra and instructs users to install it manually with `pip install bioformats_jar`.  cc @chris-allan, @joshmoore, @sbesson, @jrswedlow ... let us know if this is what you had in mind.

## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

