### PR TITLE
feature/czi-subblock-metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "aicsimageio/metadata/czi-to-ome-xslt"]
 	path = aicsimageio/metadata/czi-to-ome-xslt
 	url = https://github.com/AllenCellModeling/czi-to-ome-xslt.git
+	branch = main

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -19,6 +19,37 @@ from ..image_container_test_utils import (
 
 
 @pytest.mark.parametrize(
+    ["filename", "num_subblocks", "acquistion_time"],
+    [
+        ("s_1_t_1_c_1_z_1.czi", 1, "2019-06-27T18:33:41.1154211Z"),
+        ("s_3_t_1_c_3_z_5.czi", 45, "2019-06-27T18:39:26.6459707Z"),
+        (
+            "variable_scene_shape_first_scene_pyramid.czi",
+            27,
+            "2019-05-09T09:49:17.9414649Z",
+        ),
+        pytest.param(
+            "s_1_t_1_c_1_z_1.ome.tiff",
+            None,
+            None,
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+        ),
+    ],
+)
+def test_subblocks(filename: str, num_subblocks: int, acquistion_time: str) -> None:
+    reader = CziReader(
+        get_resource_full_path(filename, LOCAL),
+        include_subblock_metadata=True,
+    )
+
+    subblocks = reader.metadata.findall("./Subblocks/Subblock")
+
+    assert len(subblocks) == num_subblocks
+    # Ensure one of the elements in the first subblock has expected data
+    assert subblocks[0].find(".//AcquisitionTime").text == acquistion_time
+
+
+@pytest.mark.parametrize(
     "filename, "
     "set_scene, "
     "expected_scenes, "


### PR DESCRIPTION
## Description
Resolves #304 

This PR adds a param to `CziReader` that causes subblock metadata to be appended to the other embedded metadata.

## Pull request recommendations:
- [X] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [X] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [X] Provide relevant tests for your feature or bug fix.
- [X] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
