### PR TITLE
fix/pin-nd2-dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md") as readme_file:
 format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]>=2.9.0,<3", "Pillow>=8.2.0,!=8.3.0,<9"],
     "czi": ["aicspylibczi>=3.0.2"],
-    "nd2": ["nd2[legacy]>=0.1.4"],
+    "nd2": ["nd2[legacy]==0.1.4"],
     "dv": ["mrc>=0.2.0"],
     # "bioformats": ["bioformats_jar"],  # excluded for licensing reasons
     # "lif": ["readlif>=0.6.4"],  # excluded for licensing reasons


### PR DESCRIPTION
## Description

very sorry for the delay @MatteBailey et al.  I need some more time to debug what's going on with the recent nd2 release as it relates to aicsimageio.  If it's ok with you, let's just pin nd2 for this release to fix the build issues in https://github.com/AllenCellModeling/aicsimageio/pull/354.

I'll follow up with a PR here to unpin when i've had time to update nd2 and test it here.

## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
