### PR TITLE
allow metadata extraction from czi files with no subblocks

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -550,8 +550,12 @@ class CziReader(Reader):
             self._px_sizes = px_sizes
 
             # handle edge case where image has 0,0 YX dims:
-            if image_data.shape[-2:] == (0,0):
-                return xr.DataArray(dims=coords.keys(), coords=coords, attrs={constants.METADATA_UNPROCESSED: meta})
+            if image_data.shape[-2:] == (0, 0):
+                return xr.DataArray(
+                    dims=coords.keys(),
+                    coords=coords,
+                    attrs={constants.METADATA_UNPROCESSED: meta},
+                )
             else:
                 return xr.DataArray(
                     image_data,

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -46,6 +46,7 @@ PIXEL_DICT = {
     "gray32": np.uint32,
     "bgr24": np.uint8,
     "bgr48": np.uint16,
+    "invalid": np.uint8,
 }
 
 
@@ -395,7 +396,7 @@ class CziReader(Reader):
             # Get pixel type and catch unsupported
             pixel_type = PIXEL_DICT.get(czi.pixel_type)
             if pixel_type is None:
-                raise TypeError(f"Pixel type: {pixel_type} is not supported.")
+                raise TypeError(f"Pixel type: {czi.pixel_type} is not supported.")
 
             # Add delayed array to lazy arrays at index
             lazy_arrays[np_index] = da.from_delayed(
@@ -548,12 +549,16 @@ class CziReader(Reader):
             # Store pixel sizes
             self._px_sizes = px_sizes
 
-            return xr.DataArray(
-                image_data,
-                dims=img_dims_list,
-                coords=coords,  # type: ignore
-                attrs={constants.METADATA_UNPROCESSED: meta},
-            )
+            # handle edge case where image has 0,0 YX dims:
+            if image_data.shape[-2:] == (0,0):
+                return xr.DataArray(dims=coords.keys(), coords=coords, attrs={constants.METADATA_UNPROCESSED: meta})
+            else:
+                return xr.DataArray(
+                    image_data,
+                    dims=img_dims_list,
+                    coords=coords,  # type: ignore
+                    attrs={constants.METADATA_UNPROCESSED: meta},
+                )
 
     def _read_immediate(self) -> xr.DataArray:
         """

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.md") as readme_file:
 
 format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]>=2.9.0,<2.11.0", "Pillow>=8.2.0,!=8.3.0,<9"],
-    "czi": ["aicspylibczi>=3.0.2"],
+    "czi": ["aicspylibczi>=3.0.4"],
     "nd2": ["nd2[legacy]==0.1.4"],
     "dv": ["mrc>=0.2.0"],
     # "bioformats": ["bioformats_jar"],  # excluded for licensing reasons

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 format_libs: Dict[str, List[str]] = {
-    "base-imageio": ["imageio[ffmpeg]>=2.9.0,<3", "Pillow>=8.2.0,!=8.3.0,<9"],
+    "base-imageio": ["imageio[ffmpeg]>=2.9.0,<2.11.0", "Pillow>=8.2.0,!=8.3.0,<9"],
     "czi": ["aicspylibczi>=3.0.2"],
     "nd2": ["nd2[legacy]==0.1.4"],
     "dv": ["mrc>=0.2.0"],


### PR DESCRIPTION
## Description
AICS has some old czi files which apparently have metadata but no subblocks. It is thought that they were container files with expected pixel data in associated additional files, but they have now become isolated and it's ~impossible to recover the pixel data. The goal is to still be able to get metadata out.

aicspylibczi has received some changes that prevent it from crashing in this case, and the changes here are to allow for this special case - basically if there is determined to be no pixel data (the xy dims are 0,0) then we return an degenerate empty xarray.  

Currently a draft PR because I want suggestions on how to make it a bit more robust and consistent while still returning the null array.

