### PR TITLE
bugfix/reader-selection-fixes

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import importlib
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
@@ -17,6 +18,10 @@ from .readers import TiffGlobReader
 from .readers.reader import Reader
 from .types import PhysicalPixelSizes
 from .utils.io_utils import pathlike_to_fs
+
+###############################################################################
+
+log = logging.getLogger(__name__)
 
 ###############################################################################
 
@@ -166,9 +171,15 @@ class AICSImage:
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
                 if path.lower().endswith(f".{format_ext}"):
                     for reader in readers:
-                        ReaderClass = _load_reader(reader)
-                        if ReaderClass.is_supported_image(image):
-                            return ReaderClass
+                        try:
+                            ReaderClass = _load_reader(reader)
+                            if ReaderClass.is_supported_image(image):
+                                return ReaderClass
+                        except Exception as e:
+                            log.warning(
+                                f"Attempted file ({path}) load with "
+                                f"reader: {reader} failed with error: {e}"
+                            )
 
         # Try all known readers
         # Useful in cases where the provided filename is a GUID or similar

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -193,7 +193,8 @@ class AICSImage:
 
         # If we haven't hit anything yet, check for suffix and suggest a reader install
         if isinstance(image, (str, Path)):
-            _, path = pathlike_to_fs(image, enforce_exists=True)
+            # Reminder that `path` variable is already populated from prior
+            # path suffix / fast reader lookup.
 
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
                 if path.lower().endswith(f".{format_ext}"):

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -205,7 +205,7 @@ class AICSImage:
                             msg_extra=(
                                 f"File extension suggests format: '{format_ext}'. "
                                 f"Install extra format dependency with: "
-                                f"`pip install aicsimageio[{installer}]`. "
+                                f"`pip install {installer}`. "
                                 f"See all known format extensions and their "
                                 f"extra install name with "
                                 f"`aicsimageio.formats.FORMAT_IMPLEMENTATIONS`."

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -186,19 +186,25 @@ class AICSImage:
 
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
                 if path.lower().endswith(f".{format_ext}"):
-                    installer = READER_TO_INSTALL[readers[0]]
-                    raise exceptions.UnsupportedFileFormatError(
-                        "AICSImage",
-                        path,
-                        msg_extra=(
-                            f"File extension suggests format: '{format_ext}'. "
-                            f"Install extra format dependency with: "
-                            f"`pip install aicsimageio[{installer}]`. "
-                            f"See all known format extensions and their "
-                            f"extra install name with "
-                            f"`aicsimageio.formats.FORMAT_IMPLEMENTATIONS`."
-                        ),
-                    )
+                    if readers[0] in READER_TO_INSTALL:
+                        installer = READER_TO_INSTALL[readers[0]]
+                        raise exceptions.UnsupportedFileFormatError(
+                            "AICSImage",
+                            path,
+                            msg_extra=(
+                                f"File extension suggests format: '{format_ext}'. "
+                                f"Install extra format dependency with: "
+                                f"`pip install aicsimageio[{installer}]`. "
+                                f"See all known format extensions and their "
+                                f"extra install name with "
+                                f"`aicsimageio.formats.FORMAT_IMPLEMENTATIONS`."
+                            ),
+                        )
+                    else:
+                        raise exceptions.UnsupportedFileFormatError(
+                            "AICSImage",
+                            path,
+                        )
 
         # If we haven't hit anything yet, we likely don't support this file / object
         image_type = str(type(image))

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -166,13 +166,9 @@ class AICSImage:
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
                 if path.lower().endswith(f".{format_ext}"):
                     for reader in readers:
-                        try:
-                            ReaderClass = _load_reader(reader)
-                            if ReaderClass.is_supported_image(image):
-                                return ReaderClass
-
-                        except Exception:
-                            pass
+                        ReaderClass = _load_reader(reader)
+                        if ReaderClass.is_supported_image(image):
+                            return ReaderClass
 
         # Try all known readers
         # Useful in cases where the provided filename is a GUID or similar

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -16,6 +16,7 @@ from .metadata import utils as metadata_utils
 from .readers import TiffGlobReader
 from .readers.reader import Reader
 from .types import PhysicalPixelSizes
+from .utils.io_utils import pathlike_to_fs
 
 ###############################################################################
 
@@ -159,8 +160,7 @@ class AICSImage:
 
         # Try reader detection based off of file path extension
         if isinstance(image, (str, Path)):
-
-            path = str(image)
+            _, path = pathlike_to_fs(image, enforce_exists=True)
 
             # Check for extension in FORMAT_IMPLEMENTATIONS
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
@@ -185,7 +185,9 @@ class AICSImage:
                 pass
 
         # If we haven't hit anything yet, check for suffix and suggest a reader install
-        if isinstance(path, str):
+        if isinstance(image, (str, Path)):
+            _, path = pathlike_to_fs(image, enforce_exists=True)
+
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
                 if path.lower().endswith(f".{format_ext}"):
                     installer = READER_TO_INSTALL[readers[0]]
@@ -203,10 +205,10 @@ class AICSImage:
                     )
 
         # If we haven't hit anything yet, we likely don't support this file / object
-        path = str(type(image))
+        image_type = str(type(image))
         raise exceptions.UnsupportedFileFormatError(
             "AICSImage",
-            path,
+            image_type,
             msg_extra=(
                 "You may need to install an extra format dependency. "
                 "See all known format extensions and their extra install "

--- a/aicsimageio/formats.py
+++ b/aicsimageio/formats.py
@@ -476,8 +476,10 @@ FORMAT_IMPLEMENTATIONS: Dict[str, List[str]] = {
 }
 
 READER_TO_INSTALL: Dict[str, str] = {
-    "aicsimageio.readers.bioformats_reader.BioformatsReader": "bioformats",
-    "aicsimageio.readers.default_reader.DefaultReader": "base-imageio",
-    "aicsimageio.readers.lif_reader.LifReader": "lif",
-    "aicsimageio.readers.czi_reader.CziReader": "czi",
+    "aicsimageio.readers.bioformats_reader.BioformatsReader": "bioformats_jar",
+    "aicsimageio.readers.default_reader.DefaultReader": "aicsimageio[base-imageio]",
+    "aicsimageio.readers.lif_reader.LifReader": "readlif>=0.6.4",
+    "aicsimageio.readers.czi_reader.CziReader": "aicsimageio[czi]",
+    "aicsimageio.readers.dv_reader.DVReader": "aicsimageio[dv]",
+    "aicsimageio.readers.nd2_reader.ND2Reader": "aicsimageio[nd2]",
 }

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -80,6 +80,12 @@ class CziReader(Reader):
     @staticmethod
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
         try:
+            if not isinstance(fs, LocalFileSystem):
+                raise ValueError(
+                    f"Cannot read CZIs from non-local file system. "
+                    f"Received URI: {path}, which points to {type(fs)}."
+                )
+
             with fs.open(path) as open_resource:
                 CziFile(open_resource)
                 return True

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -11,6 +11,7 @@ from fsspec.spec import AbstractFileSystem
 from ome_types import from_xml
 from ome_types.model.ome import OME
 from tifffile.tifffile import TiffFile, TiffFileError, TiffTags
+from urllib.error import URLError
 from xmlschema import XMLSchemaValidationError
 
 from .. import constants, exceptions, transforms, types
@@ -98,6 +99,15 @@ class OmeTiffReader(TiffReader):
         # invalid OME XMl
         except XMLSchemaValidationError as e:
             log.error("OME XML validation failed")
+            log.error(e)
+            return False
+
+        # cant connect to external schema resource (no internet conection)
+        except URLError as e:
+            log.error(
+                "Could not validate OME XML against referenced schema "
+                "(no internet connection)"
+            )
             log.error(e)
             return False
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -92,23 +92,21 @@ class OmeTiffReader(TiffReader):
 
         # xml parse errors
         except ET.ParseError as e:
-            log.error("Failed to parse XML for the provided file.")
-            log.error(e)
+            log.error(f"Failed to parse XML for the provided file. Error: {e}")
             return False
 
         # invalid OME XMl
         except XMLSchemaValidationError as e:
-            log.error("OME XML validation failed")
-            log.error(e)
+            log.error(f"OME XML validation failed. Error: {e}")
             return False
 
         # cant connect to external schema resource (no internet conection)
         except URLError as e:
             log.error(
-                "Could not validate OME XML against referenced schema "
-                "(no internet connection)"
+                f"Could not validate OME XML against referenced schema "
+                f"(no internet connection). "
+                f"Error: {e}"
             )
-            log.error(e)
             return False
 
     def __init__(

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -4,6 +4,7 @@
 import logging
 import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.error import URLError
 
 import xarray as xr
 from fsspec.implementations.local import LocalFileSystem
@@ -11,7 +12,6 @@ from fsspec.spec import AbstractFileSystem
 from ome_types import from_xml
 from ome_types.model.ome import OME
 from tifffile.tifffile import TiffFile, TiffFileError, TiffTags
-from urllib.error import URLError
 from xmlschema import XMLSchemaValidationError
 
 from .. import constants, exceptions, transforms, types

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from typing import List, Tuple
-from urllib.error import HTTPError
 
 import numpy as np
 import pytest
@@ -407,7 +406,8 @@ def test_multi_resolution_ome_tiff_reader(
         ),
         # This file has a namespace that doesn't exist
         pytest.param(
-            "s_1_t_1_c_10_z_1.ome.tiff", marks=pytest.mark.raises(exception=HTTPError)
+            "s_1_t_1_c_10_z_1.ome.tiff",
+            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -305,6 +305,18 @@ from .image_container_test_utils import (
             None,
             marks=pytest.mark.raises(exception=IndexError),
         ),
+        pytest.param(
+            "does-not-exist-klafjjksdafkjl.bad",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            marks=pytest.mark.raises(exception=FileNotFoundError),
+        ),
     ],
 )
 def test_aicsimage(

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 
-# If you need to update a version pin for one of these supporting format libs
-# Also be sure to see if you need to update these versions in the aicsimageio/formats.py
-# The "READER_TO_INSTALL" lookup table
+# If you need to update a version pin for one of these supporting format libs,
+# be sure to also check if you need to update these versions in the
+# "READER_TO_INSTALL" lookup table from aicsimageio/formats.py.
 format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]>=2.9.0,<2.11.0", "Pillow>=8.2.0,!=8.3.0,<9"],
     "czi": ["aicspylibczi>=3.0.4"],

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ class BuildPyCommand(build_py):
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
+
+# If you need to update a version pin for one of these supporting format libs
+# Also be sure to see if you need to update these versions in the aicsimageio/formats.py
+# The "READER_TO_INSTALL" lookup table
 format_libs: Dict[str, List[str]] = {
     "base-imageio": ["imageio[ffmpeg]>=2.9.0,<2.11.0", "Pillow>=8.2.0,!=8.3.0,<9"],
     "czi": ["aicspylibczi>=3.0.4"],


### PR DESCRIPTION
## Description

Cleans up a bunch of problems with reader selection. Errors are now passed back up to the user under specific cases, specifically `FileNotFoundError` is properly raised before any readers are attempted.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_

Resolves #352 
Resolves #351 
Resolves #337 
Resolves #334
Resolves #370 

- [x] Provide relevant tests for your feature or bug fix.

Only providing a test for file not found.

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
