### PR TITLE
bugfix/v3-upgrade-m2r-to-m2r2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
-    "m2r",
+    "m2r2",
 ]
 
 # Control napoleon

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ dev_requirements = [
     "flake8>=3.7.7",
     "gitchangelog>=3.0.4",
     "ipython>=7.5.0",
-    "m2r>=0.2.1",
+    "m2r2>=0.2.7",
     "pytest>=4.3.0",
     "pytest-cov==2.6.1",
     "pytest-raises>=0.10",


### PR DESCRIPTION
This fixes the failing main branch docs build.

As a reminder, we build both v3 and v4 docs in main so that people who are still operating on v3 can have docs.

This is an easy fix because a long time ago the maintainer of `m2r` stopped maintaining it and the community took over with `m2r2`.