### PR TITLE
bugfix/czi-physical-size

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -491,15 +491,14 @@ class CziReader(Reader):
         scale_z = None
 
         # Unpack the string value to a float
-        # Split by "E" and take the first part because the values are stored
-        # with E-06 for micrometers, even though the unit is also present in metadata
-        # 🤷
+        # the values are stored in units of meters always in .czi, so
+        # divide by 1E-6 to convert to microns
         if scale_xe is not None and scale_xe.text is not None:
-            scale_x = float(scale_xe.text.split("E")[0])
+            scale_x = float(scale_xe.text)/(1E-6)
         if scale_ye is not None and scale_ye.text is not None:
-            scale_y = float(scale_ye.text.split("E")[0])
+            scale_y = float(scale_ye.text)/(1E-6)
         if scale_ze is not None and scale_ze.text is not None:
-            scale_z = float(scale_ze.text.split("E")[0])
+            scale_z = float(scale_ze.text)/(1E-6)
 
         # Handle Spatial Dimensions
         for scale, dim_name in [

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -494,11 +494,11 @@ class CziReader(Reader):
         # the values are stored in units of meters always in .czi, so
         # divide by 1E-6 to convert to microns
         if scale_xe is not None and scale_xe.text is not None:
-            scale_x = float(scale_xe.text)/(1E-6)
+            scale_x = float(scale_xe.text) / (1e-6)
         if scale_ye is not None and scale_ye.text is not None:
-            scale_y = float(scale_ye.text)/(1E-6)
+            scale_y = float(scale_ye.text) / (1e-6)
         if scale_ze is not None and scale_ze.text is not None:
-            scale_z = float(scale_ze.text)/(1E-6)
+            scale_z = float(scale_ze.text) / (1e-6)
 
         # Handle Spatial Dimensions
         for scale, dim_name in [

--- a/aicsimageio/tests/readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/test_czi_reader.py
@@ -67,7 +67,7 @@ def test_subblocks(filename: str, num_subblocks: int, acquistion_time: str) -> N
             np.uint16,
             "HTCZMYX",
             ["DAPI", "EGFP"],
-            (1.0, 4.0, 4.0),
+            (1.0, 0.4, 0.4),
         ),
         (
             "s_1_t_1_c_1_z_1.czi",


### PR DESCRIPTION
## Description

czi file format says that the scale will always be provided in meters, and it seems that aicsimageio is trying to universally provide it in microns.
<img width="1171" alt="Screen Shot 2022-02-28 at 6 34 20 PM" src="https://user-images.githubusercontent.com/98057992/156076752-d8ab19c7-a724-43a2-b650-c741acdbe095.png">

for me the .split() was not working because the pixel size was 1.3E-07 meters. I wasn't sure how to add tests so if that is important I would need someone to walk me through it.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [na] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [na] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
