### PR TITLE
feature-and-admin/create-aicsimage-objects-with-fs-kwargs-and-remove-need-for-creds

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -43,12 +43,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: '3.10'
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
       - name: Install Dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -31,12 +31,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -88,12 +82,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -27,12 +27,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -84,12 +78,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "11"
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -42,7 +42,7 @@ jobs:
           python scripts/download_test_resources.py --debug
       - name: Run tests with Tox
         # Run tox using the version of Python in `PATH`
-        run: tox -e py -- -k "not REMOTE"
+        run: tox -e py
       - name: Upload codecov
         uses: codecov/codecov-action@v2
 
@@ -92,7 +92,7 @@ jobs:
         run: |
           python scripts/download_test_resources.py --debug
       - name: Run tests with Tox
-        run: tox -e ${{ matrix.tox-env }} -- -k "not REMOTE"
+        run: tox -e ${{ matrix.tox-env }}
       - name: Upload codecov
         uses: codecov/codecov-action@v2
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ img = AICSImage("http://my-website.com/my_file.tiff")
 img = AICSImage("s3://my-bucket/my_file.tiff")
 img = AICSImage("gcs://my-bucket/my_file.tiff")
 
+# Or read with specific filesystem creation arguments
+img = AICSImage("s3://my-bucket/my_file.tiff", fs_kwargs=dict(anon=True))
+img = AICSImage("gcs://my-bucket/my_file.tiff", fs_kwargs=dict(anon=True))
+
 # All other normal operations work just fine
 ```
 

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -140,7 +140,11 @@ class AICSImage:
                 pass
 
     @staticmethod
-    def determine_reader(image: types.ImageLike, **kwargs: Any) -> Type[Reader]:
+    def determine_reader(
+        image: types.ImageLike,
+        fs_kwargs: Dict[str, Any] = {},
+        **kwargs: Any,
+    ) -> Type[Reader]:
         """
         Cheaply check to see if a given file is a recognized type and return the
         appropriate reader for the image.
@@ -165,7 +169,7 @@ class AICSImage:
 
         # Try reader detection based off of file path extension
         if isinstance(image, (str, Path)):
-            _, path = pathlike_to_fs(image, enforce_exists=True)
+            _, path = pathlike_to_fs(image, enforce_exists=True, fs_kwargs=fs_kwargs)
 
             # Check for extension in FORMAT_IMPLEMENTATIONS
             for format_ext, readers in FORMAT_IMPLEMENTATIONS.items():
@@ -173,7 +177,10 @@ class AICSImage:
                     for reader in readers:
                         try:
                             ReaderClass = _load_reader(reader)
-                            if ReaderClass.is_supported_image(image):
+                            if ReaderClass.is_supported_image(
+                                image,
+                                fs_kwargs=fs_kwargs,
+                            ):
                                 return ReaderClass
                         except Exception as e:
                             log.warning(
@@ -186,7 +193,11 @@ class AICSImage:
         # Or provided an in-memory object (arraylike)
         for ReaderClass in AICSImage.SUPPORTED_READERS:
             try:
-                if ReaderClass.is_supported_image(image, **kwargs):  # type: ignore
+                if ReaderClass.is_supported_image(
+                    image,
+                    fs_kwargs=fs_kwargs,
+                    **kwargs,  # type: ignore
+                ):
                     return ReaderClass
             except Exception:
                 pass
@@ -241,17 +252,18 @@ class AICSImage:
         image: types.ImageLike,
         reader: Optional[Type[Reader]] = None,
         reconstruct_mosaic: bool = True,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
         if reader is None:
             # Determine reader class and create dask delayed array
-            ReaderClass = self.determine_reader(image, **kwargs)
+            ReaderClass = self.determine_reader(image, fs_kwargs=fs_kwargs, **kwargs)
         else:
             # Init reader
             ReaderClass = reader
 
         # Init and store reader
-        self._reader = ReaderClass(image, **kwargs)
+        self._reader = ReaderClass(image, fs_kwargs=fs_kwargs, **kwargs)
 
         # Store delayed modifiers
         self._reconstruct_mosaic = reconstruct_mosaic

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -58,6 +58,9 @@ class AICSImage:
         `M` dimension for tiles.
         If image is not a mosaic, data won't be stitched or have an `M` dimension for
         tiles.
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
     kwargs: Any
         Extra keyword arguments that will be passed down to the reader subclass.
 

--- a/aicsimageio/readers/bfio_reader.py
+++ b/aicsimageio/readers/bfio_reader.py
@@ -89,11 +89,9 @@ class BfioReader(Reader):
         """This method should be overwritten by a subclass."""
         try:
             with BioReader(path):
-
                 return True
 
         except Exception:
-
             return False
 
     def __init__(
@@ -101,10 +99,15 @@ class BfioReader(Reader):
         image: types.PathLike,
         chunk_dims: Optional[Union[str, List[str]]] = None,
         out_order: str = DEFAULT_DIMENSION_ORDER,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
         # Expand details of provided image
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
 
         if not isinstance(self._fs, LocalFileSystem):
             raise ValueError(

--- a/aicsimageio/readers/bfio_reader.py
+++ b/aicsimageio/readers/bfio_reader.py
@@ -43,6 +43,9 @@ class BfioReader(Reader):
     out_order: List[str]
         The output dimension ordering.
         Default: DEFAULT_DIMENSION_ORDER
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Notes
     -----

--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -111,8 +111,13 @@ class BioformatsReader(Reader):
         options: Dict[str, bool] = {},
         dask_tiles: bool = False,
         tile_size: Optional[Tuple[int, int]] = None,
+        fs_kwargs: Dict[str, Any] = {},
     ):
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):
             raise ValueError(

--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -84,6 +84,10 @@ class BioformatsReader(Reader):
     tile_size: Optional[Tuple[int, int]]
         Tuple that sets the tile size of y and x axis, respectively
         By default, it will use optimal values computed by bioformats itself
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
+
     Raises
     ------
     exceptions.UnsupportedFileFormatError

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -97,9 +97,14 @@ class CziReader(Reader):
         image: types.PathLike,
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
         include_subblock_metadata: bool = False,
+        fs_kwargs: Dict[str, Any] = {},
     ):
         # Expand details of provided image
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
 
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -70,6 +70,9 @@ class CziReader(Reader):
     include_subblock_metadata: bool
         Whether to append metadata from the subblocks to the rest of the embeded
         metadata.
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Notes
     -----

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -126,10 +126,15 @@ class DefaultReader(Reader):
         image: types.PathLike,
         dim_order: Optional[str] = None,
         channel_names: Optional[List[str]] = None,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
         # Expand details of provided image
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
         self.extension, self.imageio_read_mode = self._get_extension_and_mode(
             self._path
         )

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -52,6 +52,9 @@ class DefaultReader(Reader):
         Optional list of channel names.
         Must provide the same number of channels as the read channel dimension.
         Default: None (generate standard names)
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Notes
     -----

--- a/aicsimageio/readers/dv_reader.py
+++ b/aicsimageio/readers/dv_reader.py
@@ -32,6 +32,9 @@ class DVReader(Reader):
     ----------
     image : Path or str
         path to file
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Raises
     ------

--- a/aicsimageio/readers/dv_reader.py
+++ b/aicsimageio/readers/dv_reader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 from fsspec.implementations.local import LocalFileSystem
 from resource_backed_dask_array import resource_backed_dask_array
@@ -43,8 +43,12 @@ class DVReader(Reader):
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
         return DVFile.is_supported_file(path)
 
-    def __init__(self, image: types.PathLike):
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+    def __init__(self, image: types.PathLike, fs_kwargs: Dict[str, Any] = {}):
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):
             raise NotImplementedError(

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -49,6 +49,9 @@ class LifReader(Reader):
         Note: Dimensions.SpatialY, Dimensions.SpatialX, and DimensionNames.Samples,
         will always be added to the list if not present during dask array
         construction.
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Notes
     -----

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -71,9 +71,14 @@ class LifReader(Reader):
         self,
         image: types.PathLike,
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
+        fs_kwargs: Dict[str, Any] = {},
     ):
         # Expand details of provided image
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
 
         # Store params
         if isinstance(chunk_dims, str):

--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -31,6 +31,9 @@ class ND2Reader(Reader):
     ----------
     image : Path or str
         path to file
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Raises
     ------

--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Tuple
 
 from fsspec.implementations.local import LocalFileSystem
 
@@ -42,8 +42,12 @@ class ND2Reader(Reader):
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
         return nd2.is_supported_file(path, fs.open)
 
-    def __init__(self, image: types.PathLike):
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+    def __init__(self, image: types.PathLike, fs_kwargs: Dict[str, Any] = {}):
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
         # Catch non-local file system
         if not isinstance(self._fs, LocalFileSystem):
             raise ValueError(

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -47,6 +47,9 @@ class OmeTiffReader(TiffReader):
         Should the OME XML metadata found in the file be cleaned for known
         AICSImageIO 3.x and earlier created errors.
         Default: True (Clean the metadata for known errors)
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Notes
     -----

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -114,10 +114,15 @@ class OmeTiffReader(TiffReader):
         image: types.PathLike,
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
         clean_metadata: bool = True,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
         # Expand details of provided image
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
 
         # Store params
         if isinstance(chunk_dims, str):

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -3,7 +3,7 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -49,7 +49,11 @@ class Reader(ABC):
 
     @staticmethod
     @abstractmethod
-    def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
+    def _is_supported_image(
+        fs: AbstractFileSystem,
+        path: str,
+        **kwargs: Any,
+    ) -> bool:
         """
         The per-Reader implementation used to validate that an image is supported or not
         by the Reader itself.
@@ -70,7 +74,12 @@ class Reader(ABC):
         """
 
     @classmethod
-    def is_supported_image(cls, image: types.ImageLike, **kwargs: Any) -> bool:
+    def is_supported_image(
+        cls,
+        image: types.ImageLike,
+        fs_kwargs: Dict[str, Any] = {},
+        **kwargs: Any,
+    ) -> bool:
         """
         Asserts that the provided image like object is supported by the current Reader.
 
@@ -95,7 +104,11 @@ class Reader(ABC):
         # Check path
         if isinstance(image, (str, Path)):
             # Expand details of provided image
-            fs, path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+            fs, path = io_utils.pathlike_to_fs(
+                image,
+                enforce_exists=True,
+                fs_kwargs=fs_kwargs,
+            )
 
             return cls._is_supported_image(fs, path, **kwargs)
 

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -28,6 +28,9 @@ class Reader(ABC):
     ----------
     image: Any
         Some type of object to read and follow the Reader specification.
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Notes
     -----
@@ -87,6 +90,10 @@ class Reader(ABC):
         ----------
         image: types.ImageLike
             The filepath or array to validate as a supported type.
+        fs_kwargs: Dict[str, Any]
+            Any specific keyword arguments to pass down to the fsspec created
+            filesystem.
+            Default: {}
         kwargs: Any
             Any kwargs used for reading and validation of the file.
 

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -133,6 +133,7 @@ class TiffGlobReader(Reader):
             DimensionNames.SpatialY,
             DimensionNames.SpatialX,
         ),
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
 
@@ -187,7 +188,10 @@ class TiffGlobReader(Reader):
         self._all_files = self._all_files.sort_values(sort_order).reset_index(drop=True)
 
         # run tests on a single file (?)
-        self._fs, self._path = io_utils.pathlike_to_fs(self._all_files.iloc[0].filename)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            self._all_files.iloc[0].filename,
+            fs_kwargs=fs_kwargs,
+        )
 
         # Store params
         if isinstance(chunk_dims, str):

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -72,6 +72,9 @@ class TiffGlobReader(Reader):
     single_file_dims : Optional[Tuple]
         Dimensions that correspond to the data dimensions of a single file in the glob.
         Default : ('Y', 'X')
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Examples
     --------

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -52,6 +52,9 @@ class TiffReader(Reader):
         list of lists of string channel names to be mapped onto the list of arrays
         provided to image.
         Default: None (create OME channel IDs for names for single or multiple arrays)
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
     """
 
     @staticmethod

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -70,10 +70,15 @@ class TiffReader(Reader):
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
         dim_order: Optional[Union[List[str], str]] = None,
         channel_names: Optional[Union[List[str], List[List[str]]]] = None,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
         # Expand details of provided image
-        self._fs, self._path = io_utils.pathlike_to_fs(image, enforce_exists=True)
+        self._fs, self._path = io_utils.pathlike_to_fs(
+            image,
+            enforce_exists=True,
+            fs_kwargs=fs_kwargs,
+        )
 
         # Store params
         if isinstance(chunk_dims, str):

--- a/aicsimageio/tests/image_container_test_utils.py
+++ b/aicsimageio/tests/image_container_test_utils.py
@@ -151,7 +151,7 @@ def run_image_file_checks(
     expected_metadata_type: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]],
 ) -> Union[AICSImage, Reader]:
     # Init container
-    image_container = ImageContainer(image)
+    image_container = ImageContainer(image, fs_kwargs=dict(anon=True))
 
     # Check for file pointers
     check_local_file_not_open(image_container)
@@ -191,7 +191,7 @@ def run_multi_scene_image_read_checks(
     A suite of tests to ensure that data is reset when switching scenes.
     """
     # Read file
-    image_container = ImageContainer(image)
+    image_container = ImageContainer(image, fs_kwargs=dict(anon=True))
 
     check_local_file_not_open(image_container)
     check_can_serialize_image_container(image_container)

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -420,7 +420,7 @@ def test_known_errors_without_cleaning(filename: str, host: str) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, host)
 
-    OmeTiffReader(uri, clean_metadata=False)
+    OmeTiffReader(uri, clean_metadata=False, fs_kwargs=dict(anon=True))
 
 
 def test_micromanager_ome_tiff_main_file() -> None:

--- a/aicsimageio/tests/utils/test_io_utils.py
+++ b/aicsimageio/tests/utils/test_io_utils.py
@@ -32,4 +32,4 @@ def test_pathlike_to_fs(filename: str, host: str, enforce_exists: bool) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, host)
 
-    pathlike_to_fs(uri, enforce_exists)
+    pathlike_to_fs(uri, enforce_exists, fs_kwargs=dict(anon=True))

--- a/aicsimageio/utils/io_utils.py
+++ b/aicsimageio/utils/io_utils.py
@@ -33,6 +33,9 @@ def pathlike_to_fs(
         The filesystem to operate on.
     path: str
         The full path to the target resource.
+    fs_kwargs: Dict[str, Any]
+        Any specific keyword arguments to pass down to the fsspec created filesystem.
+        Default: {}
 
     Raises
     ------

--- a/aicsimageio/utils/io_utils.py
+++ b/aicsimageio/utils/io_utils.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 from fsspec.core import url_to_fs
 from fsspec.spec import AbstractFileSystem
@@ -15,6 +15,7 @@ from ..types import PathLike
 def pathlike_to_fs(
     uri: PathLike,
     enforce_exists: bool = False,
+    fs_kwargs: Dict[str, Any] = {},
 ) -> Tuple[AbstractFileSystem, str]:
     """
     Find and return the appropriate filesystem and path from a path-like object.
@@ -44,7 +45,7 @@ def pathlike_to_fs(
         uri = str(uri)
 
     # Get details
-    fs, path = url_to_fs(uri)
+    fs, path = url_to_fs(uri, **fs_kwargs)
 
     # Check file exists
     if enforce_exists:

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -1,4 +1,7 @@
-from typing import Any, List, Optional, Tuple, Union
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -42,6 +45,7 @@ class OmeTiffWriter(Writer):
         channel_colors: Optional[
             Union[List[List[int]], List[Optional[List[List[int]]]]]
         ] = None,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> None:
         """
@@ -94,6 +98,10 @@ class OmeTiffWriter(Writer):
             List of rgb color values per channel or a list of lists for each image.
             These must be values compatible with the OME spec.
             Default: None
+        fs_kwargs: Dict[str, Any]
+            Any specific keyword arguments to pass down to the fsspec created
+            filesystem.
+            Default: {}
 
         Raises
         ------
@@ -124,7 +132,7 @@ class OmeTiffWriter(Writer):
         ... )
         """
         # Resolve final destination
-        fs, path = io_utils.pathlike_to_fs(uri)
+        fs, path = io_utils.pathlike_to_fs(uri, fs_kwargs=fs_kwargs)
 
         # Catch non-local file system
         if not isinstance(fs, LocalFileSystem):

--- a/aicsimageio/writers/timeseries_writer.py
+++ b/aicsimageio/writers/timeseries_writer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Any
+from typing import Any, Dict
 
 import dask.array as da
 import numpy as np
@@ -82,6 +82,7 @@ class TimeseriesWriter(Writer):
         uri: types.PathLike,
         dim_order: str = None,
         fps: int = 24,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> None:
         """
@@ -100,6 +101,10 @@ class TimeseriesWriter(Writer):
         fps: int
             Frames per second to attach as metadata.
             Default: 24
+        fs_kwargs: Dict[str, Any]
+            Any specific keyword arguments to pass down to the fsspec created
+            filesystem.
+            Default: {}
 
         Examples
         --------
@@ -140,7 +145,7 @@ class TimeseriesWriter(Writer):
 
         """
         # Check unpack uri and extension
-        fs, path = io_utils.pathlike_to_fs(uri)
+        fs, path = io_utils.pathlike_to_fs(uri, fs_kwargs=fs_kwargs)
         (
             extension,
             imageio_mode,

--- a/aicsimageio/writers/two_d_writer.py
+++ b/aicsimageio/writers/two_d_writer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Any
+from typing import Any, Dict
 
 import dask.array as da
 from imageio import get_writer
@@ -53,6 +53,7 @@ class TwoDWriter(Writer):
         data: types.ArrayLike,
         uri: types.PathLike,
         dim_order: str = None,
+        fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ) -> None:
         """
@@ -70,6 +71,10 @@ class TwoDWriter(Writer):
             the dimensions similar to how
             aicsimageio.readers.default_reader.DefaultReader reads in
             data. That is, two dimensions: YX and three dimensions: YXS.
+        fs_kwargs: Dict[str, Any]
+            Any specific keyword arguments to pass down to the fsspec created
+            filesystem.
+            Default: {}
 
         Examples
         --------
@@ -89,7 +94,7 @@ class TwoDWriter(Writer):
         ... TwoDWriter.save(image, "s3://my-bucket/file.png")
         """
         # Check unpack uri and extension
-        fs, path = io_utils.pathlike_to_fs(uri)
+        fs, path = io_utils.pathlike_to_fs(uri, fs_kwargs=fs_kwargs)
         (
             extension,
             imageio_mode,

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_requirements = [
 
 test_requirements = [
     "codecov>=2.1.4",
-    "distributed>=2021.4.1,!=2022.5.1",
+    "dask[array,distributed]>=2021.4.1,!=2022.5.1",
     "docutils>=0.10,<0.16",
     "psutil>=5.7.0",
     "pytest>=5.4.3",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup_requirements = [
 
 test_requirements = [
     "codecov>=2.1.4",
-    "distributed>=2021.4.1",
+    "distributed>=2021.4.1,!=2022.5.1",
     "docutils>=0.10,<0.16",
     "psutil>=5.7.0",
     "pytest>=5.4.3",


### PR DESCRIPTION
## Description

Credentials are annoying. This removes the need for credentials for downloading and reading our test data by adding a new kwarg to all reader inits and to pathlike_to_fs called `fs_kwargs` that passes any filesystem keyword argument down the chain.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_

#403 and #402 are both failing due to credentials management

Also sets `distributed` in test deps to ignore 2022.5.1 as it is problematic, see: #406 


- [x] Provide relevant tests for your feature or bug fix.

- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
