### PR TITLE
feat/use-faster-ome-types-lxml-parser

### DIFF
--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -444,7 +444,7 @@ class BioFile:
     def ome_metadata(self) -> OME:
         """Return OME object parsed by ome_types."""
         xml = metadata_utils.clean_ome_xml_for_known_issues(self.ome_xml)
-        return OME.from_xml(xml)
+        return metadata_utils._ome_from_xml(xml)
 
     def __enter__(self) -> BioFile:
         self.open()

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -9,7 +9,6 @@ from urllib.error import URLError
 import xarray as xr
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
-from ome_types import from_xml
 from ome_types.model.ome import OME
 from tifffile.tifffile import TiffFile, TiffFileError, TiffTags
 from xmlschema import XMLSchemaValidationError
@@ -66,7 +65,7 @@ class OmeTiffReader(TiffReader):
         if clean_metadata:
             ome_xml = metadata_utils.clean_ome_xml_for_known_issues(ome_xml)
 
-        return from_xml(ome_xml)
+        return metadata_utils._ome_from_xml(ome_xml)
 
     @staticmethod
     def _is_supported_image(

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -7,7 +7,7 @@ import dask.array as da
 import numpy as np
 import tifffile
 from fsspec.implementations.local import LocalFileSystem
-from ome_types import from_xml, to_xml
+from ome_types import to_xml
 from ome_types.model import OME, Channel, Image, Pixels, TiffData
 from ome_types.model.simple_types import ChannelID, Color, PositiveFloat, PositiveInt
 from tifffile import TIFF
@@ -255,7 +255,7 @@ class OmeTiffWriter(Writer):
             )
         # else if string, then construct OME from string
         elif isinstance(ome_xml, str):
-            ome_xml = from_xml(ome_xml)
+            ome_xml = utils._ome_from_xml(ome_xml)
 
         # if we do not have an OME object now, something is wrong
         if not isinstance(ome_xml, OME):
@@ -666,7 +666,7 @@ class OmeTiffWriter(Writer):
 
         # validate! (TODO: Is there a better api in ome-types for this?)
         test = to_xml(ome_object)
-        from_xml(test)
+        utils._ome_from_xml(test)
 
         return ome_object
 


### PR DESCRIPTION
## Description

ome-types 0.3.0 added a faster parser based on `lxml`.  Moreover, for the 0.3.0 release there will be a `FutureWarning` (since the default is going to change in 0.4.0) if you don't provide a `parser` argument to `from_xml`.

This PR will silence that warning and opt in to the newer `ome_types.from_xml(..., parser='lxml')`  when it detects that ome types 0.3.0+ is installed, otherwise falling back to the old behavior.


## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
