### PR TITLE
bugfix/dynamic-dimension-typing

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -379,7 +379,7 @@ class AICSImage(ImageContainer):
         # Pull the data with the appropriate dimensions
         data = transforms.reshape_data(
             data=arr.data,
-            given_dims="".join(arr.dims),  # type: ignore
+            given_dims="".join(arr.dims),
             return_dims=return_dims,
         )
 
@@ -401,7 +401,7 @@ class AICSImage(ImageContainer):
         return xr.DataArray(
             data,
             dims=tuple([d for d in return_dims]),
-            coords=coords,  # type: ignore
+            coords=coords,
             attrs=arr.attrs,
         )
 

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -146,5 +146,6 @@ class Dimensions:
     def __setattr__(self, __name: str, __value: int) -> None:
         super().__setattr__(__name, __value)
 
-    def __getattribute__(self, __name: str) -> int:
+    def __getattr__(self, __name: str) -> int:
+        # TODO: Py310 __match_args__ for better typing
         return super().__getattribute__(__name)

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -142,3 +142,9 @@ class Dimensions:
             raise TypeError(
                 f"Key must be a string or list of strings but got type {type(key)}"
             )
+
+    def __setattr__(self, __name: str, __value: int) -> None:
+        super().__setattr__(__name, __value)
+
+    def __getattribute__(self, __name: str) -> int:
+        return super().__getattribute__(__name)

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -64,7 +64,7 @@ REQUIRED_CHUNK_DIMS = [
 
 
 class Dimensions:
-    def __init__(self, dims: Union[str, Iterable], shape: Tuple[int, ...]):
+    def __init__(self, dims: Iterable[str], shape: Tuple[int, ...]):
         """
         A general object for managing the pairing of dimension name and dimension size.
 
@@ -81,8 +81,22 @@ class Dimensions:
         ... dims.X
         ... dims['T', 'X']
         """
+        # zip(strict=True) only in Python 3.10
+        # Check equal length dims and shape
+        if len(dims) != len(shape):
+            raise ValueError(
+                f"Number of dimensions provided ({len(dims)} -- '{dims}') "
+                f"does not match shape size provided ({len(shape)} -- '{shape}')."
+            )
+
         # Make dims a string
         if not isinstance(dims, str):
+            if any([len(c) != 1 for c in dims]):
+                raise ValueError(
+                    f"When providing a list of dimension strings, "
+                    f"each dimension may only be a single character long "
+                    f"(received: '{dims}')."
+                )
             dims = "".join(dims)
 
         # Store order and shape

--- a/aicsimageio/dimensions.py
+++ b/aicsimageio/dimensions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from collections.abc import Sequence as seq
-from typing import ItemsView, Iterable, Sequence, Tuple, Union
+from typing import Collection, ItemsView, Sequence, Tuple, Union
 
 ###############################################################################
 
@@ -64,14 +64,14 @@ REQUIRED_CHUNK_DIMS = [
 
 
 class Dimensions:
-    def __init__(self, dims: Iterable[str], shape: Tuple[int, ...]):
+    def __init__(self, dims: Collection[str], shape: Tuple[int, ...]):
         """
         A general object for managing the pairing of dimension name and dimension size.
 
         Parameters
         ----------
-        dims: Union[str, Iterable]
-            An ordered string or iterable of the dimensions to pair with their sizes.
+        dims: Collection[str]
+            An ordered string or collection of the dimensions to pair with their sizes.
         shape: Tuple[int, ...]
             An ordered tuple of the dimensions sizes to pair with their names.
 

--- a/aicsimageio/readers/array_like_reader.py
+++ b/aicsimageio/readers/array_like_reader.py
@@ -196,7 +196,7 @@ class ArrayLikeReader(Reader):
                         )
                         # Rename the dimensions from "dim_N" to just the guess dim
                         # Update scene list in place
-                        self._all_scenes[i] = this_scene.rename(  # type: ignore
+                        self._all_scenes[i] = this_scene.rename(
                             {
                                 f"dim_{d_index}": d
                                 for d_index, d in enumerate(
@@ -224,7 +224,7 @@ class ArrayLikeReader(Reader):
                             # Rename the dimensions from "dim_N" to just the guess dim
                             # Update scene list in place
                             self._all_scenes[i] = this_scene.rename(
-                                {  # type: ignore
+                                {
                                     f"dim_{d_index}": d
                                     for d_index, d in enumerate(dims_string)
                                 }
@@ -356,7 +356,7 @@ class ArrayLikeReader(Reader):
                     xr.DataArray(
                         data=scene_data,
                         dims=dims_list,
-                        coords=coords,  # type: ignore
+                        coords=coords,
                         attrs={constants.METADATA_UNPROCESSED: None},
                     )
                 )

--- a/aicsimageio/readers/bfio_reader.py
+++ b/aicsimageio/readers/bfio_reader.py
@@ -83,7 +83,7 @@ class BfioReader(Reader):
         return xr.DataArray(
             image_data,
             dims=self.out_dim_order,
-            coords=coords,  # type: ignore
+            coords=coords,
             attrs=attrs,
         )
 

--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -208,7 +208,7 @@ class BioformatsReader(Reader):
             dims=dimensions.DEFAULT_DIMENSION_ORDER_LIST_WITH_SAMPLES
             if rdr.core_meta.is_rgb
             else dimensions.DEFAULT_DIMENSION_ORDER_LIST,
-            coords=coords,  # type: ignore
+            coords=coords,
             attrs={
                 constants.METADATA_UNPROCESSED: rdr.ome_xml,
                 constants.METADATA_PROCESSED: rdr.ome_metadata,

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -573,7 +573,7 @@ class CziReader(Reader):
                 return xr.DataArray(
                     image_data,
                     dims=img_dims_list,
-                    coords=coords,  # type: ignore
+                    coords=coords,
                     attrs={constants.METADATA_UNPROCESSED: meta},
                 )
 
@@ -623,7 +623,7 @@ class CziReader(Reader):
             return xr.DataArray(
                 image_data,
                 dims=[d for d in self.mapped_dims],
-                coords=coords,  # type: ignore
+                coords=coords,
                 attrs={constants.METADATA_UNPROCESSED: meta},
             )
 
@@ -803,7 +803,10 @@ class CziReader(Reader):
             # so simply run array construct
             self.dask_data
 
-        return self._px_sizes  # type: ignore
+        if self._px_sizes is None:
+            raise ValueError("Pixel sizes weren't created as a part of image reading")
+
+        return self._px_sizes
 
     def get_mosaic_tile_position(self, mosaic_tile_index: int) -> Tuple[int, int]:
         """

--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -486,7 +486,7 @@ class DefaultReader(Reader):
                 return xr.DataArray(
                     image_data,
                     dims=dims,
-                    coords=coords,  # type: ignore
+                    coords=coords,
                     attrs={constants.METADATA_UNPROCESSED: metadata},
                 )
 
@@ -547,6 +547,6 @@ class DefaultReader(Reader):
             return xr.DataArray(
                 image_data,
                 dims=dims,
-                coords=coords,  # type: ignore
+                coords=coords,
                 attrs={constants.METADATA_UNPROCESSED: metadata},
             )

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -140,6 +140,8 @@ class LifReader(Reader):
         chunk: np.ndarray
             The image chunk as a numpy array.
         """
+        MISSING_DIM_SENTINAL_VALUE = -1
+
         # Open and select the target image
         with fs.open(path) as open_resource:
             selected_scene = LifFile(open_resource).get_image(scene)
@@ -153,7 +155,7 @@ class LifReader(Reader):
                     # Handle slices
                     if index_op is None:
                         # Store the dim for later to inform to use the np index
-                        use_selected_or_np_map[dim] = -1
+                        use_selected_or_np_map[dim] = MISSING_DIM_SENTINAL_VALUE
                         if dim == DimensionNames.MosaicTile:
                             retrieve_shape.append(selected_scene.n_mosaic)
                         elif dim == DimensionNames.Time:
@@ -181,7 +183,10 @@ class LifReader(Reader):
 
                 # Handle MosaicTile
                 if DimensionNames.MosaicTile in use_selected_or_np_map:
-                    if use_selected_or_np_map[DimensionNames.MosaicTile] == -1:
+                    if (
+                        use_selected_or_np_map[DimensionNames.MosaicTile]
+                        == MISSING_DIM_SENTINAL_VALUE
+                    ):
                         plane_indices["m"] = np_index[
                             retrieve_dims.index(DimensionNames.MosaicTile)
                         ]
@@ -191,7 +196,10 @@ class LifReader(Reader):
                         ]
 
                 # Handle Time
-                if use_selected_or_np_map[DimensionNames.Time] == -1:
+                if (
+                    use_selected_or_np_map[DimensionNames.Time]
+                    == MISSING_DIM_SENTINAL_VALUE
+                ):
                     plane_indices["t"] = np_index[
                         retrieve_dims.index(DimensionNames.Time)
                     ]
@@ -199,7 +207,10 @@ class LifReader(Reader):
                     plane_indices["t"] = use_selected_or_np_map[DimensionNames.Time]
 
                 # Handle Channels
-                if use_selected_or_np_map[DimensionNames.Channel] == -1:
+                if (
+                    use_selected_or_np_map[DimensionNames.Channel]
+                    == MISSING_DIM_SENTINAL_VALUE
+                ):
                     plane_indices["c"] = np_index[
                         retrieve_dims.index(DimensionNames.Channel)
                     ]
@@ -207,7 +218,10 @@ class LifReader(Reader):
                     plane_indices["c"] = use_selected_or_np_map[DimensionNames.Channel]
 
                 # Handle SpatialZ
-                if use_selected_or_np_map[DimensionNames.SpatialZ] == -1:
+                if (
+                    use_selected_or_np_map[DimensionNames.SpatialZ]
+                    == MISSING_DIM_SENTINAL_VALUE
+                ):
                     plane_indices["z"] = np_index[
                         retrieve_dims.index(DimensionNames.SpatialZ)
                     ]

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -243,7 +243,7 @@ class OmeTiffReader(TiffReader):
         return xr.DataArray(
             image_data,
             dims=dims,
-            coords=coords,  # type: ignore
+            coords=coords,
             attrs={
                 constants.METADATA_UNPROCESSED: tiff_tags,
                 constants.METADATA_PROCESSED: self._ome,

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -831,7 +831,7 @@ class Reader(ImageContainer, ABC):
             If the image is not a mosaic image, returns None.
         """
         if DimensionNames.MosaicTile in self.dims.order:
-            return Dimensions("YX", (self.dims.Y, self.dims.X))  # type: ignore
+            return Dimensions("YX", (self.dims.Y, self.dims.X))
 
         return None
 

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -471,7 +471,7 @@ class TiffReader(Reader):
                 return xr.DataArray(
                     image_data,
                     dims=dims,
-                    coords=coords,  # type: ignore
+                    coords=coords,
                     attrs=attrs,
                 )
 
@@ -526,6 +526,6 @@ class TiffReader(Reader):
                 return xr.DataArray(
                     image_data,
                     dims=dims,
-                    coords=coords,  # type: ignore
+                    coords=coords,
                     attrs=attrs,
                 )

--- a/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
@@ -294,10 +294,8 @@ def test_czi_reader_mosaic_stitching(
             None,
             None,
             None,
-            # The value returned from all of the calls is None
-            # Which when trying to operate on will raise an AttributeError
-            # Because None doesn't have a Y or X attribute for example
-            marks=pytest.mark.raises(exception=AttributeError),
+            # File has no mosaic tiles
+            marks=pytest.mark.raises(exception=AssertionError),
         ),
     ],
 )
@@ -316,8 +314,9 @@ def test_czi_reader_mosaic_tile_inspection(
     reader.set_scene(set_scene)
 
     # Check basics
-    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]  # type: ignore
-    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]  # type: ignore
+    assert reader.mosaic_tile_dims is not None
+    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]
+    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]
 
     # Pull tile info for compare
     tile_y_pos, tile_x_pos = reader.get_mosaic_tile_position(select_tile_index)
@@ -343,14 +342,14 @@ def test_czi_reader_mosaic_tile_inspection(
             position_ops.append(
                 slice(
                     tile_y_pos,
-                    tile_y_pos + reader.mosaic_tile_dims.Y,  # type: ignore
+                    tile_y_pos + reader.mosaic_tile_dims.Y,
                 )
             )
         if dim is dimensions.DimensionNames.SpatialX:
             position_ops.append(
                 slice(
                     tile_x_pos,
-                    tile_x_pos + reader.mosaic_tile_dims.X,  # type: ignore
+                    tile_x_pos + reader.mosaic_tile_dims.X,
                 )
             )
 
@@ -632,11 +631,8 @@ def test_roundtrip_save_all_scenes(
             (1, 6, 65, 233, 345),
             None,
             0,
-            # AttributeError raises not because of error in rollback
-            # but because cannot access Y or X from
-            # None return from `mosaic_tile_dims` because
-            # image is not a mosaic tiled image
-            marks=pytest.mark.raises(exception=AttributeError),
+            # File has no mosaic tiles
+            marks=pytest.mark.raises(exception=AssertionError),
         ),
     ],
 )
@@ -657,8 +653,11 @@ def test_mosaic_passthrough(
 
     # Assert basics
     assert img.shape == expected_shape
-    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]  # type: ignore
-    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]  # type: ignore
+
+    # Check test data mosaic tiles
+    assert img.mosaic_tile_dims is not None
+    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]
+    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]
 
     # Ensure that regardless of stitched or not, we can get tile position
     img.get_mosaic_tile_position(specific_tile_index)

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -248,10 +248,8 @@ def test_lif_reader_mosaic_stitching(
             None,
             None,
             None,
-            # The value returned from all of the calls is None
-            # Which when trying to operate on will raise an AttributeError
-            # Because None doesn't have a Y or X attribute for example
-            marks=pytest.mark.raises(exception=AttributeError),
+            # Doesn't have mosaic tiles
+            marks=pytest.mark.raises(exception=AssertionError),
         ),
     ],
 )
@@ -270,8 +268,9 @@ def test_lif_reader_mosaic_tile_inspection(
     reader.set_scene(set_scene)
 
     # Check basics
-    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]  # type: ignore
-    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]  # type: ignore
+    assert reader.mosaic_tile_dims is not None
+    assert reader.mosaic_tile_dims.Y == expected_tile_dims[0]
+    assert reader.mosaic_tile_dims.X == expected_tile_dims[1]
 
     # Pull tile info for compare
     tile_y_pos, tile_x_pos = reader.get_mosaic_tile_position(select_tile_index)
@@ -287,8 +286,8 @@ def test_lif_reader_mosaic_tile_inspection(
         :,
         :,
         :,
-        tile_y_pos : (tile_y_pos + reader.mosaic_tile_dims.Y),  # type: ignore
-        tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),  # type: ignore
+        tile_y_pos : (tile_y_pos + reader.mosaic_tile_dims.Y),
+        tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),
     ].compute()
 
     # Remove the first Y and X pixels
@@ -513,8 +512,9 @@ def test_mosaic_passthrough(
 
     # Assert basics
     assert img.shape == expected_shape
-    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]  # type: ignore
-    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]  # type: ignore
+    assert img.mosaic_tile_dims is not None
+    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]
+    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]
 
     # Ensure that regardless of stitched or not, we can get tile position
     img.get_mosaic_tile_position(specific_tile_index)

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -699,11 +699,8 @@ def test_parallel_read(
             (1, 6, 65, 233, 345),
             None,
             0,
-            # AttributeError raises not because of error in rollback
-            # but because cannot access Y or X from
-            # None return from `mosaic_tile_dims` because
-            # image is not a mosaic tiled image
-            marks=pytest.mark.raises(exception=AttributeError),
+            # The file has no tiles
+            marks=pytest.mark.raises(exception=AssertionError),
         ),
     ],
 )
@@ -724,8 +721,11 @@ def test_mosaic_passthrough(
 
     # Assert basics
     assert img.shape == expected_shape
-    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]  # type: ignore
-    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]  # type: ignore
+
+    # Check that the test data has tiles
+    assert img.mosaic_tile_dims is not None
+    assert img.mosaic_tile_dims.Y == expected_mosaic_tile_dims[0]
+    assert img.mosaic_tile_dims.X == expected_mosaic_tile_dims[1]
 
     # Ensure that regardless of stitched or not, we can get tile position
     img.get_mosaic_tile_position(specific_tile_index)

--- a/aicsimageio/tests/test_dimensions.py
+++ b/aicsimageio/tests/test_dimensions.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from typing import Collection, Tuple
+
 import pytest
 
 from aicsimageio.dimensions import Dimensions
-from typing import Iterable, Tuple
 
 
 def test_dimensions_getitem() -> None:
@@ -45,7 +46,7 @@ def test_dimensions_getitem() -> None:
     ],
 )
 def test_dimensions_mismatched_dims_len_and_shape_size(
-    dims: Iterable[str],
+    dims: Collection[str],
     shape: Tuple[int, ...],
 ) -> None:
     # Just check success
@@ -69,7 +70,7 @@ def test_dimensions_mismatched_dims_len_and_shape_size(
     ],
 )
 def test_dimensions_bad_iterable_of_characters(
-    dims: Iterable[str],
+    dims: Collection[str],
     shape: Tuple[int, ...],
 ) -> None:
     # Just check success

--- a/aicsimageio/tests/test_dimensions.py
+++ b/aicsimageio/tests/test_dimensions.py
@@ -19,4 +19,9 @@ def test_dimensions_getitem() -> None:
     with pytest.raises(IndexError):
         dims["blarg", "nope"]
     with pytest.raises(TypeError):
+        # Ironic we have to type ignore this because uhhh
+        # we are testing a TypeError
         dims[0]  # type: ignore
+
+    assert dims.T == 1
+    assert dims.order == "TCZYX"

--- a/aicsimageio/tests/test_dimensions.py
+++ b/aicsimageio/tests/test_dimensions.py
@@ -4,6 +4,7 @@
 import pytest
 
 from aicsimageio.dimensions import Dimensions
+from typing import Iterable, Tuple
 
 
 def test_dimensions_getitem() -> None:
@@ -25,3 +26,51 @@ def test_dimensions_getitem() -> None:
 
     assert dims.T == 1
     assert dims.order == "TCZYX"
+
+
+@pytest.mark.parametrize(
+    "dims, shape",
+    [
+        (["Z", "Y", "X"], (70, 980, 980)),
+        pytest.param(
+            "ZYXS",
+            (70, 980, 980),
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        pytest.param(
+            "YX",
+            (70, 980, 980),
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+    ],
+)
+def test_dimensions_mismatched_dims_len_and_shape_size(
+    dims: Iterable[str],
+    shape: Tuple[int, ...],
+) -> None:
+    # Just check success
+    assert Dimensions(dims, shape)
+
+
+@pytest.mark.parametrize(
+    "dims, shape",
+    [
+        (["Z", "Y", "X"], (70, 980, 980)),
+        pytest.param(
+            ["C", "ZY", "X"],
+            (70, 980, 980),
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        pytest.param(
+            ["YX"],
+            (70, 980, 980),
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+    ],
+)
+def test_dimensions_bad_iterable_of_characters(
+    dims: Iterable[str],
+    shape: Tuple[int, ...],
+) -> None:
+    # Just check success
+    assert Dimensions(dims, shape)

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -285,7 +285,7 @@ class OmeTiffWriter(Writer):
                 image_data = data[scene_index]
                 # Assumption: if provided a dask array to save, it can fit into memory
                 if isinstance(image_data, da.core.Array):
-                    image_data = data[scene_index].compute()  # type: ignore
+                    image_data = data[scene_index].compute()
 
                 description = xml if scene_index == 0 else None
                 # assume if first channel is rgb then all of it is


### PR DESCRIPTION
## Description

While debugging stuff earlier and digging around various repos to try to find the context of the bug (which, this digging around turned out to be irrelevant to the bug the user was having) I came across this comment from @GabeMedrash:

```python
# Ideally, would specify `aicsimageio ~= 4.7` or similar (note no match on patch version),
# but the Dimensions object is not properly typed and > 4.7 ships with a `py.typed` file.
# Once this is fixed in aicsimageio, this restrictive version-range can be loosened.
```

from: https://github.com/AllenCell/camera-alignment-core/blob/5ad01905a408dff2bc3c911906f87493a4a7e450/setup.py#L5

This PR solves that specific bug (which is that because our `Dimensions` object dynamically creates attributes, they aren't typed / mypy didn't know what to do with them.

```python
dims.X  # mypy was confused by this because X, Y, etc. were all dynamically added
```

But also is just a sweep through and clears a lot of the various `# type: ignore` comments. After this pass the repo is down to 22 usages of `# type: ignore`, many of those are `**kwargs` related which are really annoying to type properly and the others are seemingly always related to our flexibility in allowing dim_order, channel_names and related things to be provided as a single `str` a `List[str]` or `None`.

Happy to revert some of the changes in this if they look weird.


## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
