### PR TITLE
admin/ignore-fsspec-2022.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ benchmark_requirements = [
 
 requirements = [
     "dask[array]>=2021.4.1",
-    "fsspec>=2021.4.0",
+    "fsspec>=2021.4.0,!=2022.7.0",
     "imagecodecs>=2020.5.30",
     "lxml>=4.6,<5",
     "numpy>=1.16,<2",


### PR DESCRIPTION
## Description

Should have been a part of #422 imo. This makes it so users won't install fsspec 2022.7.0

Unlike the test upstreams changes PR am going to actually request reviews from people as this is a dep change.