### PR TITLE
feature/add-physical-pixel-sizes-param-to-array-like

### DIFF
--- a/aicsimageio/readers/array_like_reader.py
+++ b/aicsimageio/readers/array_like_reader.py
@@ -51,10 +51,13 @@ class ArrayLikeReader(Reader):
         provided to image.
         Default: None (create OME channel IDs for names for single or multiple arrays)
 
-    physical_pixel_sizes: Optional[Union[List[float], Dict[str, float], PhysicalPixelSizes]]
+    physical_pixel_sizes: Optional[
+        Union[List[float], Dict[str, float], PhysicalPixelSizes]
+    ]
         A specification of this image's physical pixel sizes. Can be provided as
         a list, dict or PhysicalPixelSizes object. If a list is passed, the assumed
-        order is [Z, Y, X]. If a dict is passed, it must contain "Z", "Y" and "X" as keys.
+        order is [Z, Y, X]. If a dict is passed, it must contain "Z", "Y" and "X"
+        as keys.
         Default: None
 
     Raises

--- a/aicsimageio/readers/array_like_reader.py
+++ b/aicsimageio/readers/array_like_reader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import Any, List, Optional, Tuple, Union, Dict
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -113,7 +113,9 @@ class ArrayLikeReader(Reader):
         image: Union[List[MetaArrayLike], MetaArrayLike],
         dim_order: Optional[Union[List[str], str]] = None,
         channel_names: Optional[Union[List[str], List[List[str]]]] = None,
-        physical_pixel_sizes: Optional[Union[List[float], Dict[str, float], PhysicalPixelSizes]] = None,
+        physical_pixel_sizes: Optional[
+            Union[List[float], Dict[str, float], PhysicalPixelSizes]
+        ] = None,
         **kwargs: Any,
     ):
         # Enforce valid image
@@ -371,9 +373,9 @@ class ArrayLikeReader(Reader):
         if isinstance(physical_pixel_sizes, PhysicalPixelSizes):
             self._physical_pixel_sizes = physical_pixel_sizes
         elif isinstance(physical_pixel_sizes, (list, tuple)):
-            self._physical_pixel_sizes = PhysicalPixelSizes(*self._physical_pixel_sizes)
+            self._physical_pixel_sizes = PhysicalPixelSizes(*physical_pixel_sizes)
         elif isinstance(physical_pixel_sizes, dict):
-            self._physical_pixel_sizes = PhysicalPixelSizes(**self._physical_pixel_sizes)
+            self._physical_pixel_sizes = PhysicalPixelSizes(**physical_pixel_sizes)
         else:
             self._physical_pixel_sizes = PhysicalPixelSizes(None, None, None)
 


### PR DESCRIPTION
## Description
Allow the specification of physical pixel sizes for array-like images

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
