### PR TITLE
bugfix/convert-dimension-spec-lists-to-slices-when-possible

### DIFF
--- a/aicsimageio/tests/test_transforms.py
+++ b/aicsimageio/tests/test_transforms.py
@@ -548,6 +548,6 @@ def test_generate_stack_mismatch_and_drop(
     ],
 )
 def test_convert_list_to_slice(
-    list_to_test: List, expected: Union[int, List, slice]
+    list_to_test: Union[List, Tuple], expected: Union[int, List, slice, Tuple]
 ) -> None:
     assert reduce_to_slice(list_to_test) == expected

--- a/aicsimageio/tests/test_transforms.py
+++ b/aicsimageio/tests/test_transforms.py
@@ -14,8 +14,8 @@ from aicsimageio import AICSImage, types
 from aicsimageio.exceptions import ConflictingArgumentsError, UnexpectedShapeError
 from aicsimageio.readers import ArrayLikeReader
 from aicsimageio.transforms import (
-    convert_list_to_slice,
     generate_stack,
+    reduce_to_slice,
     reshape_data,
     transpose_to_dims,
 )
@@ -539,9 +539,15 @@ def test_generate_stack_mismatch_and_drop(
         ([3, 5], slice(3, 6, 2)),
         ([8, 9, 11], [8, 9, 11]),
         ([15, 20, 25], slice(15, 26, 5)),
+        ((0,), 0),
+        ((0, 1), slice(0, 2, 1)),
+        ((1, 0), (1, 0)),
+        ((3, 5), slice(3, 6, 2)),
+        ((8, 9, 11), (8, 9, 11)),
+        ((15, 20, 25), slice(15, 26, 5)),
     ],
 )
 def test_convert_list_to_slice(
     list_to_test: List, expected: Union[int, List, slice]
 ) -> None:
-    assert convert_list_to_slice(list_to_test) == expected
+    assert reduce_to_slice(list_to_test) == expected

--- a/aicsimageio/tests/test_transforms.py
+++ b/aicsimageio/tests/test_transforms.py
@@ -13,7 +13,12 @@ import xarray as xr
 from aicsimageio import AICSImage, types
 from aicsimageio.exceptions import ConflictingArgumentsError, UnexpectedShapeError
 from aicsimageio.readers import ArrayLikeReader
-from aicsimageio.transforms import generate_stack, reshape_data, transpose_to_dims
+from aicsimageio.transforms import (
+    convert_list_to_slice,
+    generate_stack,
+    reshape_data,
+    transpose_to_dims,
+)
 
 
 @pytest.mark.parametrize("array_maker", [np.zeros, da.zeros])
@@ -523,3 +528,20 @@ def test_generate_stack_mismatch_and_drop(
         xr.testing.assert_allclose(stack, reference)
     else:
         np.testing.assert_allclose(stack, reference)
+
+
+@pytest.mark.parametrize(
+    "list_to_test, expected",
+    [
+        ([0], 0),
+        ([0, 1], slice(0, 2, 1)),
+        ([1, 0], [1, 0]),
+        ([3, 5], slice(3, 6, 2)),
+        ([8, 9, 11], [8, 9, 11]),
+        ([15, 20, 25], slice(15, 26, 5)),
+    ],
+)
+def test_convert_list_to_slice(
+    list_to_test: List, expected: Union[int, List, slice]
+) -> None:
+    assert convert_list_to_slice(list_to_test) == expected

--- a/aicsimageio/transforms.py
+++ b/aicsimageio/transforms.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -16,7 +16,7 @@ from .image_container import ImageContainer
 ###############################################################################
 
 
-def convert_list_to_slice(L: List) -> Union[int, List, slice]:
+def reduce_to_slice(L: Union[List, Tuple]) -> Union[int, List, slice, Tuple]:
     # if the list only has one element, then just use it
     if len(L) == 1:
         return L[0]
@@ -225,7 +225,7 @@ def reshape_data(
                 if isinstance(dim_spec, list):
                     check_selection_max = max([abs(min(dim_spec)), max(dim_spec)])
                     # try to convert to slice if possible
-                    dim_spec = convert_list_to_slice(dim_spec)
+                    dim_spec = reduce_to_slice(dim_spec)
 
                 # Get the largest absolute value index from start and stop of slice
                 if isinstance(dim_spec, slice):

--- a/aicsimageio/transforms.py
+++ b/aicsimageio/transforms.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 import dask.array as da
 import numpy as np
@@ -14,6 +14,22 @@ from .exceptions import ConflictingArgumentsError, UnexpectedShapeError
 from .image_container import ImageContainer
 
 ###############################################################################
+
+
+def convert_list_to_slice(L: List) -> Union[int, List, slice]:
+    # if the list only has one element, then just use it
+    if len(L) == 1:
+        return L[0]
+    # if the list has at least 2 elements we can check for sliceable
+    # it is convertable to a slice if the step size between each
+    # consecutive pair of elements is equal and positive
+    # 1. get all the deltas in a list:
+    steps = [(L[i + 1] - L[i]) for i in range(len(L) - 1)]
+    # 2. check if all the deltas are equal and positive
+    if steps[0] > 0 and steps.count(steps[0]) == len(steps):
+        return slice(min(L), max(L) + 1, steps[0])
+    # if we can't convert to a slice, then just return the list unmodified
+    return L
 
 
 def transpose_to_dims(
@@ -208,6 +224,8 @@ def reshape_data(
                 # Get the largest absolute value index in the list using min and max
                 if isinstance(dim_spec, list):
                     check_selection_max = max([abs(min(dim_spec)), max(dim_spec)])
+                    # try to convert to slice if possible
+                    dim_spec = convert_list_to_slice(dim_spec)
 
                 # Get the largest absolute value index from start and stop of slice
                 if isinstance(dim_spec, slice):


### PR DESCRIPTION
## Description

Trying to partially address #394:
When lists are passed as the indices for a dimension, numpy has trouble getting the slicing order correct.
This code change attempts to reduce the problem by converting the lists to slices whenever possible.

Lists that can not be turned into slices consist of: anything in non-increasing order, and anything in which the list does not increase by equal steps.  Those cases will continue to be broken.
It would be great if there were some elegant way to solve this for those remaining kinds of lists.