### PR TITLE
bug fix

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -269,6 +269,15 @@ class CziReader(Reader):
         scene_range = dims_shape_dict.get(CZI_SCENE_DIM_CHAR)
         if scene_range is None:
             return scene_index
+        if not consistent:
+            # we have selected a dims_shape_dict already based on scene index
+            # let's make sure the scene index is in the S range
+            if scene_index < scene_range[0] or scene_index >= scene_range[1]:
+                raise ValueError(
+                    f"Scene index {scene_index} is not in the range "
+                    f"{scene_range[0]} to {scene_range[1]}"
+                )
+            return scene_index
         return scene_range[0] + scene_index
 
     @staticmethod


### PR DESCRIPTION
## Description
Fix #430 
It was a regression.
The problem: multiscene czi file with "inconsistent" dims per scene was still having the scene index added as an offset, and it shouldn't.  So selecting scene 14 was resulting in reads from scene 14+14 = 28 which was out of range in this case.  In other cases the scene might be in range but would still obviously be reading from the wrong scene index.

When the scenes are "consistent", ie same dims for all scenes, then we wouldn't have this error.
