### PR TITLE
admin/include-fsspec-dep-for-czi-in-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in P
     -   `TIFF`
     -   `ND2` -- (`pip install aicsimageio[nd2]`)
     -   `DV` -- (`pip install aicsimageio[dv]`)
-    -   `CZI` -- (`pip install aicspylibczi>=3.0.5`)
+    -   `CZI` -- (`pip install aicspylibczi>=3.0.5 fsspec>=2022.7.1`)
     -   `LIF` -- (`pip install readlif>=0.6.4`)
     -   `PNG`, `GIF`, [etc.](https://github.com/imageio/imageio) -- (`pip install aicsimageio[base-imageio]`)
     -   Files supported by [Bio-Formats](https://docs.openmicroscopy.org/bio-formats/latest/supported-formats.html) -- (`pip install aicsimageio bioformats_jar`)
@@ -55,7 +55,7 @@ optionally installed using `[...]` syntax.
 -   For multiple additional supported formats: `pip install aicsimageio[base-imageio,nd2]`
 -   For all additional supported (and openly licensed) formats: `pip install aicsimageio[all]`
 -   Due to the GPL license, LIF support is not included with the `[all]` extra, and must be installed manually with `pip install aicsimageio readlif>=0.6.4`
--   Due to the GPL license, CZI support is not included with the `[all]` extra, and must be installed manually with `pip install aicsimageio aicspylibczi>=3.0.5`
+-   Due to the GPL license, CZI support is not included with the `[all]` extra, and must be installed manually with `pip install aicsimageio aicspylibczi>=3.0.5 fsspec>=2022.7.1`
 -   Due to the GPL license, Bio-Formats support is not included with the `[all]` extra, and must be installed manually with `pip install aicsimageio bioformats_jar`. **Important!!** Bio-Formats support also requires a `java` executable in the environment. The simplest method is to install `bioformats_jar` from conda: `conda install -c conda-forge bioformats_jar` (which will additionally bring `openjdk`).
 
 ## Documentation

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     raise ImportError(
         "aicspylibczi is required for this reader. "
-        "Install with `pip install aicspylibczi>=3.0.5"
+        "Install with `pip install 'aicspylibczi>=3.0.5' 'fsspec>=2022.7.1'`"
     )
 
 ###############################################################################

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     raise ImportError(
         "readlif is required for this reader. "
-        "Install with `pip install readlif>=0.6.4`"
+        "Install with `pip install 'readlif>=0.6.4'`"
     )
 
 ###############################################################################

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ format_libs: Dict[str, List[str]] = {
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],
     "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
-    # "czi": ["aicspylibczi>=3.0.5"],  # excluded for licensing reasons
+    "czi": [
+        "fsspec>=2022.7.1",
+        # "aicspylibczi>=3.0.5",  # excluded for licensing reasons
+    ],
     # "bioformats": ["bioformats_jar"],  # excluded for licensing reasons
     # "lif": ["readlif>=0.6.4"],  # excluded for licensing reasons
 }

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,9 @@ setenv =
     PYTHONPATH = {toxinidir}
 extras =
     test
-deps = aicspylibczi>=3.0.5
+deps = 
+    aicspylibczi>=3.0.5
+    fsspec>=2022.7.1
 commands =
     pytest --basetemp={envtmpdir} --cov-report xml --cov-report html --cov=aicsimageio aicsimageio/tests/readers/extra_readers/test_czi_reader.py {posargs}
 


### PR DESCRIPTION
## Description

Sorta solves #431?? We can't really fully solve it because forcing everyone to upgrade their fsspec envs may result in dependency management for them. The only reader that broke with the recent fsspec change was CZI. So updating the CZI install docs to include the fsspec upgrade.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

cc @psobolewskiPhD