### PR TITLE
fix/position-names-in-nd2-tests

### DIFF
--- a/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
@@ -12,6 +12,14 @@ from aicsimageio.tests.image_container_test_utils import run_image_file_checks
 
 from ...conftest import LOCAL, get_resource_full_path, host
 
+nd2 = pytest.importorskip("nd2")
+
+# nd2 0.4.3 and above improves detection of position names
+if tuple(int(x) for x in nd2.__version__.split(".")) >= (0, 4, 3):
+    pos_names = ("point name 1", "point name 2", "point name 3", "point name 4")
+else:
+    pos_names = ("XYPos:0", "XYPos:1", "XYPos:2", "XYPos:3")
+
 
 @host
 @pytest.mark.parametrize(
@@ -67,8 +75,8 @@ from ...conftest import LOCAL, get_resource_full_path, host
         ),
         (
             "ND2_dims_p4z5t3c2y32x32.nd2",
-            "XYPos:0",
-            ("XYPos:0", "XYPos:1", "XYPos:2", "XYPos:3"),
+            pos_names[0],
+            pos_names,
             (3, 5, 2, 32, 32),
             np.uint16,
             "TZCYX",
@@ -97,8 +105,8 @@ from ...conftest import LOCAL, get_resource_full_path, host
         ),
         (
             "ND2_dims_p2z5t3-2c4y32x32.nd2",
-            "XYPos:1",
-            ("XYPos:0", "XYPos:1"),
+            pos_names[1],
+            pos_names[:2],
             (5, 5, 4, 32, 32),
             np.uint16,
             "TZCYX",


### PR DESCRIPTION
## Description

[nd2 v0.4.3](https://github.com/tlambert03/nd2/releases/tag/v0.4.3) improved the detection of stage position names in metadata.  It will break on of the tests here though, since we were asserting that the position name was the default fallback name of `XYPos:N`.  This fixes tests in a nd2-version-aware way

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
