### PR TITLE
add lxml as parser in from_xml calls

### DIFF
--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -12,7 +12,7 @@ from fsspec.spec import AbstractFileSystem
 from ome_types import from_xml
 from ome_types.model.ome import OME
 from tifffile.tifffile import TiffFile, TiffFileError, TiffTags
-from xmlschema import XMLSchemaValidationError
+from lxml.etree import XMLSchemaValidateError
 
 from .. import constants, exceptions, transforms, types
 from ..dimensions import DEFAULT_CHUNK_DIMS, DEFAULT_DIMENSION_ORDER, DimensionNames
@@ -99,7 +99,7 @@ class OmeTiffReader(TiffReader):
             return False
 
         # invalid OME XMl
-        except XMLSchemaValidationError as e:
+        except XMLSchemaValidateError as e:
             log.debug(f"OME XML validation failed. Error: {e}")
             return False
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -66,7 +66,7 @@ class OmeTiffReader(TiffReader):
         if clean_metadata:
             ome_xml = metadata_utils.clean_ome_xml_for_known_issues(ome_xml)
 
-        return from_xml(ome_xml)
+        return from_xml(ome_xml, parser="lxml")
 
     @staticmethod
     def _is_supported_image(

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -12,6 +12,7 @@ from fsspec.spec import AbstractFileSystem
 from lxml.etree import XMLSchemaValidateError
 from ome_types import from_xml
 from ome_types.model.ome import OME
+from pydantic.error_wrappers import ValidationError
 from tifffile.tifffile import TiffFile, TiffFileError, TiffTags
 
 from .. import constants, exceptions, transforms, types
@@ -99,7 +100,7 @@ class OmeTiffReader(TiffReader):
             return False
 
         # invalid OME XMl
-        except XMLSchemaValidateError as e:
+        except (XMLSchemaValidateError, ValidationError) as e:
             log.debug(f"OME XML validation failed. Error: {e}")
             return False
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -9,10 +9,10 @@ from urllib.error import URLError
 import xarray as xr
 from fsspec.implementations.local import LocalFileSystem
 from fsspec.spec import AbstractFileSystem
+from lxml.etree import XMLSchemaValidateError
 from ome_types import from_xml
 from ome_types.model.ome import OME
 from tifffile.tifffile import TiffFile, TiffFileError, TiffTags
-from lxml.etree import XMLSchemaValidateError
 
 from .. import constants, exceptions, transforms, types
 from ..dimensions import DEFAULT_CHUNK_DIMS, DEFAULT_DIMENSION_ORDER, DimensionNames

--- a/aicsimageio/writers/ome_tiff_writer.py
+++ b/aicsimageio/writers/ome_tiff_writer.py
@@ -255,7 +255,7 @@ class OmeTiffWriter(Writer):
             )
         # else if string, then construct OME from string
         elif isinstance(ome_xml, str):
-            ome_xml = from_xml(ome_xml)
+            ome_xml = from_xml(ome_xml, parser="lxml")
 
         # if we do not have an OME object now, something is wrong
         if not isinstance(ome_xml, OME):
@@ -666,7 +666,7 @@ class OmeTiffWriter(Writer):
 
         # validate! (TODO: Is there a better api in ome-types for this?)
         test = to_xml(ome_object)
-        from_xml(test)
+        from_xml(test, parser="lxml")
 
         return ome_object
 

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ requirements = [
     "resource-backed-dask-array>=0.1.0",
     "tifffile>=2021.8.30",
     "xarray>=0.16.1",
-    "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",
 ]
 


### PR DESCRIPTION
## Description
Add `parser="lxml"` to `ome_types.from_xml` calls.
This silences a `FutureWarning`, which lets us know that `ome_types`'s default parser will be changing from `xmlschema` to `lxml`. This way we're adopting the incoming change explicitly, and since we're already depending on `lxml` we're not requiring any additional libs and we can stop requiring `xmlschema`.

I wanted to add a test to make sure the right error is raised [here](https://github.com/colobas/aicsimageio/blob/b88e1b65c062b0eabe265271c95e34e276237249/aicsimageio/readers/ome_tiff_reader.py#L102) but not quite sure how to produce a corrupted ome.tiff

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
