### PR TITLE
bugfix/Fix `UnboundLocalError` in TiffGlobReader

### DIFF
--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -148,7 +148,8 @@ class TiffGlobReader(Reader):
         elif isinstance(glob_in, Path) and "*" in str(glob_in):
             file_series = pd.Series(glob.glob(str(glob_in)))
         elif isinstance(glob_in, pd.Series):
-            file_series = glob_in
+            # Ensure all of our indices line up
+            file_series = glob_in.reset_index(drop=True, inplace=False)
         else:
             raise TypeError(f"Invalid type glob_in - got type {type(glob_in)}")
 
@@ -178,7 +179,10 @@ class TiffGlobReader(Reader):
             self._all_files = file_series.apply(indexer)
             self._all_files["filename"] = file_series
         elif isinstance(indexer, pd.DataFrame):
-            self._all_files = indexer
+            # make a copy of the indexing dataframe and reset it index
+            # to ensure that we don't generate nans when aligning with
+            # file_series.
+            self._all_files = indexer.reset_index(drop=True, inplace=False)
             self._all_files["filename"] = file_series
 
         # If a dim doesn't exist on the file set the column value for that dim to zero.

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -143,7 +143,7 @@ class TiffGlobReader(Reader):
         # Assemble glob list if given a string
         if isinstance(glob_in, str):
             file_series = pd.Series(glob.glob(glob_in))
-        elif isinstance(glob_in, list):
+        elif isinstance(glob_in, (list, tuple, np.ndarray)):
             file_series = pd.Series(glob_in)
         elif isinstance(glob_in, Path) and "*" in str(glob_in):
             file_series = pd.Series(glob.glob(str(glob_in)))

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -37,9 +37,9 @@ class TiffGlobReader(Reader):
 
     Parameters
     ----------
-    glob_in: Union[PathLike, List[PathLike]]
+    glob_in: Union[PathLike, List[PathLike], pd.Series[PathLike]]
         Glob string that identifies all files to be loaded or a list
-        of paths to the files as returned by glob.
+        or pandas Series of paths to the files as returned by glob.
     indexer: Union[Callable, pandas.DataFrame]
         If callable, should consume each filename and return a pd.Series with series
         index corresponding to the dimensions and values corresponding to the array
@@ -147,6 +147,10 @@ class TiffGlobReader(Reader):
             file_series = pd.Series(glob_in)
         elif isinstance(glob_in, Path) and "*" in str(glob_in):
             file_series = pd.Series(glob.glob(str(glob_in)))
+        elif isinstance(glob_in, pd.Series):
+            file_series = glob_in
+        else:
+            raise TypeError(f"Invalid type glob_in - got type {type(glob_in)}")
 
         if len(file_series) == 0:
             raise ValueError("No files found matching glob pattern")

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -5,7 +5,7 @@ import glob
 import re
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -37,9 +37,9 @@ class TiffGlobReader(Reader):
 
     Parameters
     ----------
-    glob_in: Union[PathLike, List[PathLike], pd.Series[PathLike]]
-        Glob string that identifies all files to be loaded or a list
-        or pandas Series of paths to the files as returned by glob.
+    glob_in: Union[PathLike, Iterable[PathLike]]
+        Glob string that identifies all files to be loaded or an iterable
+        of paths to the files as returned by glob.
     indexer: Union[Callable, pandas.DataFrame]
         If callable, should consume each filename and return a pd.Series with series
         index corresponding to the dimensions and values corresponding to the array
@@ -125,7 +125,7 @@ class TiffGlobReader(Reader):
 
     def __init__(
         self,
-        glob_in: Union[types.PathLike, List[types.PathLike]],
+        glob_in: Union[types.PathLike, Iterable[types.PathLike]],
         indexer: Union[pd.DataFrame, Callable] = None,
         scene_glob_character: str = "S",
         chunk_dims: Union[str, List[str]] = DEFAULT_CHUNK_DIMS,
@@ -143,13 +143,13 @@ class TiffGlobReader(Reader):
         # Assemble glob list if given a string
         if isinstance(glob_in, str):
             file_series = pd.Series(glob.glob(glob_in))
-        elif isinstance(glob_in, (list, tuple, np.ndarray)):
-            file_series = pd.Series(glob_in)
         elif isinstance(glob_in, Path) and "*" in str(glob_in):
             file_series = pd.Series(glob.glob(str(glob_in)))
         elif isinstance(glob_in, pd.Series):
             # Ensure all of our indices line up
             file_series = glob_in.reset_index(drop=True, inplace=False)
+        elif isinstance(glob_in, Iterable):
+            file_series = pd.Series(glob_in)
         else:
             raise TypeError(f"Invalid type glob_in - got type {type(glob_in)}")
 

--- a/aicsimageio/tests/readers/test_glob_reader.py
+++ b/aicsimageio/tests/readers/test_glob_reader.py
@@ -2,6 +2,7 @@
 import os
 from itertools import product
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -96,15 +97,16 @@ def test_index_alignment(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "type_", [
+    "type_",
+    [
         list,
         pd.Series,
-        np.array, 
+        np.array,
         # should throw a TypeError instead of an unboundlocal error
-        pytest.param(bytes, marks=pytest.mark.raises(exception=TypeError)), 
-    ]
+        pytest.param(bytes, marks=pytest.mark.raises(exception=TypeError)),
+    ],
 )
-def test_glob_types(type_, tmp_path: Path) -> None:
+def test_glob_types(type_: Any, tmp_path: Path) -> None:
     reference = make_fake_data_2d(tmp_path)
     filenames = list((tmp_path / "2d_images").glob("*.tif"))
 

--- a/aicsimageio/tests/readers/test_glob_reader.py
+++ b/aicsimageio/tests/readers/test_glob_reader.py
@@ -4,6 +4,7 @@ from itertools import product
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import tifffile as tiff
 import xarray as xr
 
@@ -66,6 +67,31 @@ def test_glob_reader_2d(tmp_path: Path) -> None:
     assert gr.xarray_dask_data.data.chunksize == (1, 1) + DATA_SHAPE[-3:]
 
     check_values(gr, reference)
+
+
+def test_index_alignment(tmp_path: Path) -> None:
+    # Testing case where user has passed in a list of files
+    # and a dataframe with non-continuous index
+
+    # use as_mm to have an easily available Indexer function
+    _ = make_fake_data_2d(tmp_path, as_mm=True)
+    filenames = np.array(list((tmp_path / "2d_images").glob("*.tif")))
+    # print(filenames)
+    indexer = pd.Series(filenames).apply(TiffGlobReader.MicroManagerIndexer)
+
+    # Keep only some of the Z
+    # more realistic case is eliminating everything after a given time point
+    # but this garuntees that our eliminated images will be embedded all through the
+    # order rather than just at the end
+    keep = indexer.Z < 5
+
+    indexer = indexer.loc[keep]
+
+    reader = TiffGlobReader(filenames[keep].tolist(), indexer)
+
+    # check that there are no nans
+    # nans are a symptom of index misalignment
+    assert not reader._all_files.isnull().any().any()
 
 
 def test_mm_indexer(tmp_path: Path) -> None:

--- a/aicsimageio/tests/readers/test_glob_reader.py
+++ b/aicsimageio/tests/readers/test_glob_reader.py
@@ -95,25 +95,21 @@ def test_index_alignment(tmp_path: Path) -> None:
     assert not reader._all_files.isnull().any().any()
 
 
-def test_glob_types(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "type_", [
+        list,
+        pd.Series,
+        np.array, 
+        # should throw a TypeError instead of an unboundlocal error
+        pytest.param(bytes, marks=pytest.mark.raises(exception=TypeError)), 
+    ]
+)
+def test_glob_types(type_, tmp_path: Path) -> None:
     reference = make_fake_data_2d(tmp_path)
     filenames = list((tmp_path / "2d_images").glob("*.tif"))
 
-    # list
-    gr = TiffGlobReader(list(filenames))
+    gr = TiffGlobReader(type_(filenames))
     check_values(gr, reference)
-
-    # pd.Series
-    gr = TiffGlobReader(pd.Series(filenames))
-    check_values(gr, reference)
-
-    # np.array
-    gr = TiffGlobReader(np.array(filenames))
-    check_values(gr, reference)
-
-    with pytest.raises(TypeError):
-        # should throw a TypeError instead of an unboundlocal error
-        TiffGlobReader(2022)  # type: ignore
 
 
 def test_mm_indexer(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

I passed a `pd.Series` of files to `TiffGlobReader` and got this error: `UnboundLocalError: local variable 'file_series' referenced before assignment`.

This prevents that error by raising a `TypeError` if passed an invalid type, and also allows for `glob_in` to be a pandas series.

As ever for tiffglobreader cc @jrussell25 

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [NA] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
