### PR TITLE
fix/fix_future_warnings

### DIFF
--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -322,7 +322,7 @@ class TiffGlobReader(Reader):
         unpack_sizes = OrderedDict(
             [
                 (d, s)
-                for d, s in scene_nunique.iteritems()
+                for d, s in scene_nunique.items()
                 if d in chunk_sizes.keys() - group_sizes.keys()
             ]
         )
@@ -473,7 +473,7 @@ class TiffGlobReader(Reader):
     ) -> OrderedDict:
 
         sizes = OrderedDict()
-        for i, x in scene_files_nunique.iteritems():
+        for i, x in scene_files_nunique.items():
             if i not in ["filename", *group_dims]:
                 if i not in self._single_file_dims:
                     sizes[i] = x

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ test_requirements = [
     "pytest-raises>=0.11",
     "quilt3",  # no pin to avoid pip cycling (boto is really hard to manage)
     "s3fs[boto3]>=0.4.2",
-    "tox>=3.15.2",
+    "tox>=3.27.1",
 ]
 
 dev_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ test_requirements = [
     "pytest-raises>=0.11",
     "quilt3",  # no pin to avoid pip cycling (boto is really hard to manage)
     "s3fs[boto3]>=0.4.2",
-    "tox>=3.27.1",
+    "tox==3.27.1",
 ]
 
 dev_requirements = [


### PR DESCRIPTION
## Description

I encountered the following future warnings

```
FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for i, x in scene_files_nunique.iteritems():
```
I applied the suggested fix which is to use  `.items`

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [?] Provide relevant tests for your feature or bug fix.

Thanks for contributing!
