### PR TITLE
bugfix/catch-invalid-XMLAnnotationID

### DIFF
--- a/aicsimageio/metadata/utils.py
+++ b/aicsimageio/metadata/utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from cProfile import label
 import logging
 import os
 import re


### PR DESCRIPTION
## Description
fixes https://github.com/AllenCellModeling/aicsimageio/issues/454

This PR is sufficient to get the xml/h5 dataset linked in the original issue reading with the bioformats reader... (and lets me think a bit longer about how I want to handle invalid schemas over in ome-types)

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
