### PR TITLE
feature/add-physical-pixel-size-to-tiff-reader

### DIFF
--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -8,7 +8,7 @@ import numpy as np
 import xarray as xr
 from dask import delayed
 from fsspec.spec import AbstractFileSystem
-from tifffile import TiffFile, TiffFileError, imread
+from tifffile import TiffFile, TiffFileError, imread, TIFF
 from tifffile.tifffile import TiffTags
 
 from .. import constants, exceptions, types
@@ -57,6 +57,7 @@ class TiffReader(Reader):
         Any specific keyword arguments to pass down to the fsspec created filesystem.
         Default: {}
     """
+
     _physical_pixel_sizes: Optional[PhysicalPixelSizes] = None
 
     @staticmethod
@@ -136,6 +137,7 @@ class TiffReader(Reader):
 
     @property
     def physical_pixel_sizes(self) -> PhysicalPixelSizes:
+        """Return the physical pixel sizes of the image."""
         if self._physical_pixel_sizes is None:
             with self._fs.open(self._path) as open_resource:
                 with TiffFile(open_resource) as tiff:
@@ -556,29 +558,25 @@ class TiffReader(Reader):
                     attrs=attrs,
                 )
 
+
 _NAME_TO_MICRONS = {
     "pm": 1e-6,
     "picometer": 1e-6,
-
     "nm": 1e-3,
     "nanometer": 1e-3,
-
     "micron": 1,
     "µm": 1,
     "um": 1,
-    1: 1,       # tifffile RESUNIT.NONE
-    5: 1,  # tifffile RESUNIT.MICROMETER
-    "\\u00B5m": 1,  # µm
+    "\\u00B5m": 1,  # µm unicode
+    TIFF.RESUNIT.NONE: 1,
+    TIFF.RESUNIT.MICROMETER: 1,
     None: 1,
-
     "mm": 1e3,
     "millimeter": 1e3,
-    4: 1e3,  # tifffile RESUNIT.MILLIMETER
-
+    TIFF.RESUNIT.MILLIMETER: 1e3,
     "cm": 1e4,
     "centimeter": 1e4,
-    3: 1e4,  # tifffile RESUNIT.CENTIMETER
-
+    TIFF.RESUNIT.CENTIMETER: 1e4,
     "cal": 2.54 * 1e4,
-    2: 2.54 * 1e4,  # tifffile RESUNIT.INCH
+    TIFF.RESUNIT.INCH: 2.54 * 1e4,
 }

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -576,7 +576,9 @@ _NAME_TO_MICRONS = {
 }
 
 
-def _get_pixel_size(path_or_file: Any, series_index: int) -> Tuple[float, float, float]:
+def _get_pixel_size(
+    path_or_file: Any, series_index: int
+) -> Tuple[Optional[float], Optional[float], Optional[float]]:
     """Return the pixel size in microns (z,y,x) for the given series in a tiff path."""
 
     with TiffFile(path_or_file) as tiff:

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -29,7 +29,8 @@ from ..image_container_test_utils import (
     "expected_shape, "
     "expected_dtype, "
     "expected_dims_order, "
-    "expected_channel_names",
+    "expected_channel_names, "
+    "expected_physical_pixel_sizes",
     [
         (
             "s_1_t_1_c_1_z_1.ome.tiff",
@@ -39,6 +40,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "YX",
             None,
+            (None, 1.0833333604166673, 1.0833333604166673),
         ),
         (
             "s_1_t_1_c_1_z_1.tiff",
@@ -48,6 +50,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "YX",
             None,
+            (None, 1.08333441666775, 1.08333441666775)
         ),
         (
             "s_1_t_1_c_10_z_1.ome.tiff",
@@ -57,6 +60,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "CYX",
             [f"Channel:0:{i}" for i in range(10)],
+            (None, 1, 1)
         ),
         (
             "s_1_t_10_c_3_z_1.tiff",
@@ -66,6 +70,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "TCYX",
             ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
+            (None, 1.08333441666775, 1.08333441666775)
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -75,6 +80,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "ZCYX",
             ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
+            (None, 1.0833333604166673, 1.0833333604166673)
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -84,6 +90,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "ZCYX",
             ["Channel:1:0", "Channel:1:1", "Channel:1:2"],
+            (None, 1.0833333604166673, 1.0833333604166673)
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -93,6 +100,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "ZCYX",
             ["Channel:2:0", "Channel:2:1", "Channel:2:2"],
+            (None, 1.0833333604166673, 1.0833333604166673)
         ),
         (
             "s_1_t_1_c_1_z_1_RGB.tiff",
@@ -102,6 +110,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "YXS",  # S stands for samples dimension
             None,
+            (None, None, None),
         ),
         (
             # Doesn't affect this test but this is actually an OME-TIFF file
@@ -112,6 +121,7 @@ from ..image_container_test_utils import (
             np.uint8,
             "CYXS",  # S stands for samples dimension
             ["Channel:0:0", "Channel:0:1"],
+            (None, 1, 1),
         ),
         pytest.param(
             "example.txt",
@@ -121,6 +131,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
+            (None, None, None),
             marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
@@ -131,6 +142,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
+            (None, None, None),
             marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
@@ -141,6 +153,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
+            (None, None, None),
             marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
@@ -151,6 +164,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
+            (None, None, None),
             marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
@@ -164,6 +178,9 @@ def test_tiff_reader(
     expected_dtype: np.dtype,
     expected_dims_order: str,
     expected_channel_names: List[str],
+    expected_physical_pixel_sizes: Tuple[
+        Optional[float], Optional[float], Optional[float]
+    ],
 ) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, host)
@@ -179,7 +196,7 @@ def test_tiff_reader(
         expected_dtype=expected_dtype,
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
-        expected_physical_pixel_sizes=(None, None, None),
+        expected_physical_pixel_sizes=expected_physical_pixel_sizes,
         expected_metadata_type=str,
     )
 
@@ -278,7 +295,7 @@ def test_micromanager_ome_tiff_binary_file() -> None:
         # because we swap the dimensions into "standard" order
         expected_dims_order="TZCYX",
         expected_channel_names=["Channel:0:0", "Channel:0:1", "Channel:0:2"],
-        expected_physical_pixel_sizes=(None, None, None),
+        expected_physical_pixel_sizes=(1.75, 0.0002, 0.0002),
         expected_metadata_type=str,
     )
 
@@ -302,7 +319,7 @@ def test_micromanager_ome_tiff_binary_file() -> None:
             np.uint16,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
-            (None, None, None),
+            (None, 1.08333441666775, 1.08333441666775),
             str,
         ),
         (

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -50,7 +50,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "YX",
             None,
-            (None, 1.08333441666775, 1.08333441666775)
+            (None, 1.08333441666775, 1.08333441666775),
         ),
         (
             "s_1_t_1_c_10_z_1.ome.tiff",
@@ -60,7 +60,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "CYX",
             [f"Channel:0:{i}" for i in range(10)],
-            (None, 1, 1)
+            (None, 1, 1),
         ),
         (
             "s_1_t_10_c_3_z_1.tiff",
@@ -70,7 +70,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "TCYX",
             ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
-            (None, 1.08333441666775, 1.08333441666775)
+            (None, 1.08333441666775, 1.08333441666775),
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -80,7 +80,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "ZCYX",
             ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
-            (None, 1.0833333604166673, 1.0833333604166673)
+            (None, 1.0833333604166673, 1.0833333604166673),
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -90,7 +90,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "ZCYX",
             ["Channel:1:0", "Channel:1:1", "Channel:1:2"],
-            (None, 1.0833333604166673, 1.0833333604166673)
+            (None, 1.0833333604166673, 1.0833333604166673),
         ),
         (
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -100,7 +100,7 @@ from ..image_container_test_utils import (
             np.uint16,
             "ZCYX",
             ["Channel:2:0", "Channel:2:1", "Channel:2:2"],
-            (None, 1.0833333604166673, 1.0833333604166673)
+            (None, 1.0833333604166673, 1.0833333604166673),
         ),
         (
             "s_1_t_1_c_1_z_1_RGB.tiff",

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -24,4 +24,3 @@ class PhysicalPixelSizes(NamedTuple):
     Z: Optional[float]
     Y: Optional[float]
     X: Optional[float]
-    unit: Optional[str] = 'um'

--- a/aicsimageio/types.py
+++ b/aicsimageio/types.py
@@ -24,3 +24,4 @@ class PhysicalPixelSizes(NamedTuple):
     Z: Optional[float]
     Y: Optional[float]
     X: Optional[float]
+    unit: Optional[str] = 'um'


### PR DESCRIPTION
## Description

closes https://github.com/AllenCellModeling/aicsimageio/issues/450 by implementing `physical_pixel_sizes` for the default TiffReader
 
## Pull request recommendations:
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
