### PR TITLE
More descriptive scene index error message.

### DIFF
--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -247,8 +247,8 @@ class Reader(ImageContainer, ABC):
                 if scene_id >= len(self.scenes):
                     raise IndexError(
                         f"Scene index: {scene_id} "
-                        f"is greater than the number of available scenes "
-                        f"present in the file."
+                        f"is greater than the maximum availabe scene index "
+                        f"({len(self.scenes) - 1}) present in the file."
                     )
 
                 # Update current scene

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -247,7 +247,7 @@ class Reader(ImageContainer, ABC):
                 if scene_id >= len(self.scenes):
                     raise IndexError(
                         f"Scene index: {scene_id} "
-                        f"is greater than the maximum availabe scene index "
+                        f"is greater than the maximum available scene index "
                         f"({len(self.scenes) - 1}) present in the file."
                     )
 


### PR DESCRIPTION
## The issue
If you read a file with 49 scenes and try to use scene index 49 to get the last one, the error message doesn't make the off-by-one error clear, since 49 is not greater than 49. 

## The fix
Update the error message

## Extra context
This issue came up because the AICS camera alignment service takes the scene index as user input through a web UI -- we should improve that UI, but this can help too.