### PR TITLE
Bugfix: Fix tests not asserting error expected

### DIFF
--- a/aicsimageio/tests/readers/extra_readers/test_bioformats_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_bioformats_reader.py
@@ -94,7 +94,7 @@ SERIES_0 = "PRIMARY" if bf_version > (6, 7) else "Series 0"
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         (
             "s_3_t_1_c_3_z_5.czi",
@@ -235,7 +235,7 @@ SERIES_0 = "PRIMARY" if bf_version > (6, 7) else "Series 0"
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
@@ -36,7 +36,7 @@ from ...image_container_test_utils import (
             "s_1_t_1_c_1_z_1.ome.tiff",
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )
@@ -159,7 +159,7 @@ def test_subblocks(filename: str, num_subblocks: int, acquistion_time: str) -> N
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "s_1_t_1_c_1_z_1.ome.tiff",
@@ -170,7 +170,7 @@ def test_subblocks(filename: str, num_subblocks: int, acquistion_time: str) -> N
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )
@@ -286,7 +286,7 @@ def test_czi_reader_mosaic_stitching(
             (440, 544),
             999,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             "s_1_t_1_c_1_z_1.czi",
@@ -295,7 +295,7 @@ def test_czi_reader_mosaic_stitching(
             None,
             None,
             # File has no mosaic tiles
-            marks=pytest.mark.raises(exception=AssertionError),
+            marks=pytest.mark.xfail(raises=AssertionError),
         ),
     ],
 )
@@ -510,7 +510,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=TypeError),
+            marks=pytest.mark.xfail(raises=TypeError),
         ),
     ],
 )
@@ -632,7 +632,7 @@ def test_roundtrip_save_all_scenes(
             None,
             0,
             # File has no mosaic tiles
-            marks=pytest.mark.raises(exception=AssertionError),
+            marks=pytest.mark.xfail(raises=AssertionError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/extra_readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_default_reader.py
@@ -39,14 +39,14 @@ from ...image_container_test_utils import run_image_file_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "example.png",
             "Image:1",
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )
@@ -206,7 +206,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Check providing too many channels
         pytest.param(
@@ -217,7 +217,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Check providing channels but no channel dim
         pytest.param(
@@ -228,7 +228,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/extra_readers/test_dv_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_dv_reader.py
@@ -33,7 +33,7 @@ from ...conftest import LOCAL, get_resource_full_path, host
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         (
             "DV_siRNAi-HeLa_IN_02.r3d_D3D.dv",

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -72,7 +72,7 @@ from ...image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "3d-cell-viewer.ome.tiff",
@@ -83,7 +83,7 @@ from ...image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )
@@ -170,9 +170,7 @@ def test_sanity_check_correct_indexing(
             "merged-tiles.lif",
             "b2_001_Crop001_Resize001",
             "TileScan_002_Merging",
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )
@@ -240,7 +238,7 @@ def test_lif_reader_mosaic_stitching(
             (512, 512),
             999,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             "merged-tiles.lif",
@@ -249,7 +247,7 @@ def test_lif_reader_mosaic_stitching(
             None,
             None,
             # Doesn't have mosaic tiles
-            marks=pytest.mark.raises(exception=AssertionError),
+            marks=pytest.mark.xfail(raises=AssertionError),
         ),
     ],
 )
@@ -491,7 +489,7 @@ def test_roundtrip_save_all_scenes(
             (165, 1, 4, 1, 512, 512),
             (512, 512),
             999,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
@@ -41,7 +41,7 @@ else:
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "ND2_aryeh_but3_cont200-1.nd2",

--- a/aicsimageio/tests/readers/extra_readers/test_ome_tiled_tiff_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_ome_tiled_tiff_reader.py
@@ -57,7 +57,7 @@ from ...image_container_test_utils import run_image_file_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "example.txt",
@@ -68,7 +68,7 @@ from ...image_container_test_utils import run_image_file_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "s_1_t_1_c_2_z_1.lif",
@@ -79,7 +79,7 @@ from ...image_container_test_utils import run_image_file_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/test_array_like_reader.py
+++ b/aicsimageio/tests/readers/test_array_like_reader.py
@@ -726,7 +726,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         pytest.param(
             [np.random.rand(1, 1), np.random.rand(1, 1, 1, 1)],
@@ -737,7 +737,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Test mismatching mapping of arrays to channel_names
         pytest.param(
@@ -749,7 +749,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         pytest.param(
             [np.random.rand(1, 1, 1, 1), (1, 1, 1, 1, 1)],
@@ -760,7 +760,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Test dim string compare to dims shape
         pytest.param(
@@ -772,7 +772,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # Test channel names length to size of channel dim
         pytest.param(
@@ -784,7 +784,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # Test channel names provided when no channel dim present
         pytest.param(
@@ -796,7 +796,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # Test that without dim_order and with more than five dims, it raises an error
         # Our guess dim order only support up to five dims
@@ -809,9 +809,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(
-                exceptions=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         pytest.param(
             "hello world",
@@ -822,7 +820,7 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )
@@ -1086,9 +1084,7 @@ def test_arraylike_reader(
             None,
             None,
             None,
-            marks=pytest.mark.raises(
-                exceptions=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         pytest.param(
             "hello world",
@@ -1099,7 +1095,7 @@ def test_arraylike_reader(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/test_array_like_reader.py
+++ b/aicsimageio/tests/readers/test_array_like_reader.py
@@ -716,6 +716,17 @@ from ..image_container_test_utils import run_image_container_checks
             "CZYX",
             ["A"],
         ),
+        # Test supporting six dimensions without explicit dim_order supplied
+        (
+            np.random.rand(1, 2, 3, 4, 5, 6),
+            None,
+            None,
+            "Image:0",
+            ("Image:0",),
+            (1, 2, 3, 4, 5, 6),
+            "TCZYXS",
+            ["Channel:0:0", "Channel:0:1"],
+        ),
         # Test mismatching mapping of arrays to dim_order
         pytest.param(
             [np.random.rand(1, 1)],
@@ -752,7 +763,7 @@ from ..image_container_test_utils import run_image_container_checks
             marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         pytest.param(
-            [np.random.rand(1, 1, 1, 1), (1, 1, 1, 1, 1)],
+            [np.random.rand(1, 1, 1, 1), np.random.rand(1, 1, 1, 1, 1)],
             None,
             [["A"], ["B"], ["C"]],
             None,
@@ -798,10 +809,10 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        # Test that without dim_order and with more than five dims, it raises an error
-        # Our guess dim order only support up to five dims
+        # Test that without dim_order and with more than six dims, it raises an error
+        # Our guess dim order only support up to six dims
         pytest.param(
-            np.random.rand(1, 2, 3, 4, 5, 6),
+            np.random.rand(1, 2, 3, 4, 5, 6, 7),
             None,
             None,
             None,
@@ -1073,21 +1084,21 @@ def test_arraylike_reader(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:1:0", "Channel:1:1", "Channel:1:2", "Channel:1:3"],
         ),
-        # Test that without dims and with more than five dims, it raises an error
-        # Our guess dim order only support up to five dims
-        pytest.param(
+        # Test supporting six dimensions without explicit dim_order supplied
+        (
             np.random.rand(1, 2, 3, 4, 5, 6),
             None,
             None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
+            "Image:0",
+            ("Image:0",),
+            (1, 2, 3, 4, 5, 6),
+            "TCZYXS",
+            ["Channel:0:0", "Channel:0:1"],
         ),
+        # Test that with more than 6 dims, it raises an error
+        # Our guess dim order only support up to six dims
         pytest.param(
-            "hello world",
+            np.random.rand(1, 2, 3, 4, 5, 6, 7),
             None,
             None,
             None,

--- a/aicsimageio/tests/readers/test_glob_reader.py
+++ b/aicsimageio/tests/readers/test_glob_reader.py
@@ -103,7 +103,7 @@ def test_index_alignment(tmp_path: Path) -> None:
         pd.Series,
         np.array,
         # should throw a TypeError instead of an unboundlocal error
-        pytest.param(bytes, marks=pytest.mark.raises(exception=TypeError)),
+        pytest.param(bytes, marks=pytest.mark.xfail(raises=TypeError)),
     ],
 )
 def test_glob_types(type_: Any, tmp_path: Path) -> None:

--- a/aicsimageio/tests/readers/test_ome_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_ome_tiff_reader.py
@@ -105,7 +105,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "s_1_t_1_c_2_z_1.lif",
@@ -116,7 +116,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "s_1_t_1_c_1_z_1.ome.tiff",
@@ -127,7 +127,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -138,7 +138,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )
@@ -399,12 +399,12 @@ def test_multi_resolution_ome_tiff_reader(
         "variance-cfe.ome.tiff",
         pytest.param(
             "actk.ome.tiff",
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         # This file has a namespace that doesn't exist
         pytest.param(
             "s_1_t_1_c_10_z_1.ome.tiff",
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )
@@ -593,7 +593,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -601,7 +601,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )
@@ -692,7 +692,7 @@ def test_parallel_read(
             None,
             0,
             # The file has no tiles
-            marks=pytest.mark.raises(exception=AssertionError),
+            marks=pytest.mark.xfail(raises=AssertionError),
         ),
     ],
 )
@@ -760,7 +760,7 @@ def test_selected_tiff_reader(
             {},
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -14,7 +14,7 @@ from aicsimageio import AICSImage, dimensions, exceptions
 from aicsimageio.readers import TiffReader
 from aicsimageio.readers.reader import Reader
 
-from ..conftest import LOCAL, REMOTE, get_resource_full_path, host
+from ..conftest import LOCAL, get_resource_full_path, host
 from ..image_container_test_utils import (
     run_image_file_checks,
     run_multi_scene_image_read_checks,
@@ -612,7 +612,6 @@ def test_parallel_read(
 
 @pytest.mark.parametrize(
     "filename, "
-    "host, "
     "first_scene, "
     "expected_first_chunk_shape, "
     "second_scene, "
@@ -620,7 +619,6 @@ def test_parallel_read(
     [
         (
             "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif",
-            LOCAL,
             0,
             (50, 5, 256, 256),
             1,
@@ -628,27 +626,16 @@ def test_parallel_read(
         ),
         (
             "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif",
-            LOCAL,
             1,
             (50, 5, 256, 256),
             0,
             (50, 5, 256, 256),
-        ),
-        pytest.param(
-            "image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif",
-            REMOTE,
-            1,  # Start with second scene to trigger error faster
-            (50, 5, 256, 256),
-            0,
-            (50, 5, 256, 256),
-            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )
 @pytest.mark.parametrize("processes", [True, False])
 def test_parallel_multifile_tiff_read(
     filename: str,
-    host: str,
     first_scene: int,
     expected_first_chunk_shape: Tuple[int, ...],
     second_scene: int,
@@ -663,7 +650,7 @@ def test_parallel_multifile_tiff_read(
     read properly from each file.
     """
     # Construct full filepath
-    uri = get_resource_full_path(filename, host)
+    uri = get_resource_full_path(filename, LOCAL)
 
     # Init image
     img = AICSImage(uri)

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -121,7 +121,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "s_1_t_1_c_2_z_1.lif",
@@ -131,7 +131,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "s_1_t_1_c_1_z_1.ome.tiff",
@@ -141,7 +141,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             "s_3_t_1_c_3_z_5.ome.tiff",
@@ -151,7 +151,7 @@ from ..image_container_test_utils import (
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )
@@ -426,7 +426,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Check providing too many channels
         pytest.param(
@@ -437,7 +437,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Check providing channels but no channel dim
         pytest.param(
@@ -448,7 +448,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Check number of scenes dims list matches n scenes
         pytest.param(
@@ -459,7 +459,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # Check number of scenes channels list matches n scenes
         pytest.param(
@@ -470,7 +470,7 @@ def test_aicsimage(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exceptions=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
     ],
 )
@@ -641,7 +641,7 @@ def test_parallel_read(
             (50, 5, 256, 256),
             0,
             (50, 5, 256, 256),
-            marks=pytest.mark.raises(exceptions=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )

--- a/aicsimageio/tests/test_aics_image.py
+++ b/aicsimageio/tests/test_aics_image.py
@@ -13,11 +13,11 @@ from .conftest import LOCAL, get_resource_full_path
     [
         pytest.param(
             "example.txt",
-            marks=pytest.mark.raises(exception=exceptions.UnsupportedFileFormatError),
+            marks=pytest.mark.xfail(raises=exceptions.UnsupportedFileFormatError),
         ),
         pytest.param(
             "does-not-exist-klafjjksdafkjl.bad",
-            marks=pytest.mark.raises(exception=FileNotFoundError),
+            marks=pytest.mark.xfail(raises=FileNotFoundError),
         ),
     ],
 )

--- a/aicsimageio/tests/test_dimensions.py
+++ b/aicsimageio/tests/test_dimensions.py
@@ -36,12 +36,12 @@ def test_dimensions_getitem() -> None:
         pytest.param(
             "ZYXS",
             (70, 980, 980),
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(
             "YX",
             (70, 980, 980),
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
     ],
 )
@@ -60,12 +60,12 @@ def test_dimensions_mismatched_dims_len_and_shape_size(
         pytest.param(
             ["C", "ZY", "X"],
             (70, 980, 980),
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(
             ["YX"],
             (70, 980, 980),
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
     ],
 )

--- a/aicsimageio/tests/test_transforms.py
+++ b/aicsimageio/tests/test_transforms.py
@@ -77,7 +77,7 @@ from aicsimageio.transforms import (
             "TYXC",
             {"Z": 7},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -85,7 +85,7 @@ from aicsimageio.transforms import (
             "TYXCZ",
             {"Z": 7},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -93,7 +93,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": 7},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -101,7 +101,7 @@ from aicsimageio.transforms import (
             "TYXCX",
             {"Z": [0, 1, 4]},
             None,
-            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=ConflictingArgumentsError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -109,7 +109,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": [0, 1, 7]},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -117,7 +117,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": (0, 1, 7)},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -125,7 +125,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": range(7)},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -133,7 +133,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": slice(0, 7, 2)},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -141,7 +141,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": [0, 1, -7]},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -149,7 +149,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": (0, 1, -7)},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -157,7 +157,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": range(0, -8, -1)},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
         pytest.param(
             (6, 200, 400),
@@ -165,7 +165,7 @@ from aicsimageio.transforms import (
             "TYXCZX",
             {"Z": slice(-7, 0, 2)},
             None,
-            marks=pytest.mark.raises(exception=IndexError),
+            marks=pytest.mark.xfail(raises=IndexError),
         ),
     ],
 )
@@ -345,28 +345,28 @@ def test_reshape_data_kwargs_values(
             "ZYX",
             "TYXC",
             None,
-            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=ConflictingArgumentsError),
         ),
         pytest.param(
             da.zeros((6, 200, 400)),
             "ZYX",
             "TYXC",
             None,
-            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=ConflictingArgumentsError),
         ),
         pytest.param(
             np.zeros((6, 200, 400)),
             "ZYX",
             "TYXCZ",
             None,
-            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=ConflictingArgumentsError),
         ),
         pytest.param(
             da.zeros((6, 200, 400)),
             "ZYX",
             "TYXCZ",
             None,
-            marks=pytest.mark.raises(exception=ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=ConflictingArgumentsError),
         ),
     ],
 )
@@ -451,7 +451,7 @@ def get_data_reference(
         ("xarray_data", "U", "index"),
         ("xarray_data", "U", "names"),
         pytest.param(
-            "xarray_data", "T", "index", marks=pytest.mark.raises(exception=ValueError)
+            "xarray_data", "T", "index", marks=pytest.mark.xfail(raises=ValueError)
         ),
         ("xarray_dask_data", "I", "index"),
         ("xarray_dask_data", "U", "index"),
@@ -460,7 +460,7 @@ def get_data_reference(
             "xarray_dask_data",
             "T",
             "index",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
     ],
 )
@@ -503,11 +503,9 @@ def test_generate_stack_stacking(
             "shape",
             False,
             None,
-            marks=pytest.mark.raises(exception=UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=UnexpectedShapeError),
         ),
-        pytest.param(
-            "dtype", False, None, marks=pytest.mark.raises(exception=TypeError)
-        ),
+        pytest.param("dtype", False, None, marks=pytest.mark.xfail(raises=TypeError)),
     ],
 )
 def test_generate_stack_mismatch_and_drop(

--- a/aicsimageio/tests/utils/test_io_utils.py
+++ b/aicsimageio/tests/utils/test_io_utils.py
@@ -19,12 +19,12 @@ from ..conftest import LOCAL, REMOTE, get_resource_full_path
         pytest.param(
             "does-not-exist.bad",
             True,
-            marks=pytest.mark.raises(exception=FileNotFoundError),
+            marks=pytest.mark.xfail(raises=FileNotFoundError),
         ),
         pytest.param(
             "does-not-exist.bad",
             True,
-            marks=pytest.mark.raises(exception=FileNotFoundError),
+            marks=pytest.mark.xfail(raises=FileNotFoundError),
         ),
     ],
 )

--- a/aicsimageio/tests/writers/extra_writers/test_timeseries_writer.py
+++ b/aicsimageio/tests/writers/extra_writers/test_timeseries_writer.py
@@ -28,30 +28,28 @@ from ...conftest import LOCAL, array_constructor, get_resource_write_full_path
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1, 1),
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1, 1, 1),
             "STCZYX",
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1),
             "ABCD",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )
@@ -99,30 +97,28 @@ def test_timeseries_writer(
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1, 1),
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1, 1, 1),
             "STCZYX",
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1),
             "ABCD",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )

--- a/aicsimageio/tests/writers/extra_writers/test_two_d_writer.py
+++ b/aicsimageio/tests/writers/extra_writers/test_two_d_writer.py
@@ -27,30 +27,28 @@ from ...conftest import LOCAL, array_constructor, get_resource_write_full_path
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1, 1),
             None,
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1, 1, 1, 1, 1),
             "STCZYX",
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.UnexpectedShapeError),
+            marks=pytest.mark.xfail(raises=exceptions.UnexpectedShapeError),
         ),
         pytest.param(
             (1, 1),
             "AB",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )

--- a/aicsimageio/tests/writers/test_ome_tiff_writer.py
+++ b/aicsimageio/tests/writers/test_ome_tiff_writer.py
@@ -32,27 +32,21 @@ from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
             "AYX",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         pytest.param(
             (2, 3, 3),
             "YXZ",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         pytest.param(
             (2, 5, 16, 16),
             "CYX",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         ((1, 2, 3, 4, 5), None, (1, 2, 3, 4, 5), "TCZYX"),
         ((2, 3, 4, 5, 6), "TCZYX", (2, 3, 4, 5, 6), "TCZYX"),
@@ -64,7 +58,7 @@ from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
             None,
             (1, 2, 3, 4, 5, 6),
             "TCZYXS",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         ((5, 16, 16, 3), "ZYXS", (1, 1, 5, 16, 16, 3), "TCZYXS"),
         ((5, 16, 16, 4), "CYXS", (1, 5, 1, 16, 16, 4), "TCZYXS"),
@@ -129,42 +123,42 @@ def test_ome_tiff_writer_no_meta(
             (1, 2, 3, 4, 5),
             to_xml(OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.float32)])),
             "TCZYX",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # wrong dtype
         pytest.param(
             (1, 2, 3, 4, 5),
             OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.float32)]),
             "TCZYX",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # wrong dims
         pytest.param(
             (1, 2, 3, 4, 5),
             to_xml(OmeTiffWriter.build_ome([(2, 2, 3, 4, 5)], [np.dtype(np.float32)])),
             "TCZYX",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # wrong dims
         pytest.param(
             (1, 2, 3, 4, 5),
             OmeTiffWriter.build_ome([(2, 2, 3, 4, 5)], [np.dtype(np.float32)]),
             "TCZYX",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # just totally wrong but valid ome
         pytest.param(
             (1, 2, 3, 4, 5),
             to_xml(OME()),
             "TCZYX",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # just totally wrong but valid ome
         pytest.param(
             (1, 2, 3, 4, 5),
             OME(),
             "TCZYX",
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         # even more blatantly bad ome
         pytest.param(
@@ -172,7 +166,7 @@ def test_ome_tiff_writer_no_meta(
             "bad ome string",
             "TCZYX",
             # raised from within ome-types
-            marks=pytest.mark.raises(exception=urllib.error.URLError),
+            marks=pytest.mark.xfail(raises=urllib.error.URLError),
         ),
     ],
 )
@@ -251,7 +245,7 @@ def test_ome_tiff_writer_with_meta(
             ["ZYXS"],
             None,
             None,
-            marks=pytest.mark.raises(exception=exceptions.ConflictingArgumentsError),
+            marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         # bad dims
         pytest.param(
@@ -259,9 +253,7 @@ def test_ome_tiff_writer_with_meta(
             "AYX",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )
@@ -372,7 +364,7 @@ def test_ome_tiff_writer_multiscene(
             [(1, 3, 1, 16, 16)],
             ["TCZYX"],
             [(None, 1.0, 1.0)],
-            marks=pytest.mark.raises(exception=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         (
             [np.random.rand(3, 16, 16)],

--- a/aicsimageio/tests/writers/test_ome_zarr_writer.py
+++ b/aicsimageio/tests/writers/test_ome_zarr_writer.py
@@ -32,9 +32,7 @@ from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
             "ZCYX",
             (10, 5, 16, 16),
             "ZCYX",
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         ((5, 10, 16, 16), "CZYX", (5, 10, 16, 16), "CZYX"),
         ((15, 16), "YX", (15, 16), "YX"),
@@ -43,9 +41,7 @@ from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
             "AYX",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         ((2, 3, 3), "YXZ", (2, 3, 3), "YXZ"),
         pytest.param(
@@ -53,9 +49,7 @@ from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
             "CYX",
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
         # error 6D data doesn't work yet
         pytest.param(
@@ -63,9 +57,7 @@ from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
             None,
             None,
             None,
-            marks=pytest.mark.raises(
-                exception=exceptions.InvalidDimensionOrderingError
-            ),
+            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
         ),
     ],
 )


### PR DESCRIPTION
## How did this come about?

This came about from [this issue](https://github.com/AllenCellModeling/aicsimageio/issues/434) where it was noted that `AICSImage` could not instantiate with an array-like image which greater than 5 dimensions. I was able to get around this issue (and also provide a fix in a related follow-up PR here), but while investigating I noticed we had [a test case for this](https://github.com/AllenCellModeling/aicsimageio/blob/main/aicsimageio/tests/readers/test_array_like_reader.py#L1078-L1091) already and it was passing even though it shouldn't based on manual testing. This led me to believe this was an evergreen test and going from using `pytest.mark.raises` to using the xfail mark (like so `pytest.mark.xfail`) caused the test to fail with a message saying the test did not raise the expected error which was the case in my manual testing.

## What this PR aims to accomplish

This pull request modifies all ~115 usages of `pytest.mark.raises` to `pytest.mark.xfail` which caused 5 tests to fail all of which were in the `ArrayLikeReader` tests. In my follow-up PR I mentioned above I fix the failing tests and resolve the issue aforementioned as well. The goal of this PR is _**not**_  to merge this without the follow-up PR included to fix the tests, but rather just highlight and display these changes without cluttering the more important to review fixes.

### Testing
Unit tested locally

