### PR TITLE
Bugfix: Dimension mismatch error + minor test fixes

### DIFF
--- a/aicsimageio/tests/readers/test_array_like_reader.py
+++ b/aicsimageio/tests/readers/test_array_like_reader.py
@@ -716,6 +716,17 @@ from ..image_container_test_utils import run_image_container_checks
             "CZYX",
             ["A"],
         ),
+        # Test supporting six dimensions without explicit dim_order supplied
+        (
+            np.random.rand(1, 2, 3, 4, 5, 6),
+            None,
+            None,
+            "Image:0",
+            ("Image:0",),
+            (1, 2, 3, 4, 5, 6),
+            "TCZYXS",
+            ["Channel:0:0", "Channel:0:1"],
+        ),
         # Test mismatching mapping of arrays to dim_order
         pytest.param(
             [np.random.rand(1, 1)],
@@ -752,7 +763,7 @@ from ..image_container_test_utils import run_image_container_checks
             marks=pytest.mark.xfail(raises=exceptions.ConflictingArgumentsError),
         ),
         pytest.param(
-            [np.random.rand(1, 1, 1, 1), (1, 1, 1, 1, 1)],
+            [np.random.rand(1, 1, 1, 1), np.random.rand(1, 1, 1, 1, 1)],
             None,
             [["A"], ["B"], ["C"]],
             None,
@@ -798,10 +809,10 @@ from ..image_container_test_utils import run_image_container_checks
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        # Test that without dim_order and with more than five dims, it raises an error
-        # Our guess dim order only support up to five dims
+        # Test that without dim_order and with more than six dims, it raises an error
+        # Our guess dim order only support up to six dims
         pytest.param(
-            np.random.rand(1, 2, 3, 4, 5, 6),
+            np.random.rand(1, 2, 3, 4, 5, 6, 7),
             None,
             None,
             None,
@@ -1073,21 +1084,21 @@ def test_arraylike_reader(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Channel:1:0", "Channel:1:1", "Channel:1:2", "Channel:1:3"],
         ),
-        # Test that without dims and with more than five dims, it raises an error
-        # Our guess dim order only support up to five dims
-        pytest.param(
+        # Test supporting six dimensions without explicit dim_order supplied
+        (
             np.random.rand(1, 2, 3, 4, 5, 6),
             None,
             None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            marks=pytest.mark.xfail(raises=exceptions.InvalidDimensionOrderingError),
+            "Image:0",
+            ("Image:0",),
+            (1, 2, 3, 4, 5, 6),
+            "TCZYXS",
+            ["Channel:0:0", "Channel:0:1"],
         ),
+        # Test that with more than 6 dims, it raises an error
+        # Our guess dim order only support up to six dims
         pytest.param(
-            "hello world",
+            np.random.rand(1, 2, 3, 4, 5, 6, 7),
             None,
             None,
             None,


### PR DESCRIPTION
## How did this come about?

This came about from [this issue](https://github.com/AllenCellModeling/aicsimageio/issues/434) where it was noted that `AICSImage` could not instantiate with an array-like image which greater than 5 dimensions. I was able to get around this issue by supplying `dim_order` explicitly like:
```
from aicsimageio.aics_image import AICSImage
import dask.array as da

data = da.random.random((1, 1,1,512,512,3))*256
data = data.astype(int)
img = AICSImage(data, dim_order="TCZYXS")
```
However, it seems we can support 6 dimensions for array-like images implicitly as well by considering the sixth dimension for array-like images to be Samples (full order: "TCZYXS").

## What this PR aims to accomplish
This pull request is meant to default 6 dimension array-like images to the order of "TCZYXS" rather than defaulting to "X" due to a bug in the way we index the default dimension order which then ends up yielding a misleading error.

**Additionally**, this adds some minor fixes to some other `ArrayLikeReader` tests to make them pass (in a non-evergreen way) which came from [the related PR](https://github.com/AllenCellModeling/aicsimageio/pull/464) this PR is merging into. They are separated to ideally help with visibility into the changes.

