### PR TITLE
Quality of Life: Make pip install platform independent

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Ready to contribute? Here's how to set up `aicsimageio` for local development.
 4.  Install the project in editable mode (and preferably in a virtual environment):
 
         cd aicsimageio/
-        pip install -e .[dev]
+        pip install -e ".[dev]"
 
 5.  Download the test resources:
 


### PR DESCRIPTION
## How did this come about?
Following along the `CONTRIBUTING.md` documentation I was unable to run `pip install .[dev]` because `.[dev]` must be escaped in zsh (MacOS's default shell) for pattern matching. By adding some double quotes this works and it should be universal to other environments ([my only source of testing is this random issue though)](https://github.com/mu-editor/mu/issues/852#issuecomment-498748927))

## What this PR aims to accomplish
Not entirely necessary since I know how to get around this, but may be useful to others in the future to help installation be more smooth.