### PR TITLE
Bugfix: Avoid FssSpec bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ benchmark_requirements = [
 
 requirements = [
     "dask[array]>=2021.4.1",
-    "fsspec>=2021.4.0,!=2022.7.0",
+    "fsspec>=2022.8.0",
     "imagecodecs>=2020.5.30",
     "lxml>=4.6,<5",
     "numpy>=1.16,<2",


### PR DESCRIPTION
### Description of Changes
Resolves #431 where the minimum allowable fssspec version had potential to cause various errors.

### Testing
Ran unit tests locally with minimum allowable version and most current version of fssspec
