### PR TITLE
bugfix: removing 2.11.0 threshold

### DIFF
--- a/aicsimageio/readers/default_reader.py
+++ b/aicsimageio/readers/default_reader.py
@@ -158,6 +158,8 @@ class DefaultReader(Reader):
             return f"{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
         elif len(shape) == 3:
             # Handle greyscale timeseries
+            # If the last dimension is greater than 4 it is unlikely to be
+            # representing a samples dimension
             if shape[-1] > 4:
                 return (
                     f"{DimensionNames.Time}"
@@ -169,7 +171,9 @@ class DefaultReader(Reader):
                 f"{DimensionNames.SpatialY}{DimensionNames.SpatialX}"
                 f"{DimensionNames.Samples}"
             )
-        elif len(shape) == 4:
+        # If the last dimension is greater than 4 it is unlikely to be
+        # representing a samples dimension
+        elif len(shape) == 4 and shape[-1] <= 4:
             return (
                 f"{DimensionNames.Time}{DimensionNames.SpatialY}"
                 f"{DimensionNames.SpatialX}{DimensionNames.Samples}"

--- a/aicsimageio/tests/readers/extra_readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_default_reader.py
@@ -268,8 +268,8 @@ def test_set_coords(
             "actk.ome.tiff",
             DefaultReader,
             {},
-            dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
-            (6, 1, 1, 65, 233, 345),
+            dimensions.DEFAULT_DIMENSION_ORDER,
+            (1, 6, 65, 233, 345),
         ),
     ],
 )

--- a/aicsimageio/tests/readers/extra_readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_default_reader.py
@@ -268,8 +268,8 @@ def test_set_coords(
             "actk.ome.tiff",
             DefaultReader,
             {},
-            dimensions.DEFAULT_DIMENSION_ORDER,
-            (390, 1, 1, 233, 345),
+            dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
+            (6, 1, 1, 65, 233, 345),
         ),
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md") as readme_file:
 # "READER_TO_INSTALL" lookup table from aicsimageio/formats.py.
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
-        "imageio[ffmpeg]>=2.9.0",
+        "imageio[ffmpeg]>=2.11.0",
         "Pillow>=8.2.0,!=8.3.0,<9",
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md") as readme_file:
 # "READER_TO_INSTALL" lookup table from aicsimageio/formats.py.
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
-        "imageio[ffmpeg]>=2.9.0,<2.11.0",
+        "imageio[ffmpeg]>=2.9.0",
         "Pillow>=8.2.0,!=8.3.0,<9",
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],


### PR DESCRIPTION
## How did this come about?
 This pull request was opened to resolve #361. At the time of this bug, several tests were failing with:

```RuntimeError: `mp4` can not handle the given uri.```

The quick-fix solution was to pin the dependency to "imageio[ffmpeg]>=2.9.0,<2.11.0".  Returning to these tests, I was unable to replicate these errors, testing with imageio (2.10.5, 2.11.0,2.12.0, 2.26.0(current)). This is likely an indication that this issue was resolved internally by the imageio team.

