### PR TITLE
Bugfix: Restrict tifffile version for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ requirements = [
     "ome-zarr>=0.6.1",
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
-    "tifffile>=2021.8.30",
+    "tifffile>=2021.8.30,<2023.3.15",
     "xarray>=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",


### PR DESCRIPTION
## Description
This pull request restricts the version of `tifffile` to be less than version `2023.3.15` until the breaking changes can be addressed as it is currently causing the test suite to fail. The specific change that seems to be causing this is [found here](https://github.com/cgohlke/tifffile/blob/fc5f5a4eea5d510e7592a84f9c1017265e718cca/tifffile/tifffile.py#L119) and can be summarized as the following:

> Older versions of tifffile used the OME-XML metadata to create series. In the OME model, positions are separate series. The new MMStack parser uses MicroManager metadata to create series. The positions are now part of a single series. It's a breaking change. Maybe this explains your issue?

[Example of broken test suite run](https://github.com/AllenCellModeling/aicsimageio/actions/runs/4471402503/jobs/7856246578)

### Testing
Unit tested locally, recreated virtual environment with fresh installs locally
