### PR TITLE
Bugfix: Upgrade minimum fsspec version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ benchmark_requirements = [
 
 requirements = [
     "dask[array]>=2021.4.1",
-    "fsspec>=2021.4.0,!=2022.7.0",
+    "fsspec>=2022.8.0",
     "imagecodecs>=2020.5.30",
     "lxml>=4.6,<5",
     "numpy>=1.16,<2",

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ requirements = [
     "ome-zarr>=0.6.1",
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
-    "tifffile>=2021.8.30",
+    "tifffile>=2021.8.30,<2023.3.15",
     "xarray>=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",


### PR DESCRIPTION
## Description of Changes
Resolves [gh-431] where the minimum allowable fsspec version had potential to cause various errors.

### Testing
Ran unit tests locally with minimum allowable version and most current version of fsspec
