### PR TITLE
feature/github-action-stale

### DIFF
--- a/.github/workflows/maintain-stale.yml
+++ b/.github/workflows/maintain-stale.yml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8.0.0
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          days-before-stale: 90
+          days-before-close: 7

--- a/.github/workflows/maintain-stale.yml
+++ b/.github/workflows/maintain-stale.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          days-before-stale: 90
-          days-before-close: 7
+          days-before-stale: 365
+          days-before-close: 14


### PR DESCRIPTION
The purpose of this PR is to introduce a feature that warns users of stale branches and issues. If no response is seen within an allotted time, the workflow will close the issue/pr.
