### PR TITLE
Bugfix/mosaic lif merge error

### DIFF
--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -595,10 +595,10 @@ class LifReader(Reader):
             is_last_row = row_index + 1 >= number_of_rows
             is_last_column = column_index + 1 >= number_of_columns
             if not is_last_row:
-                tile = tile[:, :, :, 1:, :]
+                tile = tile[:, :, :, :-1, :]
 
             if not is_last_column:
-                tile = tile[:, :, :, :, 1:]
+                tile = tile[:, :, :, :, :-1]
 
             xy_plane[row_index, column_index] = tile
 
@@ -713,10 +713,8 @@ class LifReader(Reader):
         if DimensionNames.MosaicTile not in self.dims.order:
             raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
 
-        # LIFs are packed from bottom right to top left
-        # To counter: subtract 1 + M from list index to get from back of list
-        index_y, index_x, _, _ = self._scene_short_info["mosaic_position"][
-            -(mosaic_tile_index + 1)
+        index_x, index_y, _, _ = self._scene_short_info["mosaic_position"][
+            mosaic_tile_index
         ]
 
         # Formula: (Dim position * Tile dim length) - Dim position

--- a/aicsimageio/tests/image_container_test_utils.py
+++ b/aicsimageio/tests/image_container_test_utils.py
@@ -132,6 +132,7 @@ def run_image_container_mosaic_checks(
     already_stitched_data = stitched_image_container.data
 
     # Compare
+    assert from_tiles_stitched_data.shape == already_stitched_data.shape
     np.testing.assert_array_equal(from_tiles_stitched_data, already_stitched_data)
 
 

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -209,28 +209,28 @@ def test_lif_reader_mosaic_stitching(
             "TileScan_002",
             (512, 512),
             0,
-            (5110, 7154),
+            (0, 0),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             50,
-            (3577, 4599),
+            (2555, 1533),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             3,
-            (5110, 5621),
+            (1533, 0),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             164,
-            (0, 0),
+            (7154, 5110),
         ),
         pytest.param(
             "tiled.lif",
@@ -288,11 +288,14 @@ def test_lif_reader_mosaic_tile_inspection(
         tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),
     ].compute()
 
+    # (sanity-check) Make sure they are the same shape before shaving pixels
+    assert tile_from_position.shape == tile_from_m_index.shape
+
     # Remove the first Y and X pixels
     # The stitched tiles overlap each other by 1px each so this is just
     # ignoring what would be overlap / cleaned up
-    tile_from_m_index = tile_from_m_index[:, :, :, 1:, 1:]
-    tile_from_position = tile_from_position[:, :, :, 1:, 1:]
+    tile_from_m_index = tile_from_m_index[:, :, :, :-1, :-1]
+    tile_from_position = tile_from_position[:, :, :, :-1, :-1]
 
     # Assert equal
     np.testing.assert_array_equal(tile_from_m_index, tile_from_position)
@@ -309,8 +312,8 @@ def test_lif_reader_mosaic_tile_inspection(
             "tiled.lif",
             np.arange(0, 102.71391311154599, 0.20061311154598827),
             np.arange(0, 102.71391311154599, 0.20061311154598827),
-            np.arange(0, 1127.846913111546, 0.20061311154598827),
             np.arange(0, 1537.900113111546, 0.20061311154598827),
+            np.arange(0, 1127.846913111546, 0.20061311154598827),
         ),
     ],
 )
@@ -374,7 +377,7 @@ def test_lif_reader_mosaic_coords(
             "tiled.lif",
             "TileScan_002",
             ("TileScan_002",),
-            (1, 4, 1, 5622, 7666),
+            (1, 4, 1, 7666, 5622),
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray", "Red", "Green", "Cyan"],
@@ -470,7 +473,7 @@ def test_roundtrip_save_all_scenes(
             "tiled.lif",
             True,
             "TileScan_002",
-            (1, 4, 1, 5622, 7666),
+            (1, 4, 1, 7666, 5622),
             (512, 512),
             0,
         ),

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -131,7 +131,7 @@ def test_sanity_check_correct_indexing(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri, chunk_dims=chunk_dims)
+    reader = LifReader(uri, chunk_dims=chunk_dims, is_x_and_y_swapped=True)
     lif_img = LifFile(uri).get_image(0)
 
     # Pull a chunk from LifReader
@@ -185,7 +185,7 @@ def test_lif_reader_mosaic_stitching(
     stitched_uri = get_resource_full_path(stitched_filename, LOCAL)
 
     # Construct reader
-    tiles_reader = LifReader(tiles_uri)
+    tiles_reader = LifReader(tiles_uri, is_x_and_y_swapped=True)
     stitched_reader = LifReader(stitched_uri)
 
     # Run checks
@@ -262,7 +262,7 @@ def test_lif_reader_mosaic_tile_inspection(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri)
+    reader = LifReader(uri, is_x_and_y_swapped=True)
     reader.set_scene(set_scene)
 
     # Check basics
@@ -328,7 +328,7 @@ def test_lif_reader_mosaic_coords(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri)
+    reader = LifReader(uri, is_x_and_y_swapped=True)
 
     # Check tile y and x min max
     np.testing.assert_array_equal(

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -209,28 +209,28 @@ def test_lif_reader_mosaic_stitching(
             "TileScan_002",
             (512, 512),
             0,
-            (0, 0),
+            (5110, 7154),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             50,
-            (2555, 1533),
+            (3577, 4599),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             3,
-            (1533, 0),
+            (5110, 5621),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             164,
-            (7154, 5110),
+            (0, 0),
         ),
         pytest.param(
             "tiled.lif",
@@ -294,8 +294,8 @@ def test_lif_reader_mosaic_tile_inspection(
     # Remove the first Y and X pixels
     # The stitched tiles overlap each other by 1px each so this is just
     # ignoring what would be overlap / cleaned up
-    tile_from_m_index = tile_from_m_index[:, :, :, :-1, :-1]
-    tile_from_position = tile_from_position[:, :, :, :-1, :-1]
+    tile_from_m_index = tile_from_m_index[:, :, :, 1:, 1:]
+    tile_from_position = tile_from_position[:, :, :, 1:, 1:]
 
     # Assert equal
     np.testing.assert_array_equal(tile_from_m_index, tile_from_position)
@@ -312,8 +312,8 @@ def test_lif_reader_mosaic_tile_inspection(
             "tiled.lif",
             np.arange(0, 102.71391311154599, 0.20061311154598827),
             np.arange(0, 102.71391311154599, 0.20061311154598827),
-            np.arange(0, 1537.900113111546, 0.20061311154598827),
             np.arange(0, 1127.846913111546, 0.20061311154598827),
+            np.arange(0, 1537.900113111546, 0.20061311154598827),
         ),
     ],
 )
@@ -377,7 +377,7 @@ def test_lif_reader_mosaic_coords(
             "tiled.lif",
             "TileScan_002",
             ("TileScan_002",),
-            (1, 4, 1, 7666, 5622),
+            (1, 4, 1, 5622, 7666),
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray", "Red", "Green", "Cyan"],
@@ -473,7 +473,7 @@ def test_roundtrip_save_all_scenes(
             "tiled.lif",
             True,
             "TileScan_002",
-            (1, 4, 1, 7666, 5622),
+            (1, 4, 1, 5622, 7666),
             (512, 512),
             0,
         ),


### PR DESCRIPTION
## What is this trying to solve? 
This work is meant to resolve #278 where the dimensions post mosaic merge of tiled LIF files were incorrect and in some cases not working at all. What I found was this package by default swapped the x & y coordinates given by the `readlif` package which effectively transposed the XY plane we produced across all axes. When stitched with the file given in the issue this produced an image that appeared to be a reflection due to our default transposing **and also a rotation** or lack thereof when compared to the expected image which seems to explain the strange findings reported in the issue. Flipping or swapping x and y coordinates is something LIF files allow for so this isn't unheard of. This does **not** address improving the stitching overlap methodology in this reader to remove even more overlapping pixels by using the physical coordinates.

## How is this changeset trying to solve this problem?
I added three flags that represent flipping the x coordinates, y coordinates, and also swapping the x and y coordinates. These are all technically available within the LIF metadata, but I am unsure how to retrieve it, and `readlif` currently does not provide it, so for the time being I added them as optional parameters to the constructor.

## Testing
I tested against the unit tests and locally with the file in the issue. By setting the X and Y coordinates to flip and turning off the X and Y swapping I seem to be able to get the desired image.
