### PR TITLE
Restrict xarray version to support py3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ requirements = [
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
     "tifffile>=2021.8.30,<2023.3.15",
-    "xarray>=0.16.1",
+    "xarray>=0.16.1,<2023.02.0",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",
 ]


### PR DESCRIPTION
## Description
Due to `xarray` and likely soon `numpy` and others dropping support for Python 3.8 this PR restricts `xarrays` version to 3.8 compatible versions so we can do a final release supporting Python 3.8 declaring its EoL with `aicsimageio`. 

After this PR I will release a new minor version of `aicsimageio` announcing in the release notes the EoL and then open another PR removing this restriction and dropping support for Python 3.8.
