### PR TITLE
Extract S dim from OME data

### DIFF
--- a/aicsimageio/metadata/utils.py
+++ b/aicsimageio/metadata/utils.py
@@ -6,7 +6,7 @@ import os
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 from xml.etree import ElementTree as ET
 
 import lxml.etree
@@ -606,11 +606,9 @@ def bioformats_ome(path: PathLike, original_meta: bool = False) -> OME:
         return lf.ome_metadata
 
 
-def get_dims_and_coords_from_ome(
-    ome: OME, scene_index: int
-) -> Tuple[List[str], Dict[str, Union[List[Any], Union[ArrayLike, Any]]]]:
+def get_dims_from_ome(ome: OME, scene_index: int) -> List[str]:
     """
-    Process the OME metadata to retrieve the dimension names and coordinate planes.
+    Process the OME metadata to retrieve the dimension names.
 
     Parameters
     ----------
@@ -623,11 +621,7 @@ def get_dims_and_coords_from_ome(
     -------
     dims: List[str]
         The dimension names pulled from the OME metadata.
-    coords: Dict[str, Union[List[Any], Union[types.ArrayLike, Any]]]
-        The coordinate planes / data for each dimension.
     """
-    from ..readers.reader import Reader
-
     # Select scene
     scene_meta = ome.images[scene_index]
 
@@ -635,20 +629,37 @@ def get_dims_and_coords_from_ome(
     # and reversing it because OME store order vs use order is :shrug:
     dims = [d for d in scene_meta.pixels.dimension_order.value[::-1]]
 
-    # The Samples dimension can be extracted from the OME data by
-    # looking at the SamplesPerPixel defined per channel
-    if "C" in dims and "S" not in dims:
-        n_samples = scene_meta.pixels.channels[0].samples_per_pixel
-        if n_samples is not None and n_samples > 1:
-            temp_dims: List[str] = []
-            for dim in dims:
-                # SamplesPerPixel is defined per channel so inserting it after
-                # we encounter the channel dimension seems appropriate
-                temp_dims.append(dim)
-                if dim == "C":
-                    temp_dims.append("S")
+    # Check for num samples and expand dims if greater than 1
+    n_samples = scene_meta.pixels.channels[0].samples_per_pixel
+    if n_samples is not None and n_samples > 1 and "S" not in dims:
+        # Append to the end, i.e. the last dimension
+        dims.append("S")
 
-            dims = temp_dims
+    return dims
+
+
+def get_coords_from_ome(
+    ome: OME, scene_index: int
+) -> Dict[str, Union[List[Any], Union[ArrayLike, Any]]]:
+    """
+    Process the OME metadata to retrieve the coordinate planes.
+
+    Parameters
+    ----------
+    ome: OME
+        A constructed OME object to retrieve data from.
+    scene_index: int
+        The current operating scene index to pull metadata from.
+
+    Returns
+    -------
+    coords: Dict[str, Union[List[Any], Union[types.ArrayLike, Any]]]
+        The coordinate planes / data for each dimension.
+    """
+    from ..readers.reader import Reader
+
+    # Select scene
+    scene_meta = ome.images[scene_index]
 
     # Get coordinate planes
     coords: Dict[str, Union[List[str], np.ndarray]] = {}
@@ -696,7 +707,7 @@ def get_dims_and_coords_from_ome(
             0, scene_meta.pixels.size_x, scene_meta.pixels.physical_size_x
         )
 
-    return dims, coords
+    return coords
 
 
 def physical_pixel_sizes(ome: OME, scene: int = 0) -> PhysicalPixelSizes:

--- a/aicsimageio/metadata/utils.py
+++ b/aicsimageio/metadata/utils.py
@@ -635,6 +635,21 @@ def get_dims_and_coords_from_ome(
     # and reversing it because OME store order vs use order is :shrug:
     dims = [d for d in scene_meta.pixels.dimension_order.value[::-1]]
 
+    # The Samples dimension can be extracted from the OME data by
+    # looking at the SamplesPerPixel defined per channel
+    if "C" in dims and "S" not in dims:
+        n_samples = scene_meta.pixels.channels[0].samples_per_pixel
+        if n_samples is not None and n_samples > 1:
+            temp_dims: List[str] = []
+            for dim in dims:
+                # SamplesPerPixel is defined per channel so inserting it after
+                # we encounter the channel dimension seems appropriate
+                temp_dims.append(dim)
+                if dim == "C":
+                    temp_dims.append("S")
+
+            dims = temp_dims
+
     # Get coordinate planes
     coords: Dict[str, Union[List[str], np.ndarray]] = {}
 

--- a/aicsimageio/readers/bfio_reader.py
+++ b/aicsimageio/readers/bfio_reader.py
@@ -65,7 +65,7 @@ class BfioReader(Reader):
     ) -> xr.DataArray:
 
         # Unpack dims and coords from OME
-        _, coords = metadata_utils.get_dims_and_coords_from_ome(
+        coords = metadata_utils.get_coords_from_ome(
             ome=self._rdr.metadata,
             scene_index=0,
         )

--- a/aicsimageio/readers/bioformats_reader.py
+++ b/aicsimageio/readers/bioformats_reader.py
@@ -198,7 +198,7 @@ class BioformatsReader(Reader):
             **self._bf_kwargs,  # type: ignore
         ) as rdr:
             image_data = rdr.to_dask() if delayed else rdr.to_numpy()
-            _, coords = metadata_utils.get_dims_and_coords_from_ome(
+            coords = metadata_utils.get_coords_from_ome(
                 ome=rdr.ome_metadata,
                 scene_index=self.current_scene_index,
             )

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -224,13 +224,14 @@ class OmeTiffReader(TiffReader):
 
         # need to correct channel count if this is a RGB image
         n_samples = ome.images[scene_index].pixels.channels[0].samples_per_pixel
+        has_multiple_samples = n_samples is not None and n_samples > 1
         for d in dims:
             # SizeC can represent RGB (Samples) data rather
             # than channel data, whether or not this is the case depends
             # on what the SamplesPerPixel are for the channel
-            if d == "C" and n_samples is not None and n_samples > 1:
+            if d == "C" and has_multiple_samples:
                 count = len(ome.images[scene_index].pixels.channels)
-            elif d == "S" and n_samples is not None and n_samples > 1:
+            elif d == "S" and has_multiple_samples:
                 count = n_samples
             else:
                 count = getattr(ome.images[scene_index].pixels, f"size_{d.lower()}")

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -189,14 +189,19 @@ class OmeTiffReader(TiffReader):
         # need to correct channel count if this is a RGB image
         n_samples = ome.images[scene_index].pixels.channels[0].samples_per_pixel
         for d in dims:
+            # SizeC can represent RGB (Samples) data rather
+            # than channel data, whether or not this is the case depends
+            # on what the SamplesPerPixel are for the channel
             if d == "C" and n_samples is not None and n_samples > 1:
                 count = len(ome.images[scene_index].pixels.channels)
+            elif d == "S" and n_samples is not None and n_samples > 1:
+                count = n_samples
             else:
                 count = getattr(ome.images[scene_index].pixels, f"size_{d.lower()}")
             ome_shape.append(count)
 
         # Check for num samples and expand dims if greater than 1
-        if n_samples is not None and n_samples > 1:
+        if n_samples is not None and n_samples > 1 and "S" not in dims:
             # Append to the end, i.e. the last dimension
             dims.append("S")
             ome_shape.append(n_samples)

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -143,6 +143,10 @@ class OmeTiffReader(TiffReader):
         """
         dims_from_ome = metadata_utils.get_dims_from_ome(ome, scene_index)
 
+        # Assumes the dimensions coming from here are align semantically
+        # with the dimensions specified in this package. Possible T dimension
+        # is not equivalent to T dimension here. However, any dimensions
+        # not also found in OME will be omitted.
         dims_from_tiff_axes = list(tiff.series[scene_index].axes)
 
         # Adjust the guess of what the dimensions are based on the combined


### PR DESCRIPTION
## Description
#457 describes an error where a RGB OME TIFF fails to open. This error occurs because the dimensions of the file are SYX and currently the `OmeTiffReader` only supports the Samples dimension being at the end of the dimension order via [this line](https://github.com/AllenCellModeling/aicsimageio/blob/main/aicsimageio/readers/ome_tiff_reader.py#L199).

## How does this PR address the issue?
The `OmeTiffReader` was already aware of the `SizeC` occasionally being representative of RGB data when `SamplesPerPixel` was present [elsewhere in the code](https://github.com/AllenCellModeling/aicsimageio/blob/main/aicsimageio/readers/ome_tiff_reader.py#L190-L202). However, it just incorrectly assumed the Samples dimension [is the last dimension of the image data](https://github.com/AllenCellModeling/aicsimageio/blob/main/aicsimageio/readers/ome_tiff_reader.py#L198-L202_
).

## Testing
Tested locally with file from issue as well as some random OME TIFFs from AICS
