### PR TITLE
Feature/tiledtiffwriter

### DIFF
--- a/aicsimageio/tests/writers/test_ome_tiled_tiff_writer.py
+++ b/aicsimageio/tests/writers/test_ome_tiled_tiff_writer.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Callable, Tuple
+import urllib
+from typing import Callable, Tuple, Union
 
 import numpy as np
 import pytest
+from ome_types import OME, to_xml
 
 from aicsimageio.readers import OmeTiffReader
+from aicsimageio.writers import OmeTiffWriter
 from aicsimageio.writers.bfio_writers import OmeTiledTiffWriter
 
 from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
@@ -39,8 +42,6 @@ def test_ome_tiled_tiff_writer_no_meta(
     # Create array
     arr = array_constructor(write_shape, dtype=np.uint8)
 
-    print(arr.shape)
-
     # Construct save end point
     save_uri = get_resource_write_full_path(filename, LOCAL)
 
@@ -56,378 +57,107 @@ def test_ome_tiled_tiff_writer_no_meta(
     assert reader.dims.order == expected_read_dim_order
 
 
-# @array_constructor
-# @pytest.mark.parametrize(
-#     "shape_to_create, ome_xml, expected_dim_order",
-#     [
-#         # ok dims
-#         (
-#             (1, 2, 3, 4, 5),
-#             to_xml(OmeTiffWriter.build_ome([(1,2,3, 4, 5)], [np.dtype(np.uint8)])),
-#             "TCZYX",
-#         ),
-#         (
-#             (1, 2, 3, 4, 5),
-#             OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.uint8)]),
-#             "TCZYX",
-#         ),
-#         # with RGB data:
-#         (
-#             (2, 2, 3, 4, 5, 3),
-#             to_xml(OmeTiffWriter.build_ome([(2, 2,3,4, 5, 3)], [np.dtype(np.uint8)])),
-#             "TCZYXS",
-#         ),
-#         (
-#             (2, 2, 3, 4, 5, 3),
-#             OmeTiffWriter.build_ome([(2, 2, 3, 4, 5, 3)], [np.dtype(np.uint8)]),
-#             "TCZYXS",
-#         ),
-#         # wrong dtype
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             to_xml(OmeTiffWriter.build_ome([(1, 2, 3,4, 5)], [np.dtype(np.float32)])),
-#             "TCZYX",
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         # wrong dtype
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.float32)]),
-#             "TCZYX",
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         # wrong dims
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             to_xml(OmeTiffWriter.build_ome([(2,2,3, 4, 5)], [np.dtype(np.float32)])),
-#             "TCZYX",
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         # wrong dims
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             OmeTiffWriter.build_ome([(2, 2, 3, 4, 5)], [np.dtype(np.float32)]),
-#             "TCZYX",
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         # just totally wrong but valid ome
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             to_xml(OME()),
-#             "TCZYX",
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         # just totally wrong but valid ome
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             OME(),
-#             "TCZYX",
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         # even more blatantly bad ome
-#         pytest.param(
-#             (1, 2, 3, 4, 5),
-#             "bad ome string",
-#             "TCZYX",
-#             # raised from within ome-types
-#             marks=pytest.mark.raises(exception=urllib.error.URLError),
-#         ),
-#     ],
-# )
-# @pytest.mark.parametrize("filename", ["e.ome.tiff"])
-# def test_ome_tiff_writer_with_meta(
-#     array_constructor: Callable,
-#     shape_to_create: Tuple[int, ...],
-#     ome_xml: Union[str, OME, None],
-#     expected_dim_order: Tuple[int, ...],
-#     filename: str,
-# ) -> None:
-#     # Create array
-#     arr = array_constructor(shape_to_create, dtype=np.uint8)
+@array_constructor
+@pytest.mark.parametrize(
+    "shape_to_create, ome_xml, expected_dim_order",
+    [
+        # ok dims
+        (
+            (1, 2, 3, 4, 5),
+            to_xml(OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.uint8)])),
+            "TCZYX",
+        ),
+        (
+            (1, 2, 3, 4, 5),
+            OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.uint8)]),
+            "TCZYX",
+        ),
+        # with RGB data:
+        pytest.param(
+            (2, 2, 3, 4, 5, 3),
+            to_xml(OmeTiffWriter.build_ome([(2, 2, 3, 4, 5, 3)], [np.dtype(np.uint8)])),
+            "TCZYXS",
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        pytest.param(
+            (2, 2, 3, 4, 5, 3),
+            OmeTiffWriter.build_ome([(2, 2, 3, 4, 5, 3)], [np.dtype(np.uint8)]),
+            "TCZYXS",
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        # wrong dtype
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            to_xml(OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.float32)])),
+            "TCZYX",
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        # wrong dtype
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.float32)]),
+            "TCZYX",
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        # wrong dims
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            to_xml(OmeTiffWriter.build_ome([(2, 2, 3, 4, 5)], [np.dtype(np.float32)])),
+            "TCZYX",
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        # wrong dims
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            OmeTiffWriter.build_ome([(2, 2, 3, 4, 5)], [np.dtype(np.float32)]),
+            "TCZYX",
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        # just totally wrong but valid ome
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            to_xml(OME()),
+            "TCZYX",
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        # just totally wrong but valid ome
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            OME(),
+            "TCZYX",
+            marks=pytest.mark.raises(exception=IndexError),
+        ),
+        # even more blatantly bad ome
+        pytest.param(
+            (1, 2, 3, 4, 5),
+            "bad ome string",
+            "TCZYX",
+            # raised from within ome-types
+            marks=pytest.mark.raises(exception=urllib.error.URLError),
+        ),
+    ],
+)
+@pytest.mark.parametrize("filename", ["e.ome.tiff"])
+def test_ome_tiff_writer_with_meta(
+    array_constructor: Callable,
+    shape_to_create: Tuple[int, ...],
+    ome_xml: Union[str, OME, None],
+    expected_dim_order: Tuple[int, ...],
+    filename: str,
+) -> None:
+    # Create array
+    arr = array_constructor(shape_to_create, dtype=np.uint8)
 
-#     # Construct save end point
-#     save_uri = get_resource_write_full_path(filename, LOCAL)
+    # Construct save end point
+    save_uri = get_resource_write_full_path(filename, LOCAL)
 
-#     # Normal save
-#     OmeTiffWriter.save(arr, save_uri, dimension_order=None, ome_xml=ome_xml)
+    # Normal save
+    OmeTiledTiffWriter.save(arr, save_uri, dimension_order=None, ome_xml=ome_xml)
 
-#     # Read written result and check basics
-#     reader = OmeTiffReader(save_uri)
+    # Read written result and check basics
+    reader = OmeTiffReader(save_uri)
 
-#     # Check basics
-#     assert len(reader.scenes) == 1
-#     assert reader.shape == shape_to_create
-#     assert reader.dims.order == expected_dim_order
-
-
-# @pytest.mark.parametrize(
-#     "array_data, write_dim_order, read_shapes, read_dim_order",
-#     [
-#         ([np.random.rand(5, 16, 16)], None, [(1, 1, 5, 16, 16)], ["TCZYX"]),
-#         (
-#             [np.random.rand(5, 16, 16), np.random.rand(4, 12, 12)],
-#             None,
-#             [(1, 1, 5, 16, 16), (1, 1, 4, 12, 12)],
-#             ["TCZYX", "TCZYX"],
-#         ),
-#         (
-#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12, 3)],
-#             None,
-#             [(1, 5, 16, 16, 3), (1, 4, 12, 12, 3)],
-#             ["TCZYX", "TCZYX"],
-#         ),
-#         (
-#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12, 3)],
-#             ["ZYXS", "CYXS"],
-#             [(1, 1, 5, 16, 16, 3), (1, 4, 1, 12, 12, 3)],
-#             ["TCZYXS", "TCZYXS"],
-#         ),
-#         # spread dim_order to each image written
-#         (
-#             [np.random.rand(3, 10, 16, 16), np.random.rand(4, 12, 16, 16)],
-#             "CZYX",
-#             [(1, 3, 10, 16, 16), (1, 4, 12, 16, 16)],
-#             ["TCZYX", "TCZYX"],
-#         ),
-#         # different dims, rgb last
-#         (
-#             [np.random.rand(5, 16, 16), np.random.rand(4, 12, 12, 3)],
-#             ["ZYX", "CYXS"],
-#             [(1, 1, 5, 16, 16), (1, 4, 1, 12, 12, 3)],
-#             ["TCZYX", "TCZYXS"],
-#         ),
-#         # different dims, rgb first
-#         (
-#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12)],
-#             ["ZYXS", "CYX"],
-#             [(1, 1, 5, 16, 16, 3), (1, 4, 1, 12, 12)],
-#             ["TCZYXS", "TCZYX"],
-#         ),
-#         # two scenes but only one dimension order as list
-#         pytest.param(
-#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12)],
-#             ["ZYXS"],
-#             None,
-#             None,
-#             marks=pytest.mark.raises(exception=exceptions.ConflictingArgumentsError),
-#         ),
-#         # bad dims
-#         pytest.param(
-#             [np.random.rand(2, 3, 3)],
-#             "AYX",
-#             None,
-#             None,
-#             marks=pytest.mark.raises(
-#                 exception=exceptions.InvalidDimensionOrderingError
-#             ),
-#         ),
-#     ],
-# )
-# @pytest.mark.parametrize("filename", ["e.ome.tiff"])
-# def test_ome_tiff_writer_multiscene(
-#     array_data: List[types.ArrayLike],
-#     write_dim_order: List[Optional[str]],
-#     read_shapes: List[Tuple[int, ...]],
-#     read_dim_order: List[str],
-#     filename: str,
-# ) -> None:
-#     # Construct save end point
-#     save_uri = get_resource_write_full_path(filename, LOCAL)
-
-#     # Normal save
-#     OmeTiffWriter.save(array_data, save_uri, write_dim_order)
-
-#     # Read written result and check basics
-#     reader = OmeTiffReader(save_uri)
-
-#     # Check basics
-#     assert len(reader.scenes) == len(read_shapes)
-#     for i in range(len(reader.scenes)):
-#         reader.set_scene(reader.scenes[i])
-#         assert reader.shape == read_shapes[i]
-#         assert reader.dims.order == read_dim_order[i]
-
-
-# @pytest.mark.parametrize(
-#     "array_data, "
-#     "write_dim_order, "
-#     "pixel_size, "
-#     "channel_names, "
-#     "channel_colors, "
-#     "read_shapes, "
-#     "read_dim_order, "
-#     "expected_pixel_size",
-#     [
-#         (
-#             np.random.rand(1, 2, 5, 16, 16),
-#             "TCZYX",
-#             None,
-#             ["C0", "C1"],
-#             None,
-#             [(1, 2, 5, 16, 16)],
-#             ["TCZYX"],
-#             [(None, None, None)],
-#         ),
-#         (
-#             [np.random.rand(1, 2, 5, 16, 16), np.random.rand(1, 2, 4, 15, 15)],
-#             "TCZYX",
-#             None,
-#             ["C0", "C1"],
-#             None,
-#             [(1, 2, 5, 16, 16), (1, 2, 4, 15, 15)],
-#             ["TCZYX", "TCZYX"],
-#             [(None, None, None), (None, None, None)],
-#         ),
-#         (
-#             [np.random.rand(5, 16, 16)],
-#             None,
-#             [types.PhysicalPixelSizes(1.0, 2.0, 3.0)],
-#             ["C0"],
-#             None,
-#             [(1, 1, 5, 16, 16)],
-#             ["TCZYX"],
-#             [(1.0, 2.0, 3.0)],
-#         ),
-#         (
-#             [np.random.rand(5, 16, 16)],
-#             None,
-#             [types.PhysicalPixelSizes(None, 2.0, 3.0)],
-#             ["C0"],
-#             None,
-#             [(1, 1, 5, 16, 16)],
-#             ["TCZYX"],
-#             [(None, 2.0, 3.0)],
-#         ),
-#         (
-#             [np.random.rand(2, 16, 16), np.random.rand(2, 12, 12)],
-#             "CYX",
-#             [
-#                 types.PhysicalPixelSizes(1.0, 2.0, 3.0),
-#                 types.PhysicalPixelSizes(4.0, 5.0, 6.0),
-#             ],
-#             [["C0", "C1"], None],
-#             None,
-#             [(1, 2, 1, 16, 16), (1, 2, 1, 12, 12)],
-#             ["TCZYX", "TCZYX"],
-#             [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)],
-#         ),
-#         (
-#             np.random.rand(3, 16, 16),
-#             "CYX",
-#             types.PhysicalPixelSizes(None, 1.0, 1.0),
-#             ["C0", "C1", "C2"],
-#             [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
-#             [(1, 3, 1, 16, 16)],
-#             ["TCZYX"],
-#             [(None, 1.0, 1.0)],
-#         ),
-#         pytest.param(
-#             np.random.rand(3, 16, 16),
-#             "CYX",
-#             types.PhysicalPixelSizes(None, 1.0, 1.0),
-#             ["C0", "C1", "C2"],
-#             [[255, 0, 0], [0, 255, 0], [0, 0, 255], [1, 1, 1]],
-#             [(1, 3, 1, 16, 16)],
-#             ["TCZYX"],
-#             [(None, 1.0, 1.0)],
-#             marks=pytest.mark.raises(exception=ValueError),
-#         ),
-#         (
-#             [np.random.rand(3, 16, 16)],
-#             ["CYX"],
-#             [types.PhysicalPixelSizes(None, 1.0, 1.0)],
-#             [["C0", "C1", "C2"]],
-#             [[[255, 0, 0], [0, 255, 0], [0, 0, 255]]],
-#             [(1, 3, 1, 16, 16)],
-#             ["TCZYX"],
-#             [(None, 1.0, 1.0)],
-#         ),
-#         (
-#             [np.random.rand(3, 16, 16)],
-#             ["CYX"],
-#             [types.PhysicalPixelSizes(None, 1.0, 1.0)],
-#             [["C0", "C1", "C2"]],
-#             [None],
-#             [(1, 3, 1, 16, 16)],
-#             ["TCZYX"],
-#             [(None, 1.0, 1.0)],
-#         ),
-#         (
-#             [np.random.rand(3, 16, 16), np.random.rand(3, 16, 16)],
-#             "CYX",
-#             types.PhysicalPixelSizes(None, 1.0, 1.0),
-#             ["C0", "C1", "C2"],
-#             [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
-#             [(1, 3, 1, 16, 16), (1, 3, 1, 16, 16)],
-#             ["TCZYX", "TCZYX"],
-#             [(None, 1.0, 1.0), (None, 1.0, 1.0)],
-#         ),
-#         (
-#             [np.random.rand(3, 16, 16), np.random.rand(3, 4, 16, 16)],
-#             ["CYX", "CZYX"],
-#             [
-#                 types.PhysicalPixelSizes(None, 1.0, 1.0),
-#                 types.PhysicalPixelSizes(1.0, 1.0, 1.0),
-#             ],
-#             [["C0", "C1", "C2"], ["C4", "C5", "C6"]],
-#             [
-#                 [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
-#                 [[0, 255, 0], [0, 0, 255], [255, 0, 0]],
-#             ],
-#             [(1, 3, 1, 16, 16), (1, 3, 4, 16, 16)],
-#             ["TCZYX", "TCZYX"],
-#             [(None, 1.0, 1.0), (1.0, 1.0, 1.0)],
-#         ),
-#         (
-#             [np.random.rand(3, 16, 16), np.random.rand(3, 4, 16, 16)],
-#             ["CYX", "CZYX"],
-#             [
-#                 types.PhysicalPixelSizes(None, 1.0, 1.0),
-#                 types.PhysicalPixelSizes(1.0, 1.0, 1.0),
-#             ],
-#             [["C0", "C1", "C2"], ["C4", "C5", "C6"]],
-#             [
-#                 None,
-#                 [[0, 255, 0], [0, 0, 255], [255, 0, 0]],
-#             ],
-#             [(1, 3, 1, 16, 16), (1, 3, 4, 16, 16)],
-#             ["TCZYX", "TCZYX"],
-#             [(None, 1.0, 1.0), (1.0, 1.0, 1.0)],
-#         ),
-#     ],
-# )
-# @pytest.mark.parametrize("filename", ["e.ome.tiff"])
-# def test_ome_tiff_writer_common_metadata(
-#     array_data: Union[types.ArrayLike, List[types.ArrayLike]],
-#     write_dim_order: Union[Optional[str], List[Optional[str]]],
-#     pixel_size: Union[types.PhysicalPixelSizes, List[types.PhysicalPixelSizes]],
-#     channel_names: Union[List[str], List[Optional[List[str]]]],
-#     channel_colors: Union[Optional[List[List[int]]], List[Optional[List[List[int]]]]],
-#     read_shapes: List[Tuple[int, ...]],
-#     read_dim_order: List[str],
-#     expected_pixel_size: List[types.PhysicalPixelSizes],
-#     filename: str,
-# ) -> None:
-#     # Construct save end point
-#     save_uri = get_resource_write_full_path(filename, LOCAL)
-
-#     # Normal save
-#     OmeTiffWriter.save(
-#         array_data,
-#         save_uri,
-#         write_dim_order,
-#         channel_names=channel_names,
-#         channel_colors=channel_colors,
-#         physical_pixel_sizes=pixel_size,
-#     )
-
-#     # Read written result and check basics
-#     reader = OmeTiffReader(save_uri)
-
-#     # Check basics
-#     assert len(reader.scenes) == len(read_shapes)
-#     for i in range(len(reader.scenes)):
-#         reader.set_scene(reader.scenes[i])
-#         assert reader.shape == read_shapes[i]
-#         assert reader.dims.order == read_dim_order[i]
-#         assert reader.physical_pixel_sizes == expected_pixel_size[i]
+    # Check basics
+    assert len(reader.scenes) == 1
+    assert reader.shape == shape_to_create
+    assert reader.dims.order == expected_dim_order

--- a/aicsimageio/tests/writers/test_ome_tiled_tiff_writer.py
+++ b/aicsimageio/tests/writers/test_ome_tiled_tiff_writer.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import Callable, Tuple
+
+import numpy as np
+import pytest
+
+from aicsimageio.readers import OmeTiffReader
+from aicsimageio.writers.bfio_writers import OmeTiledTiffWriter
+
+from ..conftest import LOCAL, array_constructor, get_resource_write_full_path
+
+
+@array_constructor
+@pytest.mark.parametrize(
+    "write_shape, expected_read_shape, expected_read_dim_order",
+    [
+        ((5, 16, 16), (1, 1, 5, 16, 16), "TCZYX"),
+        ((5, 16, 16), (1, 1, 5, 16, 16), "TCZYX"),
+        # OmeTiffReader is curently reordering dims to TCZYX always
+        ((5, 1, 16, 16), (1, 5, 1, 16, 16), "TCZYX"),
+        ((5, 10, 16, 16), (1, 5, 10, 16, 16), "TCZYX"),
+        ((5, 10, 16, 16), (1, 5, 10, 16, 16), "TCZYX"),
+        ((16, 16), (1, 1, 1, 16, 16), "TCZYX"),
+        ((1, 2, 3, 4, 5), (1, 2, 3, 4, 5), "TCZYX"),
+        ((2, 3, 4, 5, 6), (2, 3, 4, 5, 6), "TCZYX"),
+        ((2, 3, 4, 5, 6), (2, 3, 4, 5, 6), "TCZYX"),
+    ],
+)
+@pytest.mark.parametrize("filename", ["e.ome.tiff"])
+def test_ome_tiled_tiff_writer_no_meta(
+    array_constructor: Callable,
+    write_shape: Tuple[int, ...],
+    expected_read_shape: Tuple[int, ...],
+    expected_read_dim_order: str,
+    filename: str,
+) -> None:
+    # Create array
+    arr = array_constructor(write_shape, dtype=np.uint8)
+
+    print(arr.shape)
+
+    # Construct save end point
+    save_uri = get_resource_write_full_path(filename, LOCAL)
+
+    # Normal save
+    OmeTiledTiffWriter.save(arr, save_uri)
+
+    # Read written result and check basics
+    reader = OmeTiffReader(save_uri)
+
+    # Check basics
+    assert len(reader.scenes) == 1
+    assert reader.shape == expected_read_shape
+    assert reader.dims.order == expected_read_dim_order
+
+
+# @array_constructor
+# @pytest.mark.parametrize(
+#     "shape_to_create, ome_xml, expected_dim_order",
+#     [
+#         # ok dims
+#         (
+#             (1, 2, 3, 4, 5),
+#             to_xml(OmeTiffWriter.build_ome([(1,2,3, 4, 5)], [np.dtype(np.uint8)])),
+#             "TCZYX",
+#         ),
+#         (
+#             (1, 2, 3, 4, 5),
+#             OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.uint8)]),
+#             "TCZYX",
+#         ),
+#         # with RGB data:
+#         (
+#             (2, 2, 3, 4, 5, 3),
+#             to_xml(OmeTiffWriter.build_ome([(2, 2,3,4, 5, 3)], [np.dtype(np.uint8)])),
+#             "TCZYXS",
+#         ),
+#         (
+#             (2, 2, 3, 4, 5, 3),
+#             OmeTiffWriter.build_ome([(2, 2, 3, 4, 5, 3)], [np.dtype(np.uint8)]),
+#             "TCZYXS",
+#         ),
+#         # wrong dtype
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             to_xml(OmeTiffWriter.build_ome([(1, 2, 3,4, 5)], [np.dtype(np.float32)])),
+#             "TCZYX",
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         # wrong dtype
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             OmeTiffWriter.build_ome([(1, 2, 3, 4, 5)], [np.dtype(np.float32)]),
+#             "TCZYX",
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         # wrong dims
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             to_xml(OmeTiffWriter.build_ome([(2,2,3, 4, 5)], [np.dtype(np.float32)])),
+#             "TCZYX",
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         # wrong dims
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             OmeTiffWriter.build_ome([(2, 2, 3, 4, 5)], [np.dtype(np.float32)]),
+#             "TCZYX",
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         # just totally wrong but valid ome
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             to_xml(OME()),
+#             "TCZYX",
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         # just totally wrong but valid ome
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             OME(),
+#             "TCZYX",
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         # even more blatantly bad ome
+#         pytest.param(
+#             (1, 2, 3, 4, 5),
+#             "bad ome string",
+#             "TCZYX",
+#             # raised from within ome-types
+#             marks=pytest.mark.raises(exception=urllib.error.URLError),
+#         ),
+#     ],
+# )
+# @pytest.mark.parametrize("filename", ["e.ome.tiff"])
+# def test_ome_tiff_writer_with_meta(
+#     array_constructor: Callable,
+#     shape_to_create: Tuple[int, ...],
+#     ome_xml: Union[str, OME, None],
+#     expected_dim_order: Tuple[int, ...],
+#     filename: str,
+# ) -> None:
+#     # Create array
+#     arr = array_constructor(shape_to_create, dtype=np.uint8)
+
+#     # Construct save end point
+#     save_uri = get_resource_write_full_path(filename, LOCAL)
+
+#     # Normal save
+#     OmeTiffWriter.save(arr, save_uri, dimension_order=None, ome_xml=ome_xml)
+
+#     # Read written result and check basics
+#     reader = OmeTiffReader(save_uri)
+
+#     # Check basics
+#     assert len(reader.scenes) == 1
+#     assert reader.shape == shape_to_create
+#     assert reader.dims.order == expected_dim_order
+
+
+# @pytest.mark.parametrize(
+#     "array_data, write_dim_order, read_shapes, read_dim_order",
+#     [
+#         ([np.random.rand(5, 16, 16)], None, [(1, 1, 5, 16, 16)], ["TCZYX"]),
+#         (
+#             [np.random.rand(5, 16, 16), np.random.rand(4, 12, 12)],
+#             None,
+#             [(1, 1, 5, 16, 16), (1, 1, 4, 12, 12)],
+#             ["TCZYX", "TCZYX"],
+#         ),
+#         (
+#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12, 3)],
+#             None,
+#             [(1, 5, 16, 16, 3), (1, 4, 12, 12, 3)],
+#             ["TCZYX", "TCZYX"],
+#         ),
+#         (
+#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12, 3)],
+#             ["ZYXS", "CYXS"],
+#             [(1, 1, 5, 16, 16, 3), (1, 4, 1, 12, 12, 3)],
+#             ["TCZYXS", "TCZYXS"],
+#         ),
+#         # spread dim_order to each image written
+#         (
+#             [np.random.rand(3, 10, 16, 16), np.random.rand(4, 12, 16, 16)],
+#             "CZYX",
+#             [(1, 3, 10, 16, 16), (1, 4, 12, 16, 16)],
+#             ["TCZYX", "TCZYX"],
+#         ),
+#         # different dims, rgb last
+#         (
+#             [np.random.rand(5, 16, 16), np.random.rand(4, 12, 12, 3)],
+#             ["ZYX", "CYXS"],
+#             [(1, 1, 5, 16, 16), (1, 4, 1, 12, 12, 3)],
+#             ["TCZYX", "TCZYXS"],
+#         ),
+#         # different dims, rgb first
+#         (
+#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12)],
+#             ["ZYXS", "CYX"],
+#             [(1, 1, 5, 16, 16, 3), (1, 4, 1, 12, 12)],
+#             ["TCZYXS", "TCZYX"],
+#         ),
+#         # two scenes but only one dimension order as list
+#         pytest.param(
+#             [np.random.rand(5, 16, 16, 3), np.random.rand(4, 12, 12)],
+#             ["ZYXS"],
+#             None,
+#             None,
+#             marks=pytest.mark.raises(exception=exceptions.ConflictingArgumentsError),
+#         ),
+#         # bad dims
+#         pytest.param(
+#             [np.random.rand(2, 3, 3)],
+#             "AYX",
+#             None,
+#             None,
+#             marks=pytest.mark.raises(
+#                 exception=exceptions.InvalidDimensionOrderingError
+#             ),
+#         ),
+#     ],
+# )
+# @pytest.mark.parametrize("filename", ["e.ome.tiff"])
+# def test_ome_tiff_writer_multiscene(
+#     array_data: List[types.ArrayLike],
+#     write_dim_order: List[Optional[str]],
+#     read_shapes: List[Tuple[int, ...]],
+#     read_dim_order: List[str],
+#     filename: str,
+# ) -> None:
+#     # Construct save end point
+#     save_uri = get_resource_write_full_path(filename, LOCAL)
+
+#     # Normal save
+#     OmeTiffWriter.save(array_data, save_uri, write_dim_order)
+
+#     # Read written result and check basics
+#     reader = OmeTiffReader(save_uri)
+
+#     # Check basics
+#     assert len(reader.scenes) == len(read_shapes)
+#     for i in range(len(reader.scenes)):
+#         reader.set_scene(reader.scenes[i])
+#         assert reader.shape == read_shapes[i]
+#         assert reader.dims.order == read_dim_order[i]
+
+
+# @pytest.mark.parametrize(
+#     "array_data, "
+#     "write_dim_order, "
+#     "pixel_size, "
+#     "channel_names, "
+#     "channel_colors, "
+#     "read_shapes, "
+#     "read_dim_order, "
+#     "expected_pixel_size",
+#     [
+#         (
+#             np.random.rand(1, 2, 5, 16, 16),
+#             "TCZYX",
+#             None,
+#             ["C0", "C1"],
+#             None,
+#             [(1, 2, 5, 16, 16)],
+#             ["TCZYX"],
+#             [(None, None, None)],
+#         ),
+#         (
+#             [np.random.rand(1, 2, 5, 16, 16), np.random.rand(1, 2, 4, 15, 15)],
+#             "TCZYX",
+#             None,
+#             ["C0", "C1"],
+#             None,
+#             [(1, 2, 5, 16, 16), (1, 2, 4, 15, 15)],
+#             ["TCZYX", "TCZYX"],
+#             [(None, None, None), (None, None, None)],
+#         ),
+#         (
+#             [np.random.rand(5, 16, 16)],
+#             None,
+#             [types.PhysicalPixelSizes(1.0, 2.0, 3.0)],
+#             ["C0"],
+#             None,
+#             [(1, 1, 5, 16, 16)],
+#             ["TCZYX"],
+#             [(1.0, 2.0, 3.0)],
+#         ),
+#         (
+#             [np.random.rand(5, 16, 16)],
+#             None,
+#             [types.PhysicalPixelSizes(None, 2.0, 3.0)],
+#             ["C0"],
+#             None,
+#             [(1, 1, 5, 16, 16)],
+#             ["TCZYX"],
+#             [(None, 2.0, 3.0)],
+#         ),
+#         (
+#             [np.random.rand(2, 16, 16), np.random.rand(2, 12, 12)],
+#             "CYX",
+#             [
+#                 types.PhysicalPixelSizes(1.0, 2.0, 3.0),
+#                 types.PhysicalPixelSizes(4.0, 5.0, 6.0),
+#             ],
+#             [["C0", "C1"], None],
+#             None,
+#             [(1, 2, 1, 16, 16), (1, 2, 1, 12, 12)],
+#             ["TCZYX", "TCZYX"],
+#             [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)],
+#         ),
+#         (
+#             np.random.rand(3, 16, 16),
+#             "CYX",
+#             types.PhysicalPixelSizes(None, 1.0, 1.0),
+#             ["C0", "C1", "C2"],
+#             [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+#             [(1, 3, 1, 16, 16)],
+#             ["TCZYX"],
+#             [(None, 1.0, 1.0)],
+#         ),
+#         pytest.param(
+#             np.random.rand(3, 16, 16),
+#             "CYX",
+#             types.PhysicalPixelSizes(None, 1.0, 1.0),
+#             ["C0", "C1", "C2"],
+#             [[255, 0, 0], [0, 255, 0], [0, 0, 255], [1, 1, 1]],
+#             [(1, 3, 1, 16, 16)],
+#             ["TCZYX"],
+#             [(None, 1.0, 1.0)],
+#             marks=pytest.mark.raises(exception=ValueError),
+#         ),
+#         (
+#             [np.random.rand(3, 16, 16)],
+#             ["CYX"],
+#             [types.PhysicalPixelSizes(None, 1.0, 1.0)],
+#             [["C0", "C1", "C2"]],
+#             [[[255, 0, 0], [0, 255, 0], [0, 0, 255]]],
+#             [(1, 3, 1, 16, 16)],
+#             ["TCZYX"],
+#             [(None, 1.0, 1.0)],
+#         ),
+#         (
+#             [np.random.rand(3, 16, 16)],
+#             ["CYX"],
+#             [types.PhysicalPixelSizes(None, 1.0, 1.0)],
+#             [["C0", "C1", "C2"]],
+#             [None],
+#             [(1, 3, 1, 16, 16)],
+#             ["TCZYX"],
+#             [(None, 1.0, 1.0)],
+#         ),
+#         (
+#             [np.random.rand(3, 16, 16), np.random.rand(3, 16, 16)],
+#             "CYX",
+#             types.PhysicalPixelSizes(None, 1.0, 1.0),
+#             ["C0", "C1", "C2"],
+#             [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+#             [(1, 3, 1, 16, 16), (1, 3, 1, 16, 16)],
+#             ["TCZYX", "TCZYX"],
+#             [(None, 1.0, 1.0), (None, 1.0, 1.0)],
+#         ),
+#         (
+#             [np.random.rand(3, 16, 16), np.random.rand(3, 4, 16, 16)],
+#             ["CYX", "CZYX"],
+#             [
+#                 types.PhysicalPixelSizes(None, 1.0, 1.0),
+#                 types.PhysicalPixelSizes(1.0, 1.0, 1.0),
+#             ],
+#             [["C0", "C1", "C2"], ["C4", "C5", "C6"]],
+#             [
+#                 [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
+#                 [[0, 255, 0], [0, 0, 255], [255, 0, 0]],
+#             ],
+#             [(1, 3, 1, 16, 16), (1, 3, 4, 16, 16)],
+#             ["TCZYX", "TCZYX"],
+#             [(None, 1.0, 1.0), (1.0, 1.0, 1.0)],
+#         ),
+#         (
+#             [np.random.rand(3, 16, 16), np.random.rand(3, 4, 16, 16)],
+#             ["CYX", "CZYX"],
+#             [
+#                 types.PhysicalPixelSizes(None, 1.0, 1.0),
+#                 types.PhysicalPixelSizes(1.0, 1.0, 1.0),
+#             ],
+#             [["C0", "C1", "C2"], ["C4", "C5", "C6"]],
+#             [
+#                 None,
+#                 [[0, 255, 0], [0, 0, 255], [255, 0, 0]],
+#             ],
+#             [(1, 3, 1, 16, 16), (1, 3, 4, 16, 16)],
+#             ["TCZYX", "TCZYX"],
+#             [(None, 1.0, 1.0), (1.0, 1.0, 1.0)],
+#         ),
+#     ],
+# )
+# @pytest.mark.parametrize("filename", ["e.ome.tiff"])
+# def test_ome_tiff_writer_common_metadata(
+#     array_data: Union[types.ArrayLike, List[types.ArrayLike]],
+#     write_dim_order: Union[Optional[str], List[Optional[str]]],
+#     pixel_size: Union[types.PhysicalPixelSizes, List[types.PhysicalPixelSizes]],
+#     channel_names: Union[List[str], List[Optional[List[str]]]],
+#     channel_colors: Union[Optional[List[List[int]]], List[Optional[List[List[int]]]]],
+#     read_shapes: List[Tuple[int, ...]],
+#     read_dim_order: List[str],
+#     expected_pixel_size: List[types.PhysicalPixelSizes],
+#     filename: str,
+# ) -> None:
+#     # Construct save end point
+#     save_uri = get_resource_write_full_path(filename, LOCAL)
+
+#     # Normal save
+#     OmeTiffWriter.save(
+#         array_data,
+#         save_uri,
+#         write_dim_order,
+#         channel_names=channel_names,
+#         channel_colors=channel_colors,
+#         physical_pixel_sizes=pixel_size,
+#     )
+
+#     # Read written result and check basics
+#     reader = OmeTiffReader(save_uri)
+
+#     # Check basics
+#     assert len(reader.scenes) == len(read_shapes)
+#     for i in range(len(reader.scenes)):
+#         reader.set_scene(reader.scenes[i])
+#         assert reader.shape == read_shapes[i]
+#         assert reader.dims.order == read_dim_order[i]
+#         assert reader.physical_pixel_sizes == expected_pixel_size[i]

--- a/aicsimageio/writers/bfio_writers.py
+++ b/aicsimageio/writers/bfio_writers.py
@@ -1,0 +1,114 @@
+from typing import Any, List, Optional, Union
+
+import dask.array as da
+import numpy as np
+from bfio import BioWriter
+from fsspec.implementations.local import LocalFileSystem
+from ome_types import OME, from_xml
+
+from .. import types
+from ..utils import io_utils
+from .writer import Writer
+
+
+class OmeTiledTiffWriter(Writer):
+    @staticmethod
+    def save(  # type: ignore
+        data: types.ArrayLike,
+        uri: types.PathLike,
+        ome_xml: Optional[Union[str, OME]] = None,
+        channel_names: Optional[Union[List[str], List[Optional[List[str]]]]] = None,
+        physical_pixel_sizes: Optional[
+            Union[types.PhysicalPixelSizes, List[types.PhysicalPixelSizes]]
+        ] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Write a data array to a file using tile chunking. Tiles are 1024x1024 pixels.
+
+        Parameters
+        ----------
+        data: Union[List[types.ArrayLike], types.ArrayLike]
+            The array of data to store. Data arrays must have 2 to 5 dimensions. Data
+            should have shape [T,C,Z,Y,X], where interstitial empty dimensions must be
+            present. For example, a 3-channel image that is 1024x1024 must at least have
+            shape [3,1,1024,1024]. Image with shape [3,1024,1024] will be interpreted as
+            an image with 3 z-slices.
+        uri: types.PathLike
+            The URI or local path for where to save the data.
+            Note: OmeTiledTiffWriter can only write to local file systems.
+        ome_xml: Optional[Union[str, OME]]
+            Provided OME metadata. The metadata can be an xml string or an OME object
+            from ome-types. A provided ome_xml will override any other provided
+            metadata arguments.
+            Default: None
+            The passed-in metadata will be validated against current OME_XML schema and
+            raise exception if invalid.
+            The ome_xml will also be compared against the dimensions of the input data.
+            If None is given, then OME-XML metadata will be generated from the data
+            array and any of the following metadata arguments.
+        channel_names: Optional[Union[List[str], List[Optional[List[str]]]]]
+            Lists of strings representing the names of the data channels
+            Default: None
+            If None is given, the list will be generated as a 0-indexed list of strings
+            of the form "Channel:channel_index"
+        physical_pixel_sizes: Optional[Union[types.PhysicalPixelSizes,
+                List[types.PhysicalPixelSizes]]]
+            List of numbers representing the physical pixel sizes in Z, Y, X in microns
+            Default: None
+
+        Raises
+        ------
+        ValueError:
+            Non-local file system URI provided.
+
+        Examples
+        --------
+        Write a TCZYX data set to OME-Tiff
+
+        >>> image = numpy.ndarray([1, 10, 3, 1024, 2048])
+        ... OmeTiffWriter.save(image, "file.ome.tif")
+        """
+        # Resolve final destination
+        fs, path = io_utils.pathlike_to_fs(uri)
+
+        # Catch non-local file system
+        if not isinstance(fs, LocalFileSystem):
+            raise ValueError(
+                f"Cannot write to non-local file system. "
+                f"Received URI: {uri}, which points to {type(fs)}."
+            )
+
+        # If metadata is attached as lists, enforce matching shape
+        if not isinstance(data, (np.ndarray, da.core.Array)):
+            raise TypeError(
+                "Input data for the OmeTiledTiffWriter must be a numpy.ndarray"
+            )
+
+        if isinstance(ome_xml, str):
+            ome_xml = from_xml(ome_xml)
+
+        with BioWriter(path, metadata=ome_xml, backend="python") as bw:
+
+            # Define xml if ome_xml is not present but other kwargs are
+            if ome_xml is None:
+                if channel_names is not None:
+                    bw.channel_names = channel_names
+
+                if physical_pixel_sizes is not None:
+                    bw.ps_z = (physical_pixel_sizes[0], None)
+                    bw.ps_y = (physical_pixel_sizes[1], None)
+                    bw.ps_x = (physical_pixel_sizes[2], None)
+
+                for dim, val in zip("XYZCT", reversed(data.shape)):
+                    setattr(bw, dim, val)
+
+                bw.dtype = data.dtype
+
+            dim_order = (-2, -1) + tuple(reversed(range(len(data.shape) - 2)))
+
+            if isinstance(data, da.core.Array):
+                data = data[...].compute()  # type: ignore
+
+            data = data.transpose(dim_order)
+            bw[:] = data

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Specific Doc Pages
    aicsimageio.readers.ome_tiff_reader.OmeTiffReader
    aicsimageio.readers.tiff_reader.TiffReader
    aicsimageio.writers.ome_tiff_writer.OmeTiffWriter
+   aicsimageio.writers.bfio_writers.OmeTiledTiffWriter
 
 Indices and tables
 ==================

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,10 @@ test_requirements = [
     "pytest-raises>=0.11",
     "quilt3",  # no pin to avoid pip cycling (boto is really hard to manage)
     "s3fs[boto3]>=2022.11.0",
-    "tox==3.27.1",
+    "tox>=3.27.1",
+    "bioformats_jar",  # to test bioformats
+    "readlif>=0.6.4",  # to test lif
+    "aicspylibczi>=3.0.5",  # to test czi
 ]
 
 dev_requirements = [


### PR DESCRIPTION
This PR is a continuation of #396.

This PR adds adds a writer to wrap the bfio.BioWriter(backend="python"). This writer will only write OME TIFFs with the tile width and tile tags set to 1024 and dimension order XYZCT with Deflate compression. The BioWriter performs pseudo-threaded writing, where compression is performed in threads and written in the main thread as they complete. This leads to significant performance improvements for images larger than 1024x1024, or images of moderate size with many image planes. The potential deficit to this format is that image chunks may be scattered throughout the file, potentially leading to slower reading times on older hard drives. However, early testing shows marginal performance deficits, but thorough performance testing has not been performed.
