### PR TITLE
Bugfix/slow tile retrieval

### DIFF
--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -911,6 +911,49 @@ class AICSImage(ImageContainer):
         """
         return self.reader.get_mosaic_tile_position(mosaic_tile_index, **kwargs)
 
+    def get_mosaic_tile_positions(self, **kwargs: int) -> List[Tuple[int, int]]:
+        """
+        Get the absolute positions of the top left points for each mosaic tile
+        matching the specified dimensions and current scene.
+
+        Parameters
+        ----------
+        kwargs: int
+            The keywords below allow you to specify the dimensions that you wish
+            to match. If you under-specify the constraints you can easily
+            end up with a massive image stack.
+                       Z = 1   # The Z-dimension.
+                       C = 2   # The C-dimension ("channel").
+                       T = 3   # The T-dimension ("time").
+                       M = 4   # The mosaic tile index
+
+        Returns
+        -------
+        mosaic_tile_positions: List[Tuple[int, int]]
+            List of the Y and X coordinate for the tile positions.
+
+        Raises
+        ------
+        UnexpectedShapeError
+            The image has no mosaic dimension available.
+        NotImplementedError
+            Unable to combine M dimension with other dimensions when finding
+            tiles matching kwargs
+        """
+        if "M" in kwargs:
+            # Don't support getting positions by M + another dim
+            if len(kwargs) != 1:
+                other_keys = {key for key in kwargs if key != "M"}
+                raise NotImplementedError(
+                    "Unable to determine appropriate position using mosaic tile "
+                    + "index (M) combined with other dimensions "
+                    + f"(including {other_keys})"
+                )
+
+            return [self.get_mosaic_tile_position(kwargs["M"])]
+
+        return self.reader.get_mosaic_tile_positions(**kwargs)
+
     @property
     def mosaic_tile_dims(self) -> Optional[dimensions.Dimensions]:
         """

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -938,17 +938,23 @@ class AICSImage(ImageContainer):
             Unable to combine M dimension with other dimensions when finding
             tiles matching kwargs
         """
-        if "M" in kwargs:
+        if dimensions.DimensionNames.MosaicTile in kwargs:
             # Don't support getting positions by M + another dim
             if len(kwargs) != 1:
-                other_keys = {key for key in kwargs if key != "M"}
+                other_keys = {
+                    key for key in kwargs if key != dimensions.DimensionNames.MosaicTile
+                }
                 raise NotImplementedError(
                     "Unable to determine appropriate position using mosaic tile "
                     + "index (M) combined with other dimensions "
                     + f"(including {other_keys})"
                 )
 
-            return [self.get_mosaic_tile_position(kwargs["M"])]
+            return [
+                self.get_mosaic_tile_position(
+                    kwargs[dimensions.DimensionNames.MosaicTile]
+                )
+            ]
 
         return self.reader.get_mosaic_tile_positions(**kwargs)
 

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -906,8 +906,6 @@ class AICSImage(ImageContainer):
         ------
         UnexpectedShapeError
             The image has no mosaic dimension available.
-        IndexError
-            No matching mosaic tile index found.
         """
         return self.reader.get_mosaic_tile_position(mosaic_tile_index, **kwargs)
 

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -878,7 +878,7 @@ class AICSImage(ImageContainer):
         return self.reader.physical_pixel_sizes
 
     def get_mosaic_tile_position(
-        self, mosaic_tile_index: int, **kwargs: Any
+        self, mosaic_tile_index: int, **kwargs: int
     ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
@@ -887,7 +887,7 @@ class AICSImage(ImageContainer):
         ----------
         mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
-        kwargs: Any
+        kwargs: int
             The keywords below allow you to specify the dimensions that you wish
             to match. If you under-specify the constraints you can easily
             end up with a massive image stack.

--- a/aicsimageio/aics_image.py
+++ b/aicsimageio/aics_image.py
@@ -878,16 +878,22 @@ class AICSImage(ImageContainer):
         return self.reader.physical_pixel_sizes
 
     def get_mosaic_tile_position(
-        self, mosaic_tile_index: int
-    ) -> Optional[Tuple[int, int]]:
+        self, mosaic_tile_index: int, **kwargs: Any
+    ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
-        Returns None if the image is not a mosaic.
 
         Parameters
         ----------
         mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
+        kwargs: Any
+            The keywords below allow you to specify the dimensions that you wish
+            to match. If you under-specify the constraints you can easily
+            end up with a massive image stack.
+                       Z = 1   # The Z-dimension.
+                       C = 2   # The C-dimension ("channel").
+                       T = 3   # The T-dimension ("time").
 
         Returns
         -------
@@ -895,8 +901,15 @@ class AICSImage(ImageContainer):
             The Y coordinate for the tile position.
         left: int
             The X coordinate for the tile position.
+
+        Raises
+        ------
+        UnexpectedShapeError
+            The image has no mosaic dimension available.
+        IndexError
+            No matching mosaic tile index found.
         """
-        return self.reader.get_mosaic_tile_position(mosaic_tile_index)
+        return self.reader.get_mosaic_tile_position(mosaic_tile_index, **kwargs)
 
     @property
     def mosaic_tile_dims(self) -> Optional[dimensions.Dimensions]:

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -974,3 +974,39 @@ class CziReader(Reader):
                 M=mosaic_tile_index, S=self.current_scene_index, **kwargs
             )
             return bbox.y, bbox.x
+
+    def get_mosaic_tile_positions(self, **kwargs: int) -> List[Tuple[int, int]]:
+        """
+        Get the absolute positions of the top left points for each mosaic tile
+        matching the specified dimensions and current scene.
+
+        Parameters
+        ----------
+        kwargs: int
+            The keywords below allow you to specify the dimensions that you wish
+            to match. If you under-specify the constraints you can easily
+            end up with a massive image stack.
+                       Z = 1   # The Z-dimension.
+                       C = 2   # The C-dimension ("channel").
+                       T = 3   # The T-dimension ("time").
+
+        Returns
+        -------
+        mosaic_tile_positions: List[Tuple[int, int]]
+            List of the Y and X coordinate for the tile positions.
+
+        Raises
+        ------
+        UnexpectedShapeError
+            The image has no mosaic dimension available.
+        """
+        if DimensionNames.MosaicTile not in self.dims.order:
+            raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
+
+        with self._fs.open(self._path) as open_resource:
+            czi = CziFile(open_resource.f)
+
+            bboxes = czi.get_all_mosaic_tile_bounding_boxes(
+                S=self.current_scene_index, **kwargs
+            )
+            return [(bbox.y, bbox.x) for bbox in bboxes]

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -922,7 +922,7 @@ class CziReader(Reader):
         mosaic_tile_index: int,
         T: Optional[int] = 0,
         C: Optional[int] = 0,
-        **kwargs: Any,
+        **kwargs: int,
     ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
@@ -939,7 +939,7 @@ class CziReader(Reader):
             C ("channel") dimension index. Defaults to 0 to avoid reading massive image
             stack into memory in the simple case where the mosaic positions are the
             same for each channel (or otherwise doesn't matter)
-        kwargs: Any
+        kwargs: int
             The keywords below allow you to specify the dimensions that you wish
             to match. If you under-specify the constraints you can easily
             end up with a massive image stack.

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -960,13 +960,12 @@ class CziReader(Reader):
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
 
-            # Default T and C dimensions to 0 to improve
+            # Default Channel and Time dimensions to 0 to improve
             # worst case read time for large files **only**
             # when those dimensions are present on the image.
-            if "T" not in kwargs and "T" in self.dims.order:
-                kwargs["T"] = 0
-            if "C" not in kwargs and "C" in self.dims.order:
-                kwargs["C"] = 0
+            for dimension_name in [DimensionNames.Channel, DimensionNames.Time]:
+                if dimension_name not in kwargs and dimension_name in self.dims.order:
+                    kwargs[dimension_name] = 0
 
             bbox = czi.get_mosaic_tile_bounding_box(
                 M=mosaic_tile_index, S=self.current_scene_index, **kwargs

--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -948,8 +948,6 @@ class CziReader(Reader):
         ------
         UnexpectedShapeError
             The image has no mosaic dimension available.
-        IndexError
-            No matching mosaic tile index found.
 
         Notes
         -----
@@ -1006,7 +1004,18 @@ class CziReader(Reader):
         with self._fs.open(self._path) as open_resource:
             czi = CziFile(open_resource.f)
 
-            bboxes = czi.get_all_mosaic_tile_bounding_boxes(
+            tile_info_to_bboxes = czi.get_all_mosaic_tile_bounding_boxes(
                 S=self.current_scene_index, **kwargs
             )
-            return [(bbox.y, bbox.x) for bbox in bboxes]
+
+            # Convert dictionary of tile info mappings to
+            # a list of bounding boxes sorted according to their
+            # respective M indexes
+            m_indexes_to_mosaic_positions = {
+                tile_info.m_index: (bbox.y, bbox.x)
+                for tile_info, bbox in tile_info_to_bboxes.items()
+            }
+            return [
+                m_indexes_to_mosaic_positions[m_index]
+                for m_index in sorted(m_indexes_to_mosaic_positions.keys())
+            ]

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -750,7 +750,9 @@ class LifReader(Reader):
 
         return self._px_sizes
 
-    def get_mosaic_tile_position(self, mosaic_tile_index: int) -> Tuple[int, int]:
+    def get_mosaic_tile_position(
+        self, mosaic_tile_index: int, **kwargs: Any
+    ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
         Not equivalent to readlif's notion of mosaic_position.
@@ -759,6 +761,13 @@ class LifReader(Reader):
         ----------
         mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
+        kwargs: Any
+            The keywords below allow you to specify the dimensions that you wish
+            to match. If you under-specify the constraints you can easily
+            end up with a massive image stack.
+                       Z = 1   # The Z-dimension.
+                       C = 2   # The C-dimension ("channel").
+                       T = 3   # The T-dimension ("time").
 
         Returns
         -------
@@ -776,6 +785,13 @@ class LifReader(Reader):
         """
         if DimensionNames.MosaicTile not in self.dims.order:
             raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
+
+        if kwargs:
+            raise NotImplementedError(
+                "Selecting mosaic positions by dimensions is not supporting "
+                + "by LifReader. Retrieve a specific mosaic position via the "
+                + "mosaic tile index (M) by using .get_mosaic_tile_position() instead."
+            )
 
         # LIFs are packed from bottom right to top left
         # To counter: subtract 1 + M from list index to get from back of list

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -751,7 +751,7 @@ class LifReader(Reader):
         return self._px_sizes
 
     def get_mosaic_tile_position(
-        self, mosaic_tile_index: int, **kwargs: Any
+        self, mosaic_tile_index: int, **kwargs: int
     ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
@@ -761,7 +761,7 @@ class LifReader(Reader):
         ----------
         mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
-        kwargs: Any
+        kwargs: int
             The keywords below allow you to specify the dimensions that you wish
             to match. If you under-specify the constraints you can easily
             end up with a massive image stack.

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -595,10 +595,10 @@ class LifReader(Reader):
             is_last_row = row_index + 1 >= number_of_rows
             is_last_column = column_index + 1 >= number_of_columns
             if not is_last_row:
-                tile = tile[:, :, :, 1:, :]
+                tile = tile[:, :, :, :-1, :]
 
             if not is_last_column:
-                tile = tile[:, :, :, :, 1:]
+                tile = tile[:, :, :, :, :-1]
 
             xy_plane[row_index, column_index] = tile
 
@@ -713,10 +713,8 @@ class LifReader(Reader):
         if DimensionNames.MosaicTile not in self.dims.order:
             raise exceptions.UnexpectedShapeError("No mosaic dimension in image.")
 
-        # LIFs are packed from bottom right to top left
-        # To counter: subtract 1 + M from list index to get from back of list
-        index_y, index_x, _, _ = self._scene_short_info["mosaic_position"][
-            -(mosaic_tile_index + 1)
+        index_x, index_y, _, _ = self._scene_short_info["mosaic_position"][
+            mosaic_tile_index
         ]
 
         # Formula: (Dim position * Tile dim length) - Dim position

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -857,12 +857,10 @@ class LifReader(Reader):
         ]
 
         # LIFs are packed from bottom right to top left
-        # To counter: reverse the list
-        mosaic_positions.reverse()
-
+        # To counter: read the positions in reverse
         adjusted_mosaic_positions: List[Tuple[int, int]] = []
         y_dim_length, x_dim_length = self._get_yx_tile_count()
-        for x, y, *_ in mosaic_positions:
+        for x, y, *_ in reversed(mosaic_positions):
             if self.is_x_and_y_swapped:
                 x, y = y, x
             if self.is_x_flipped:

--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -852,12 +852,16 @@ class LifReader(Reader):
                 + "mosaic tile index (M) by using .get_mosaic_tile_position() instead."
             )
 
+        mosaic_positions: List[Tuple[int, int, float, float]] = self._scene_short_info[
+            "mosaic_position"
+        ]
+
         # LIFs are packed from bottom right to top left
         # To counter: reverse the list
-        mosaic_positions = self._scene_short_info["mosaic_position"].reverse()
-        y_dim_length, x_dim_length = self._get_yx_tile_count()
+        mosaic_positions.reverse()
 
         adjusted_mosaic_positions: List[Tuple[int, int]] = []
+        y_dim_length, x_dim_length = self._get_yx_tile_count()
         for x, y, *_ in mosaic_positions:
             if self.is_x_and_y_swapped:
                 x, y = y, x

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -827,6 +827,33 @@ class Reader(ImageContainer, ABC):
         """
         raise NotImplementedError()
 
+    def get_mosaic_tile_positions(self, **kwargs: int) -> List[Tuple[int, int]]:
+        """
+        Get the absolute positions of the top left points for each mosaic tile
+        matching the specified dimensions and current scene.
+
+        Parameters
+        ----------
+        kwargs: int
+            The keywords below allow you to specify the dimensions that you wish
+            to match. If you under-specify the constraints you can easily
+            end up with a massive image stack.
+                       Z = 1   # The Z-dimension.
+                       C = 2   # The C-dimension ("channel").
+                       T = 3   # The T-dimension ("time").
+
+        Returns
+        -------
+        mosaic_tile_positions: List[Tuple[int, int]]
+            List of the Y and X coordinate for the tile positions.
+
+        Raises
+        ------
+        UnexpectedShapeError
+            The image has no mosaic dimension available.
+        """
+        raise NotImplementedError()
+
     @property
     def mosaic_tile_dims(self) -> Optional[Dimensions]:
         """

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -794,16 +794,22 @@ class Reader(ImageContainer, ABC):
         return PhysicalPixelSizes(None, None, None)
 
     def get_mosaic_tile_position(
-        self, mosaic_tile_index: int
-    ) -> Optional[Tuple[int, int]]:
+        self, mosaic_tile_index: int, **kwargs: Any
+    ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
-        Returns None if the image is not a mosaic.
 
         Parameters
         ----------
         mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
+        kwargs
+            The keywords below allow you to specify the dimensions that you wish
+            to match. If you under-specify the constraints you can easily
+            end up with a massive image stack.
+                       Z = 1   # The Z-dimension.
+                       C = 2   # The C-dimension ("channel").
+                       T = 3   # The T-dimension ("time").
 
         Returns
         -------

--- a/aicsimageio/readers/reader.py
+++ b/aicsimageio/readers/reader.py
@@ -794,7 +794,7 @@ class Reader(ImageContainer, ABC):
         return PhysicalPixelSizes(None, None, None)
 
     def get_mosaic_tile_position(
-        self, mosaic_tile_index: int, **kwargs: Any
+        self, mosaic_tile_index: int, **kwargs: int
     ) -> Tuple[int, int]:
         """
         Get the absolute position of the top left point for a single mosaic tile.
@@ -803,7 +803,7 @@ class Reader(ImageContainer, ABC):
         ----------
         mosaic_tile_index: int
             The index for the mosaic tile to retrieve position information for.
-        kwargs
+        kwargs: int
             The keywords below allow you to specify the dimensions that you wish
             to match. If you under-specify the constraints you can easily
             end up with a massive image stack.

--- a/aicsimageio/tests/image_container_test_utils.py
+++ b/aicsimageio/tests/image_container_test_utils.py
@@ -132,6 +132,7 @@ def run_image_container_mosaic_checks(
     already_stitched_data = stitched_image_container.data
 
     # Compare
+    assert from_tiles_stitched_data.shape == already_stitched_data.shape
     np.testing.assert_array_equal(from_tiles_stitched_data, already_stitched_data)
 
 

--- a/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
@@ -762,13 +762,13 @@ def test_mosaic_passthrough(
 @pytest.mark.parametrize(
     "filename, " "set_scene, " "num_mosaic_position_expected, " "additional_kwargs, ",
     [
-        ("OverViewScan.czi", "TR1", 10, {}),
+        ("OverViewScan.czi", "TR1", 120, {}),
         ("OverViewScan.czi", "TR1", 1, {"M": 3}),
         pytest.param(
-            "tiled.lif",
-            "TileScan_002",
-            -1,
-            {"M": 3},
+            "OverViewScan.czi",
+            "TR1",
+            -1,  # Shouldn't ever compare against this
+            {"M": 3, "C": 1},
             marks=pytest.mark.xfail(raises=NotImplementedError),
         ),
     ],

--- a/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
@@ -4,7 +4,7 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -757,6 +757,43 @@ def test_mosaic_passthrough(
 
     # Ensure that regardless of stitched or not, we can get tile position
     img.get_mosaic_tile_position(specific_tile_index)
+
+
+@pytest.mark.parametrize(
+    "filename, " "set_scene, " "num_mosaic_position_expected, " "additional_kwargs, ",
+    [
+        ("OverViewScan.czi", "TR1", 10, {}),
+        ("OverViewScan.czi", "TR1", 1, {"M": 3}),
+        pytest.param(
+            "tiled.lif",
+            "TileScan_002",
+            -1,
+            {"M": 3},
+            marks=pytest.mark.xfail(raises=NotImplementedError),
+        ),
+    ],
+)
+def test_multi_tile_position_retrieval(
+    filename: str,
+    set_scene: str,
+    num_mosaic_position_expected: int,
+    additional_kwargs: Dict[str, Any],
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Init
+    img = AICSImage(uri)
+    img.set_scene(set_scene)
+
+    # Assert listed positions is equivalent to individual
+    # position retrievals
+    mosaic_positions = img.get_mosaic_tile_positions(**additional_kwargs)
+    assert len(mosaic_positions) == num_mosaic_position_expected
+    for m_index, mosaic_position in enumerate(mosaic_positions):
+        assert mosaic_position == img.get_mosaic_tile_position(
+            m_index
+        ), f"Bad comparision at m_index {m_index}"
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
@@ -791,9 +791,10 @@ def test_multi_tile_position_retrieval(
     mosaic_positions = img.get_mosaic_tile_positions(**additional_kwargs)
     assert len(mosaic_positions) == num_mosaic_position_expected
     for m_index, mosaic_position in enumerate(mosaic_positions):
+        M = m_index + additional_kwargs.get("M", 0)
         assert mosaic_position == img.get_mosaic_tile_position(
-            m_index
-        ), f"Bad comparision at m_index {m_index}"
+            M
+        ), f"Bad comparison at M={M}"
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_czi_reader.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from _aicspylibczi import PylibCZI_CDimCoordinatesOverspecifiedException
 from aicspylibczi import CziFile
 from fsspec.implementations.local import LocalFileSystem
 from ome_types import OME
@@ -290,7 +291,9 @@ def test_czi_reader_mosaic_stitching(
             (440, 544),
             999,
             None,
-            marks=pytest.mark.xfail(raises=IndexError),
+            marks=pytest.mark.xfail(
+                raises=PylibCZI_CDimCoordinatesOverspecifiedException
+            ),
         ),
         pytest.param(
             "s_1_t_1_c_1_z_1.czi",

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -209,28 +209,28 @@ def test_lif_reader_mosaic_stitching(
             "TileScan_002",
             (512, 512),
             0,
-            (5110, 7154),
+            (0, 0),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             50,
-            (3577, 4599),
+            (2555, 1533),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             3,
-            (5110, 5621),
+            (1533, 0),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             164,
-            (0, 0),
+            (7154, 5110),
         ),
         pytest.param(
             "tiled.lif",
@@ -288,11 +288,14 @@ def test_lif_reader_mosaic_tile_inspection(
         tile_x_pos : (tile_x_pos + reader.mosaic_tile_dims.X),
     ].compute()
 
+    # (sanity-check) Make sure they are the same shape before shaving pixels
+    assert tile_from_position.shape == tile_from_m_index.shape
+
     # Remove the first Y and X pixels
     # The stitched tiles overlap each other by 1px each so this is just
     # ignoring what would be overlap / cleaned up
-    tile_from_m_index = tile_from_m_index[:, :, :, 1:, 1:]
-    tile_from_position = tile_from_position[:, :, :, 1:, 1:]
+    tile_from_m_index = tile_from_m_index[:, :, :, :-1, :-1]
+    tile_from_position = tile_from_position[:, :, :, :-1, :-1]
 
     # Assert equal
     np.testing.assert_array_equal(tile_from_m_index, tile_from_position)
@@ -309,8 +312,8 @@ def test_lif_reader_mosaic_tile_inspection(
             "tiled.lif",
             np.arange(0, 102.71391311154599, 0.20061311154598827),
             np.arange(0, 102.71391311154599, 0.20061311154598827),
-            np.arange(0, 1127.846913111546, 0.20061311154598827),
             np.arange(0, 1537.900113111546, 0.20061311154598827),
+            np.arange(0, 1127.846913111546, 0.20061311154598827),
         ),
     ],
 )
@@ -374,7 +377,7 @@ def test_lif_reader_mosaic_coords(
             "tiled.lif",
             "TileScan_002",
             ("TileScan_002",),
-            (1, 4, 1, 5622, 7666),
+            (1, 4, 1, 7666, 5622),
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray", "Red", "Green", "Cyan"],
@@ -470,7 +473,7 @@ def test_roundtrip_save_all_scenes(
             "tiled.lif",
             True,
             "TileScan_002",
-            (1, 4, 1, 5622, 7666),
+            (1, 4, 1, 7666, 5622),
             (512, 512),
             0,
         ),

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -529,8 +529,8 @@ def test_mosaic_passthrough(
         pytest.param(
             "tiled.lif",
             "TileScan_002",
-            -1,
-            {"M": 3},
+            -1,  # Shouldn't ever compare against this
+            {"M": 3, "C": 1},
             marks=pytest.mark.xfail(raises=NotImplementedError),
         ),
     ],

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -553,9 +553,10 @@ def test_multi_tile_position_retrieval(
     mosaic_positions = img.get_mosaic_tile_positions(**additional_kwargs)
     assert len(mosaic_positions) == num_mosaic_position_expected
     for m_index, mosaic_position in enumerate(mosaic_positions):
+        M = m_index + additional_kwargs.get("M", 0)
         assert mosaic_position == img.get_mosaic_tile_position(
-            m_index
-        ), f"Bad comparision at m_index {m_index}"
+            M
+        ), f"Bad comparison at M={M}"
 
 
 @pytest.mark.parametrize(

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -131,7 +131,7 @@ def test_sanity_check_correct_indexing(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri, chunk_dims=chunk_dims)
+    reader = LifReader(uri, chunk_dims=chunk_dims, is_x_and_y_swapped=True)
     lif_img = LifFile(uri).get_image(0)
 
     # Pull a chunk from LifReader
@@ -185,7 +185,7 @@ def test_lif_reader_mosaic_stitching(
     stitched_uri = get_resource_full_path(stitched_filename, LOCAL)
 
     # Construct reader
-    tiles_reader = LifReader(tiles_uri)
+    tiles_reader = LifReader(tiles_uri, is_x_and_y_swapped=True)
     stitched_reader = LifReader(stitched_uri)
 
     # Run checks
@@ -262,7 +262,7 @@ def test_lif_reader_mosaic_tile_inspection(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri)
+    reader = LifReader(uri, is_x_and_y_swapped=True)
     reader.set_scene(set_scene)
 
     # Check basics
@@ -328,7 +328,7 @@ def test_lif_reader_mosaic_coords(
     uri = get_resource_full_path(filename, LOCAL)
 
     # Construct reader
-    reader = LifReader(uri)
+    reader = LifReader(uri, is_x_and_y_swapped=True)
 
     # Check tile y and x min max
     np.testing.assert_array_equal(

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -524,7 +524,7 @@ def test_mosaic_passthrough(
 @pytest.mark.parametrize(
     "filename, " "set_scene, " "num_mosaic_position_expected, " "additional_kwargs, ",
     [
-        ("tiled.lif", "TileScan_002", 10, {}),
+        ("tiled.lif", "TileScan_002", 165, {}),
         ("tiled.lif", "TileScan_002", 1, {"M": 3}),
         pytest.param(
             "tiled.lif",

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -522,6 +522,43 @@ def test_mosaic_passthrough(
 
 
 @pytest.mark.parametrize(
+    "filename, " "set_scene, " "num_mosaic_position_expected, " "additional_kwargs, ",
+    [
+        ("tiled.lif", "TileScan_002", 10, {}),
+        ("tiled.lif", "TileScan_002", 1, {"M": 3}),
+        pytest.param(
+            "tiled.lif",
+            "TileScan_002",
+            -1,
+            {"M": 3},
+            marks=pytest.mark.xfail(raises=NotImplementedError),
+        ),
+    ],
+)
+def test_multi_tile_position_retrieval(
+    filename: str,
+    set_scene: str,
+    num_mosaic_position_expected: int,
+    additional_kwargs: Dict[str, Any],
+) -> None:
+    # Construct full filepath
+    uri = get_resource_full_path(filename, LOCAL)
+
+    # Init
+    img = AICSImage(uri)
+    img.set_scene(set_scene)
+
+    # Assert listed positions is equivalent to individual
+    # position retrievals
+    mosaic_positions = img.get_mosaic_tile_positions(**additional_kwargs)
+    assert len(mosaic_positions) == num_mosaic_position_expected
+    for m_index, mosaic_position in enumerate(mosaic_positions):
+        assert mosaic_position == img.get_mosaic_tile_position(
+            m_index
+        ), f"Bad comparision at m_index {m_index}"
+
+
+@pytest.mark.parametrize(
     "filename, set_scene, get_dims, get_specific_dims, expected_shape",
     [
         (

--- a/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_lif_reader.py
@@ -209,28 +209,28 @@ def test_lif_reader_mosaic_stitching(
             "TileScan_002",
             (512, 512),
             0,
-            (0, 0),
+            (5110, 7154),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             50,
-            (2555, 1533),
+            (3577, 4599),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             3,
-            (1533, 0),
+            (5110, 5621),
         ),
         (
             "tiled.lif",
             "TileScan_002",
             (512, 512),
             164,
-            (7154, 5110),
+            (0, 0),
         ),
         pytest.param(
             "tiled.lif",
@@ -294,8 +294,8 @@ def test_lif_reader_mosaic_tile_inspection(
     # Remove the first Y and X pixels
     # The stitched tiles overlap each other by 1px each so this is just
     # ignoring what would be overlap / cleaned up
-    tile_from_m_index = tile_from_m_index[:, :, :, :-1, :-1]
-    tile_from_position = tile_from_position[:, :, :, :-1, :-1]
+    tile_from_m_index = tile_from_m_index[:, :, :, 1:, 1:]
+    tile_from_position = tile_from_position[:, :, :, 1:, 1:]
 
     # Assert equal
     np.testing.assert_array_equal(tile_from_m_index, tile_from_position)
@@ -312,8 +312,8 @@ def test_lif_reader_mosaic_tile_inspection(
             "tiled.lif",
             np.arange(0, 102.71391311154599, 0.20061311154598827),
             np.arange(0, 102.71391311154599, 0.20061311154598827),
-            np.arange(0, 1537.900113111546, 0.20061311154598827),
             np.arange(0, 1127.846913111546, 0.20061311154598827),
+            np.arange(0, 1537.900113111546, 0.20061311154598827),
         ),
     ],
 )
@@ -377,7 +377,7 @@ def test_lif_reader_mosaic_coords(
             "tiled.lif",
             "TileScan_002",
             ("TileScan_002",),
-            (1, 4, 1, 7666, 5622),
+            (1, 4, 1, 5622, 7666),
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Gray", "Red", "Green", "Cyan"],
@@ -473,7 +473,7 @@ def test_roundtrip_save_all_scenes(
             "tiled.lif",
             True,
             "TileScan_002",
-            (1, 4, 1, 7666, 5622),
+            (1, 4, 1, 5622, 7666),
             (512, 512),
             0,
         ),


### PR DESCRIPTION
## Description
This is intended to resolve #482.

Currently retrieving mosaic positions for tiled CZIs is very slow for large images. This has caused users of this package to resort to using the underlying CZI reader `aicspylibczi` because using it directly ([like seen here](https://github.com/aics-int/nuc-morph-analysis/pull/88)) is faster. It appeared that this is because this package was reading in all mosaic positions and then indexing into that list to get the specific mosaic position requested which isn't necessary thanks to a more specific function in `aicspylibczi` luckily. Unluckily that wasn't enough to get performance to a suitable place since for large images requesting `M=24`, for example, without specifying a channel or timepoint (when present) seems to still cause a significant portion of the file to be read. To get around this I took a note from the previously linked workaround and by default have the channel and timepoint dimensions specified as `0` when present on the file and added the ability to override the T, C, & Z dimensions.

While here I added a function for retrieving all mosaic positions (filterable by T, C, Z, & M dimensions) too since it seems like that should help round out these kinds of use cases like seen in #460 and hopefully aid in avoiding forced usage of `aicspylibczi`.

## Testing
Tested locally with file mentioned in issue (sub-second mosaic position retrieval now!) and via unit tests including new unit tests for the new `get_mosaic_positions()`
