### PR TITLE
Adjusting tiffile versioning

### DIFF
--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -79,6 +79,8 @@ class OmeTiffReader(TiffReader):
             with fs.open(path) as open_resource:
                 with TiffFile(open_resource) as tiff:
                     # Get first page description (aka the description tag in general)
+                    # after Tifffile version 2023.3.15 mmstack images read all scenes
+                    # into tiff.pages[0]
                     xml = tiff.pages[0].description
                     ome = OmeTiffReader._get_ome(xml, clean_metadata)
 

--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -77,7 +77,7 @@ class OmeTiffReader(TiffReader):
     ) -> bool:
         try:
             with fs.open(path) as open_resource:
-                with TiffFile(open_resource, is_mmstack=False) as tiff:
+                with TiffFile(open_resource) as tiff:
                     # Get first page description (aka the description tag in general)
                     xml = tiff.pages[0].description
                     ome = OmeTiffReader._get_ome(xml, clean_metadata)

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -117,7 +117,7 @@ class TiffGlobReader(Reader):
     ) -> bool:
         try:
             with fs.open(path) as open_resource:
-                with TiffFile(open_resource):
+                with TiffFile(open_resource, is_mmstack=False):
                     return True
 
         except (TiffFileError, TypeError):
@@ -256,7 +256,7 @@ class TiffGlobReader(Reader):
 
         if single_file_shape is None:
             with self._fs.open(self._path) as open_resource:
-                with TiffFile(open_resource) as tiff:
+                with TiffFile(open_resource, is_mmstack=False) as tiff:
                     self._single_file_shape = tiff.series[0].shape
 
         else:
@@ -299,7 +299,9 @@ class TiffGlobReader(Reader):
         scene_files = scene_files.drop(self.scene_glob_character, axis=1)
         scene_nunique = scene_files.nunique()
 
-        tiff_tags = self._get_tiff_tags(TiffFile(scene_files.filename.iloc[0]))
+        tiff_tags = self._get_tiff_tags(
+            TiffFile(scene_files.filename.iloc[0], is_mmstack=False)
+        )
 
         group_dims = [
             x for x in scene_files.columns if x not in ["filename", *self.chunk_dims]
@@ -364,7 +366,9 @@ class TiffGlobReader(Reader):
             dims = list(expanded_blocks_sizes.keys())
 
         else:  # assemble array in a single chunk
-            zarr_im = imread(scene_files.filename.tolist(), aszarr=True, level=0)
+            zarr_im = imread(
+                scene_files.filename.tolist(), aszarr=True, level=0, is_mmstack=False
+            )
             darr = da.from_zarr(zarr_im).rechunk(-1)
             darr = darr.reshape(reshape_sizes)
             darr = darr.transpose(axes_order)
@@ -403,7 +407,9 @@ class TiffGlobReader(Reader):
         scene_files = scene_files.drop(self.scene_glob_character, axis=1)
         scene_nunique = scene_files.nunique()
 
-        tiff_tags = self._get_tiff_tags(TiffFile(scene_files.filename.iloc[0]))
+        tiff_tags = self._get_tiff_tags(
+            TiffFile(scene_files.filename.iloc[0], is_mmstack=False)
+        )
 
         chunk_sizes = self._get_chunk_sizes(scene_nunique)
 

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -64,7 +64,7 @@ class TiffReader(Reader):
     def _is_supported_image(fs: AbstractFileSystem, path: str, **kwargs: Any) -> bool:
         try:
             with fs.open(path) as open_resource:
-                with TiffFile(open_resource, is_mmstack=False):
+                with TiffFile(open_resource):
                     return True
 
         except (TiffFileError, TypeError):

--- a/aicsimageio/tests/readers/extra_readers/test_ome_tiled_tiff_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_ome_tiled_tiff_reader.py
@@ -215,20 +215,8 @@ def test_ome_tiff_reader_large_files(
     "filename, expected_reader",
     [
         (
-            "s_1_t_1_c_1_z_1.tiff",
-            readers.TiffReader,
-        ),
-        (
-            "s_1_t_1_c_1_z_1.ome.tiff",
-            readers.OmeTiffReader,
-        ),
-        (
             "s_1_t_1_c_1_z_1_ome_tiff_tiles.ome.tif",
             readers.OmeTiledTiffReader,
-        ),
-        (  # Multiscene tiff
-            "variable_scene_shape_first_scene_pyramid.ome.tiff",
-            readers.OmeTiffReader,
         ),
     ],
 )

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -287,13 +287,13 @@ def test_micromanager_ome_tiff_binary_file() -> None:
         ImageContainer=TiffReader,
         image=uri,
         set_scene="Image:0",
-        expected_scenes=("Image:0",),
+        expected_scenes=("Image:0", "Image:1"),
         expected_current_scene="Image:0",
-        expected_shape=(50, 5, 3, 256, 256),
+        expected_shape=(50, 3, 5, 256, 256),
         expected_dtype=np.dtype(np.uint16),
         # Note this dimension order is correct but is different from OmeTiffReader
         # because we swap the dimensions into "standard" order
-        expected_dims_order="TZCYX",
+        expected_dims_order="TCZYX",
         expected_channel_names=["Channel:0:0", "Channel:0:1", "Channel:0:2"],
         expected_physical_pixel_sizes=(1.75, 0.0002, 0.0002),
         expected_metadata_type=str,

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -287,7 +287,7 @@ def test_micromanager_ome_tiff_binary_file() -> None:
         ImageContainer=TiffReader,
         image=uri,
         set_scene="Image:0",
-        expected_scenes=("Image:0", "Image:1"),
+        expected_scenes=("Image:0",),
         expected_current_scene="Image:0",
         expected_shape=(50, 5, 3, 256, 256),
         expected_dtype=np.dtype(np.uint16),

--- a/aicsimageio/tests/readers/test_tiff_reader.py
+++ b/aicsimageio/tests/readers/test_tiff_reader.py
@@ -289,11 +289,11 @@ def test_micromanager_ome_tiff_binary_file() -> None:
         set_scene="Image:0",
         expected_scenes=("Image:0", "Image:1"),
         expected_current_scene="Image:0",
-        expected_shape=(50, 3, 5, 256, 256),
+        expected_shape=(50, 5, 3, 256, 256),
         expected_dtype=np.dtype(np.uint16),
         # Note this dimension order is correct but is different from OmeTiffReader
         # because we swap the dimensions into "standard" order
-        expected_dims_order="TCZYX",
+        expected_dims_order="TZCYX",
         expected_channel_names=["Channel:0:0", "Channel:0:1", "Channel:0:2"],
         expected_physical_pixel_sizes=(1.75, 0.0002, 0.0002),
         expected_metadata_type=str,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ format_libs: Dict[str, List[str]] = {
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],
-    "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
+    "bfio": ["bfio>=2.3.0", "tifffile>=2023.3.15"],
     # "czi": [  # excluded for licensing reasons
     #     "fsspec>=2022.8.0",
     #     "aicspylibczi>=3.1.1",
@@ -108,7 +108,7 @@ requirements = [
     "ome-zarr>=0.6.1",
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
-    "tifffile>=2021.8.30",
+    "tifffile>=2023.3.15",
     "xarray>=0.16.1,<2023.02.0",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ format_libs: Dict[str, List[str]] = {
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],
-    "bfio": ["bfio>=2.3.0", "tifffile>=2023.3.15"],
+    "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
     # "czi": [  # excluded for licensing reasons
     #     "fsspec>=2022.8.0",
     #     "aicspylibczi>=3.1.1",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ format_libs: Dict[str, List[str]] = {
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],
-    "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
+    "bfio": ["bfio>=2.3.0"],
     # "czi": [  # excluded for licensing reasons
     #     "fsspec>=2022.8.0",
     #     "aicspylibczi>=3.1.1",
@@ -108,7 +108,7 @@ requirements = [
     "ome-zarr>=0.6.1",
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
-    "tifffile>=2021.8.30,<2023.3.15",
+    "tifffile>=2021.8.30",
     "xarray>=0.16.1,<2023.02.0",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open("README.md") as readme_file:
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
         "imageio[ffmpeg]>=2.11.0",
-        "Pillow>=9.3",
+        "Pillow>=8.2.0,!=8.3.0,<9.0.0",
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ requirements = [
     "ome-zarr>=0.6.1",
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
-    "tifffile>=2023.3.15",
+    "tifffile>=2021.8.30",
     "xarray>=0.16.1,<2023.02.0",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ with open("README.md") as readme_file:
 # "READER_TO_INSTALL" lookup table from aicsimageio/formats.py.
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
-        "imageio[ffmpeg]>=2.11.0",
-        "Pillow>=9.3.0,<9.5.0",
+        "imageio[ffmpeg]>=2.11.0,<2.28.0",
+        "Pillow>=9.3.0",
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open("README.md") as readme_file:
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
         "imageio[ffmpeg]>=2.11.0",
-        "Pillow>=8.2.0,!=8.3.0,<9.0.0",
+        "Pillow>=9.3.0,<9.5.0",
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ format_libs: Dict[str, List[str]] = {
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],
     "dv": ["mrc>=0.2.0"],
-    "bfio": ["bfio>=2.3.0"],
+    "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
     # "czi": [  # excluded for licensing reasons
     #     "fsspec>=2022.8.0",
     #     "aicspylibczi>=3.1.1",


### PR DESCRIPTION
Tifffile 2023.3.15 is released;

2023.3.15

- Fix corruption using tile generators with prediction/compression.
- Add parser for Micro-Manager MMStack series (breaking).
- Return micromanager_metadata IndexMap as numpy array (breaking).
- Revert optimizations for Micro-Manager OME series.
- Do not use numcodecs zstd in write_fsspec (kerchunk issue 317).

More type annotations.


“For mmstack images”

TiffFile Before:

- Individual scenes were accessed through tifffile.series[scene_index]
- Scene dims  = “TCZYX” or “TZCYX” depending on reader.

TiffFile After:

- Individual scenes are stored in dims. “TRCZYX” or “TRZCYX”.
- Tifffile.series[scene_index] does not return single scene anymore.
- Image data is stored at tiffile.series[0].


This change results in our _read_delayed and _read_immediate functions in ome_tiff_reader and tiff_reader being unable to read single scenes.



Discussed Possible solutions:

1. Creating a psudo-scene object to wrap the scene object and function as normally. Reshaping the internal data when reading initially.
2. Adding “if mmstack” to each reference of the images traits to reassign dims/shape metadata.
3. Reshaping data after the object has been created 