### PR TITLE
Admin/drop 3.8 support for newest xarray

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10']
         os: [
           ubuntu-20.04,
           windows-latest,
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10']
         os: [
           ubuntu-20.04,
           windows-latest,

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10']
         os: [
           ubuntu-20.04,
           windows-latest,
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10']
         os: [
           ubuntu-20.04,
           windows-latest,

--- a/.github/workflows/test-upstreams.yml
+++ b/.github/workflows/test-upstreams.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.9, '3.10']
         os: [
           ubuntu-20.04,
           windows-latest,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
                     --count,
                     --show-source,
                     --statistics,
-                    --min-python-version=3.8.0,
+                    --min-python-version=3.9.0,
                 ]
     - repo: https://github.com/myint/autoflake
       rev: v1.4

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ setup(
         "Intended Audience :: Education",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
@@ -161,7 +160,7 @@ setup(
             "*.benchmarks.*",
         ]
     ),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     setup_requires=setup_requirements,
     test_suite="aicsimageio/tests",
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ requirements = [
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
     "tifffile>=2021.8.30,<2023.3.15",
-    "xarray>=0.16.1,<2023.02.0",
+    "xarray>=0.16.1",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",
 ]


### PR DESCRIPTION
## Description
A main dependency of this package, `xarray`, [dropped support for Python 3.8](https://github.com/pydata/xarray/releases) in version `2023.02.0`. This has caused our upstream tests to fail ([see here](https://github.com/AllenCellModeling/aicsimageio/actions/runs/4504290698/jobs/7928581490)). Per the conversation in #475 I removed support for Python 3.8 in favor of supporting the newest `xarray` version.

A version of `aicsimageio` (4.10.0) has been released announcing end of its support for Python 3.8

#### Testing
Clean installed locally, unit tested locally
