### PR TITLE
Admin: Update deploy process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,5 @@ docs: ## generate Sphinx HTML documentation, including API docs, and serve to br
 	make gen-docs
 	$(BROWSER) docs/_build/html/index.html
 
-prepare-release: ## Generate new section of changelog & bump version
-	gitchangelog
-	git add docs/CHANGELOG.rst
-	git commit -m "Update changelog"
-	bumpversion $(VERSION_CHANGE)
-
-prepare-release-dry-run:
-	bumpversion $(VERSION_CHANGE) --dry-run --verbose
-
 update-from-cookiecutter: ## update this repo using latest cookiecutter-pypackage
 	cookiecutter gh:AllenCellModeling/cookiecutter-pypackage --config-file cookiecutter.yaml --no-input --overwrite-if-exists --output-dir ..

--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,14 @@ docs: ## generate Sphinx HTML documentation, including API docs, and serve to br
 	make gen-docs
 	$(BROWSER) docs/_build/html/index.html
 
-prepare-release: ## Checkout main, generate new section of changelog
-	bumpversion patch
+prepare-release: ## Generate new section of changelog & bump version
 	gitchangelog
 	git add docs/CHANGELOG.rst
 	git commit -m "Update changelog"
-	git reset --soft HEAD~1
-	git commit --amend  # This and the line above squash the "Update changelog" and bumpversion commits together
+	bumpversion $(VERSION_CHANGE)
+
+prepare-release-dry-run:
+	bumpversion $(VERSION_CHANGE) --dry-run --verbose
 
 update-from-cookiecutter: ## update this repo using latest cookiecutter-pypackage
 	cookiecutter gh:AllenCellModeling/cookiecutter-pypackage --config-file cookiecutter.yaml --no-input --overwrite-if-exists --output-dir ..

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -208,8 +208,18 @@ For more information on `asv` and full commands please see
 ## Deploying
 
 A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed.
+Make sure all your changes are committed and merged into main.
 Then run:
+
+```bash
+git checkout main
+git stash
+git pull
+export VERSION_CHANGE=? # NOTE: Specify either major, minor, or patch
+make prepare-release-dry-run
+```
+
+Check results of dry run, verify that it seems correct then run
 
 ```bash
 make prepare-release
@@ -218,6 +228,3 @@ git push --tags
 ```
 
 After all builds pass, GitHub Actions will automatically publish to PyPI.
-
-**Note:** `make prepare-release` by default only bumps the patch number and
-not a minor or major version.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -208,23 +208,29 @@ For more information on `asv` and full commands please see
 ## Deploying
 
 A reminder for the maintainers on how to deploy.
-Make sure all your changes are committed and merged into main.
-Then run:
+1) Make sure all your changes are committed and merged into main.
+2) Run:
+    ```bash
+    git checkout main
+    git stash
+    git pull
+    export VERSION_CHANGE=? # NOTE: Specify either major, minor, or patch
+    bumpversion ${VERSION_CHANGE} --dry-run --verbose
+    ```
+3) Check results of dry run, verify that it seems correct
+4) Run:
+    ```bash
+    bumpversion ${VERSION_CHANGE}
+    git push
+    git push --tags
+    ```
+5) Wait for a [GitHub Action](https://github.com/AllenCellModeling/aicsimageio/actions) to automatically publish to [PyPI](https://pypi.org/project/aicsimageio/)
+6) [Create GitHub release](https://github.com/AllenCellModeling/aicsimageio/releases/new) for the corresponding version created.
 
-```bash
-git checkout main
-git stash
-git pull
-export VERSION_CHANGE=? # NOTE: Specify either major, minor, or patch
-make prepare-release-dry-run
-```
+    6a) Select tag for version created
 
-Check results of dry run, verify that it seems correct then run
+    6b) Ensure GitHub automatically generates releases notes ([click "Generate Release Notes"](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes))
 
-```bash
-make prepare-release
-git push
-git push --tags
-```
+    6c) Double check format is similar to previous releases
 
-After all builds pass, GitHub Actions will automatically publish to PyPI.
+    6d) Publish release


### PR DESCRIPTION
## Description
The tags created from the deploy process were separated from main as seen in the below screenshots (provided by Dan) where orange is `main`. This updates the deploy process to try to avoid an orphaned tag seemingly happening due to the `git commit --amend` step as well as some little QoL updates.

![aicsimageio 2023-05-09 10-28-02](https://github.com/AllenCellModeling/aicsimageio/assets/41307451/586bec7f-1c5d-4391-b136-ac9a6cffc5f4)
![aicsimageio 2023-05-09 10-27-33](https://github.com/AllenCellModeling/aicsimageio/assets/41307451/06340452-b776-452e-bb86-14c68946b823)
![aicsimageio 2023-05-09 10-27-50](https://github.com/AllenCellModeling/aicsimageio/assets/41307451/be235e01-03dd-4d89-84e5-8f2916cae074)

Unsure exactly how to test without triggering the GitHub deploy workflow, welcome to any ideas!
