### PR TITLE
Ignore missing Position dimension

### DIFF
--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -84,7 +84,7 @@ class ND2Reader(Reader):
                 xarr.attrs[constants.METADATA_UNPROCESSED][
                     "frame"
                 ] = rdr.frame_metadata(self.current_scene_index)
-        return xarr.isel({nd2.AXIS.POSITION: 0})
+        return xarr.isel({nd2.AXIS.POSITION: 0}, missing_dims="ignore")
 
     @property
     def physical_pixel_sizes(self) -> types.PhysicalPixelSizes:

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ format_libs: Dict[str, List[str]] = {
         "imageio[ffmpeg]>=2.11.0,<2.28.0",
         "Pillow>=9.3.0",
     ],
-    "nd2": ["nd2[legacy]>=0.2.0"],
+    "nd2": ["nd2[legacy]>=0.6.0"],
     "dv": ["mrc>=0.2.0"],
     "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
     # "czi": [  # excluded for licensing reasons


### PR DESCRIPTION
## Description
This is a partner PR to [this PR in the `nd2` library](https://github.com/tlambert03/nd2/pull/131) from the discussion in #488 where a new/different Nikon format was causing an issue since there was an expected piece of metadata missing. That piece of metadata seemed irrelevant to the reading of the file and after that PR will no longer cause an issue however, it either has the side-effect of causing the `Position (P)` dimension to be ignored or it is also missing from this Nikon format. Either way, this PR is intended to expect that dimension to be optional (since we drop it on the line I am changing anyway). What should happen now is if `P` is there it will be dropped, if not, the data will be unchanged and the missing `P` dimension will be ignored.
