### PR TITLE
Upgrade imageio to prevent bug with Pillow in 2.28.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md") as readme_file:
 # "READER_TO_INSTALL" lookup table from aicsimageio/formats.py.
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
-        "imageio[ffmpeg]>=2.11.0,<2.28.0",
+        "imageio[ffmpeg]>=2.28.1",
         "Pillow>=9.3.0",
     ],
     "nd2": ["nd2[legacy]>=0.2.0"],


### PR DESCRIPTION
## Description
`imageio` introduced a bug with `Pillow` in `2.28.0` where it was accessing an optional attribute `n_frames`, this has been fixed in `2.28.1` so I am adjusting the dependency requirements
