### PR TITLE
LIF image data ordering

### DIFF
--- a/aicsimageio/readers/lif_reader.py
+++ b/aicsimageio/readers/lif_reader.py
@@ -254,7 +254,7 @@ class LifReader(Reader):
             # Stack and reshape to get rid of the array of arrays
             scene_dims = selected_scene.info["dims"]
             retrieved_chunk = np.stack(planes).reshape(
-                np_array_for_indices.shape + (scene_dims.y, scene_dims.x)
+                np_array_for_indices.shape + (scene_dims.y, scene_dims.x), order="F"
             )
 
             # Remove extra dimensions if they were not requested


### PR DESCRIPTION
## Description
Intended to resolve #508 where it appeared the channels and timepoints were being swapped around. I was able to reproduce this and it seems the default C-like ordering of the images.

## Testing
Let me know if you have some good unit test ideas, I think we'd need a new LIF file to test this appropriately (we can use the one from the discussion, but it would largely be testing nothing). I tested it locally by reading in various LIFs and comparing it against FIJI with different ordering styles.
