### PR TITLE
Fix publish task according to pypi rec for 2fa accounts

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -124,6 +124,10 @@ jobs:
     if: "contains(github.event.head_commit.message, 'Bump version')"
     needs: [test-core-lib, test-readers, lint]
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
       - uses: actions/checkout@v2
@@ -141,7 +145,4 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: aicspypi
-          password: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description
[My recent publish attempt failed](https://github.com/AllenCellModeling/aicsimageio/actions/runs/5755458578/job/15603378961) due to 2 factor auth being enforced by pypi for 2 factor auth accounts now. [According to pypi](https://docs.pypi.org/trusted-publishers/using-a-publisher/) if I am understanding correctly, this should let GitHub ask pypi for an API token and authorize itself once our account in pypi is setup to allow that which infra-eng is taking care of.
