### PR TITLE
Revert to pre-2023.3.15 tifffile to avoid mm_stack issue

### DIFF
--- a/aicsimageio/readers/ome_tiff_reader.py
+++ b/aicsimageio/readers/ome_tiff_reader.py
@@ -185,7 +185,7 @@ class OmeTiffReader(TiffReader):
 
         # Get ome-types object and warn of other behaviors
         with self._fs.open(self._path) as open_resource:
-            with TiffFile(open_resource, is_mmstack=False) as tiff:
+            with TiffFile(open_resource) as tiff:
                 # Get and store OME
                 self._ome = self._get_ome(
                     tiff.pages[0].description, self.clean_metadata
@@ -308,7 +308,7 @@ class OmeTiffReader(TiffReader):
             The file could not be read or is not supported.
         """
         with self._fs.open(self._path) as open_resource:
-            with TiffFile(open_resource, is_mmstack=False) as tiff:
+            with TiffFile(open_resource) as tiff:
                 # Get unprocessed metadata from tags
                 tiff_tags = self._get_tiff_tags(tiff)
 
@@ -353,7 +353,7 @@ class OmeTiffReader(TiffReader):
             The file could not be read or is not supported.
         """
         with self._fs.open(self._path) as open_resource:
-            with TiffFile(open_resource, is_mmstack=False) as tiff:
+            with TiffFile(open_resource) as tiff:
                 # Get unprocessed metadata from tags
                 tiff_tags = self._get_tiff_tags(tiff)
 

--- a/aicsimageio/readers/tiff_glob_reader.py
+++ b/aicsimageio/readers/tiff_glob_reader.py
@@ -117,7 +117,7 @@ class TiffGlobReader(Reader):
     ) -> bool:
         try:
             with fs.open(path) as open_resource:
-                with TiffFile(open_resource, is_mmstack=False):
+                with TiffFile(open_resource):
                     return True
 
         except (TiffFileError, TypeError):
@@ -256,7 +256,7 @@ class TiffGlobReader(Reader):
 
         if single_file_shape is None:
             with self._fs.open(self._path) as open_resource:
-                with TiffFile(open_resource, is_mmstack=False) as tiff:
+                with TiffFile(open_resource) as tiff:
                     self._single_file_shape = tiff.series[0].shape
 
         else:
@@ -299,9 +299,7 @@ class TiffGlobReader(Reader):
         scene_files = scene_files.drop(self.scene_glob_character, axis=1)
         scene_nunique = scene_files.nunique()
 
-        tiff_tags = self._get_tiff_tags(
-            TiffFile(scene_files.filename.iloc[0], is_mmstack=False)
-        )
+        tiff_tags = self._get_tiff_tags(TiffFile(scene_files.filename.iloc[0]))
 
         group_dims = [
             x for x in scene_files.columns if x not in ["filename", *self.chunk_dims]
@@ -366,9 +364,7 @@ class TiffGlobReader(Reader):
             dims = list(expanded_blocks_sizes.keys())
 
         else:  # assemble array in a single chunk
-            zarr_im = imread(
-                scene_files.filename.tolist(), aszarr=True, level=0, is_mmstack=False
-            )
+            zarr_im = imread(scene_files.filename.tolist(), aszarr=True, level=0)
             darr = da.from_zarr(zarr_im).rechunk(-1)
             darr = darr.reshape(reshape_sizes)
             darr = darr.transpose(axes_order)
@@ -407,9 +403,7 @@ class TiffGlobReader(Reader):
         scene_files = scene_files.drop(self.scene_glob_character, axis=1)
         scene_nunique = scene_files.nunique()
 
-        tiff_tags = self._get_tiff_tags(
-            TiffFile(scene_files.filename.iloc[0], is_mmstack=False)
-        )
+        tiff_tags = self._get_tiff_tags(TiffFile(scene_files.filename.iloc[0]))
 
         chunk_sizes = self._get_chunk_sizes(scene_nunique)
 

--- a/aicsimageio/readers/tiff_reader.py
+++ b/aicsimageio/readers/tiff_reader.py
@@ -126,7 +126,7 @@ class TiffReader(Reader):
     def scenes(self) -> Tuple[str, ...]:
         if self._scenes is None:
             with self._fs.open(self._path) as open_resource:
-                with TiffFile(open_resource, is_mmstack=False) as tiff:
+                with TiffFile(open_resource) as tiff:
                     # This is non-metadata tiff, just use available series indices
                     self._scenes = tuple(
                         metadata_utils.generate_ome_image_id(i)
@@ -186,7 +186,6 @@ class TiffReader(Reader):
                 series=scene,
                 level=0,
                 chunkmode="page",
-                is_mmstack=False,
             ) as store:
                 arr = da.from_zarr(store)
                 arr = arr.transpose(transpose_indices)
@@ -456,7 +455,7 @@ class TiffReader(Reader):
             The file could not be read or is not supported.
         """
         with self._fs.open(self._path) as open_resource:
-            with TiffFile(open_resource, is_mmstack=False) as tiff:
+            with TiffFile(open_resource) as tiff:
                 # Get dims from provided or guess
                 dims = self._get_dims_for_scene(tiff)
 
@@ -509,7 +508,7 @@ class TiffReader(Reader):
             The file could not be read or is not supported.
         """
         with self._fs.open(self._path) as open_resource:
-            with TiffFile(open_resource, is_mmstack=False) as tiff:
+            with TiffFile(open_resource) as tiff:
                 # Get dims from provided or guess
                 dims = self._get_dims_for_scene(tiff)
 
@@ -577,7 +576,7 @@ def _get_pixel_size(
 ) -> Tuple[Optional[float], Optional[float], Optional[float]]:
     """Return the pixel size in microns (z,y,x) for the given series in a tiff path."""
 
-    with TiffFile(path_or_file, is_mmstack=False) as tiff:
+    with TiffFile(path_or_file) as tiff:
         tags = tiff.series[series_index].pages[0].tags
 
     if tiff.is_imagej:

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ requirements = [
     "tifffile>=2021.8.30,<2023.3.15",
     "xarray>=0.16.1,<2023.02.0",
     "xmlschema",  # no pin because it's pulled in from OME types
-    "zarr>=2.6,<3",
+    "zarr>=2.6,<2.16.0",
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ requirements = [
     "PyYAML>=6.0",
     "wrapt>=1.12",
     "resource-backed-dask-array>=0.1.0",
-    "tifffile>=2021.8.30",
+    "tifffile>=2021.8.30,<2023.3.15",
     "xarray>=0.16.1,<2023.02.0",
     "xmlschema",  # no pin because it's pulled in from OME types
     "zarr>=2.6,<3",


### PR DESCRIPTION
## Description
Attempt to resolve issue installing `aicsimageio` with conflicting `bfio` dependencies due to changes in > `2023.3.15 tifffile`. This largely just reverts this [PR](https://github.com/AllenCellModeling/aicsimageio/pull/487/files#diff-41e181e394789314fa976c29183e5993b567fd2d7c26d9551cf590dac00a276e)

## Testing
Unit tests
