### PR TITLE
Feature/nd2reader-xarray-ome-metadata

### DIFF
--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -85,6 +85,14 @@ class ND2Reader(Reader):
                 xarr.attrs[constants.METADATA_UNPROCESSED][
                     "frame"
                 ] = rdr.frame_metadata(self.current_scene_index)
+
+            # include OME metadata as attrs of returned xarray.DataArray if possible
+            # (not possible with `nd2` version < 0.7.0; see PR #521)
+            try:
+                xarr.attrs[constants.METADATA_PROCESSED] = self.ome_metadata
+            except NotImplementedError:
+                pass
+        
         return xarr.isel({nd2.AXIS.POSITION: 0}, missing_dims="ignore")
 
     @property

--- a/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
@@ -31,10 +31,12 @@ else:
     "expected_dtype, "
     "expected_dims_order, "
     "expected_channel_names, "
-    "expected_physical_pixel_sizes",
+    "expected_physical_pixel_sizes, "
+    "expected_metadata_type",
     [
         pytest.param(
             "example.txt",
+            None,
             None,
             None,
             None,
@@ -53,6 +55,7 @@ else:
             "TCYX",
             ["20phase", "20xDiO"],
             (1, 50, 50),
+            dict,
         ),
         (
             "ND2_jonas_header_test2.nd2",
@@ -63,6 +66,7 @@ else:
             "CTZYX",
             ["Jonas_DIC"],
             (0.5, 0.12863494437945, 0.12863494437945),
+            OME,
         ),
         (
             "ND2_maxime_BF007.nd2",
@@ -73,6 +77,7 @@ else:
             "CYX",
             ["405/488/561/633nm"],
             (1.0, 0.158389678930686, 0.158389678930686),
+            OME,
         ),
         (
             "ND2_dims_p4z5t3c2y32x32.nd2",
@@ -83,6 +88,7 @@ else:
             "TZCYX",
             ["Widefield Green", "Widefield Red"],
             (1.0, 0.652452890023035, 0.652452890023035),
+            OME,
         ),
         (
             "ND2_dims_c2y32x32.nd2",
@@ -93,6 +99,7 @@ else:
             "CYX",
             ["Widefield Green", "Widefield Red"],
             (1.0, 0.652452890023035, 0.652452890023035),
+            OME,
         ),
         (
             "ND2_dims_p1z5t3c2y32x32.nd2",
@@ -103,6 +110,7 @@ else:
             "TZCYX",
             ["Widefield Green", "Widefield Red"],
             (1.0, 0.652452890023035, 0.652452890023035),
+            OME,
         ),
         (
             "ND2_dims_p2z5t3-2c4y32x32.nd2",
@@ -113,6 +121,7 @@ else:
             "TZCYX",
             ["Widefield Green", "Widefield Red", "Widefield Far-Red", "Brightfield"],
             (1.0, 0.652452890023035, 0.652452890023035),
+            OME,
         ),
         (
             "ND2_dims_t3c2y32x32.nd2",
@@ -123,6 +132,7 @@ else:
             "TCYX",
             ["Widefield Green", "Widefield Red"],
             (1.0, 0.652452890023035, 0.652452890023035),
+            OME,
         ),
         (
             "ND2_dims_rgb_t3p2c2z3x64y64.nd2",
@@ -133,6 +143,7 @@ else:
             "TZCYXS",
             ["Brightfield", "Brightfield"],
             (0.01, 0.34285714285714286, 0.34285714285714286),
+            OME,
         ),
         (
             "ND2_dims_rgb.nd2",
@@ -143,6 +154,7 @@ else:
             "CYXS",
             ["Brightfield"],
             (1.0, 0.34285714285714286, 0.34285714285714286),
+            OME,
         ),
     ],
 )
@@ -156,6 +168,7 @@ def test_nd2_reader(
     expected_dims_order: str,
     expected_channel_names: List[str],
     expected_physical_pixel_sizes: Tuple[float, float, float],
+    expected_metadata_type: Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]],
 ) -> None:
     # Construct full filepath
     uri = get_resource_full_path(filename, host)
@@ -172,7 +185,7 @@ def test_nd2_reader(
         expected_dims_order=expected_dims_order,
         expected_channel_names=expected_channel_names,
         expected_physical_pixel_sizes=expected_physical_pixel_sizes,
-        expected_metadata_type=dict,
+        expected_metadata_type=expected_metadata_type,
     )
 
 
@@ -196,7 +209,7 @@ def test_nd2_reader(
             dimensions.DEFAULT_DIMENSION_ORDER,
             ["Jonas_DIC"],
             (0.5, 0.12863494437945, 0.12863494437945),
-            dict,
+            OME,
         ),
     ],
 )


### PR DESCRIPTION
## Description

Include parsed metadata (OME) as attrs of returned xarray DataArray when using nd2_reader.

The OME metadata is already accessible from the nd2_reader since 4.12.1 (specifically from PR #521), but is currently not included in the xarray interface. 

It's my first PR and while I tried to dig in to tests for `Reader`, `AICSImage`, and extra readers, I didn't see if this specific feature is covered/should be included. I'm probably also missing a lot of things and will be grateful if anyone would point me some reference and/or just say "read this!".

Also - if an issue/discussion is required before opening a PR, please let me know and I'll change this to a draft.

## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-<number>], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
    - ~~Didn't see where this should be tested or if at all tested for other readers. But it's most likely that I missed something... I'll be happy to include tests if I could get some suggestions/guidance.~~
    - Updated existing tests to reflect changes in nd2 reader's metadata attribute. Now expecting OME (originally dict) if supported.
- [x] Provide or update documentation for any feature added by your pull request.
    - This probably is not needed for this PR, but please let me know if I'm wrong.