### PR TITLE
Limit fsspec version for now due to glob bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,9 @@ benchmark_requirements = [
 
 requirements = [
     "dask[array]>=2021.4.1,<=2023.5.0",
-    "fsspec>=2022.8.0",
+    # fssspec restricted due to glob issue tracked here, when fixed remove ceiling
+    # https://github.com/fsspec/filesystem_spec/issues/1380
+    "fsspec>=2022.8.0,<2023.9.0",
     "imagecodecs>=2020.5.30",
     "lxml>=4.6,<5",
     "numpy>=1.16,<=1.24.0",


### PR DESCRIPTION
## Description
The SLDY reader uses the `glob()` function of `fsspec` which seems to be buggy after version `2023.9.0`, limiting the version until a resolution to [this issue](https://github.com/fsspec/filesystem_spec/issues/1380) is reached
