### PR TITLE
Adjust bfio & fsspec versions to avoid bugs

### DIFF
--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -92,7 +92,7 @@ class ND2Reader(Reader):
                 xarr.attrs[constants.METADATA_PROCESSED] = self.ome_metadata
             except NotImplementedError:
                 pass
-        
+
         return xarr.isel({nd2.AXIS.POSITION: 0}, missing_dims="ignore")
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ format_libs: Dict[str, List[str]] = {
     ],
     "nd2": ["nd2[legacy]>=0.6.0"],
     "dv": ["mrc>=0.2.0"],
-    "bfio": ["bfio>=2.3.0", "tifffile<2022.4.22"],
+    "bfio": ["bfio==2.3.0", "tifffile<2022.4.22"],
     # "czi": [  # excluded for licensing reasons
     #     "fsspec>=2022.8.0",
     #     "aicspylibczi>=3.1.1",

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,9 @@ benchmark_requirements = [
 
 requirements = [
     "dask[array]>=2021.4.1,<=2023.5.0",
-    "fsspec>=2022.8.0",
+    # fssspec restricted due to glob issue tracked here, when fixed remove ceiling
+    # https://github.com/fsspec/filesystem_spec/issues/1380
+    "fsspec>=2022.8.0,<2023.9.0",
     "imagecodecs>=2020.5.30",
     "lxml>=4.6,<5",
     "numpy>=1.16,<=1.24.0",


### PR DESCRIPTION
## Description
This fixes 2 bugs and a lint issue

### fsspec bugfix
The SLDY reader uses the `glob()` function of `fsspec` which seems to be buggy after version `2023.9.0`, limiting the version until a resolution to the corresponding fsspec issue is reached

### bfio bugfix
`bfio` versions 2.3.1 & 2.3.2 (AKA every version > 2.3.0) seem to leave a file open when it seems they used to automatically close. I didn't catch a change to the API/contract in` bfio` that suggest that this should happen and to manually close it. Hoping that this will be removed in 2.4.0 hence the weird version selection.
