### PR TITLE
Remove ceiling on Pillow; adjust default reader expectations

### DIFF
--- a/aicsimageio/tests/readers/extra_readers/test_default_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_default_reader.py
@@ -18,10 +18,9 @@ from ...image_container_test_utils import run_image_file_checks
 @pytest.mark.parametrize(
     "filename, set_scene, expected_shape, expected_dims_order",
     [
-        ("example.bmp", "Image:0", (480, 640, 4), "YXS"),
         ("example.png", "Image:0", (800, 537, 4), "YXS"),
         ("example.jpg", "Image:0", (452, 400, 3), "YXS"),
-        ("example.gif", "Image:0", (72, 268, 268, 4), "TYXS"),
+        ("example.gif", "Image:0", (72, 268, 268, 3), "TYXS"),
         (
             "example_invalid_frame_count.mp4",
             "Image:0",
@@ -108,7 +107,7 @@ def test_ffmpeg_header_fail() -> None:
             "example.gif",
             "Image:0",
             ("Image:0",),
-            (72, 1, 1, 268, 268, 4),
+            (72, 1, 1, 268, 268, 3),
             np.uint8,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0"],
@@ -175,7 +174,7 @@ def test_aicsimage(
             None,
             dimensions.DEFAULT_DIMENSION_ORDER_WITH_SAMPLES,
             ["Channel:0:0"],
-            (72, 1, 1, 268, 268, 4),
+            (72, 1, 1, 268, 268, 3),
         ),
         # Check just dims to see default channel name creation
         (
@@ -184,18 +183,18 @@ def test_aicsimage(
             "ZYXC",
             None,
             dimensions.DEFAULT_DIMENSION_ORDER,
-            ["Channel:0:0", "Channel:0:1", "Channel:0:2", "Channel:0:3"],
-            (1, 4, 72, 268, 268),
+            ["Channel:0:0", "Channel:0:1", "Channel:0:2"],
+            (1, 3, 72, 268, 268),
         ),
         # Check setting both as simple definitions
         (
             "example.gif",
             "Image:0",
             "ZYXC",
-            ["Red", "Green", "Blue", "Alpha"],
+            ["Red", "Green", "Blue"],
             dimensions.DEFAULT_DIMENSION_ORDER,
-            ["Red", "Green", "Blue", "Alpha"],
-            (1, 4, 72, 268, 268),
+            ["Red", "Green", "Blue"],
+            (1, 3, 72, 268, 268),
         ),
         # Check providing too many dims
         pytest.param(
@@ -213,7 +212,7 @@ def test_aicsimage(
             "example.gif",
             "Image:0",
             "ZYXC",
-            ["A", "B", "C"],
+            ["A", "B", "C", "D"],
             None,
             None,
             None,

--- a/aicsimageio/tests/writers/extra_writers/test_timeseries_writer.py
+++ b/aicsimageio/tests/writers/extra_writers/test_timeseries_writer.py
@@ -17,12 +17,12 @@ from ...conftest import LOCAL, array_constructor, get_resource_write_full_path
 @pytest.mark.parametrize(
     "write_shape, write_dim_order, read_shape, read_dim_order",
     [
-        ((30, 100, 100), None, (30, 100, 100), "TYX"),
+        ((30, 100, 100), None, (30, 100, 100, 3), "TYXS"),
         # Note that files get saved out with RGBA, instead of just RGB
-        ((30, 100, 100, 3), None, (30, 100, 100, 4), "TYXS"),
-        ((100, 30, 100), "XTY", (30, 100, 100), "TYX"),
+        ((30, 100, 100, 3), None, (30, 100, 100, 3), "TYXS"),
+        ((100, 30, 100), "XTY", (30, 100, 100, 3), "TYXS"),
         # Note that files get saved out with RGBA, instead of just RGB
-        ((3, 100, 30, 100), "SYTX", (30, 100, 100, 4), "TYXS"),
+        ((3, 100, 30, 100), "SYTX", (30, 100, 100, 3), "TYXS"),
         pytest.param(
             (1, 1),
             None,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("README.md") as readme_file:
 # "READER_TO_INSTALL" lookup table from aicsimageio/formats.py.
 format_libs: Dict[str, List[str]] = {
     "base-imageio": [
-        "imageio[ffmpeg]>=2.11.0,<2.28.0",
+        "imageio[ffmpeg]>=2.31.0",
         "Pillow>=9.3.0",
     ],
     "nd2": ["nd2[legacy]>=0.6.0"],


### PR DESCRIPTION
With the release of imageio 2.28.0 on 04/23/2023, main[base-imageio] failed when using imageio's pillow plugin to access images. As a result of this we pinned 2.27.0. In 2.31.0 it seems this issue was resolved, so this adjusts the versions.

**Note** It seems instead of RGBA imageio now returns RGB for gifs? Unsure if we want to do some more investigation before merging this.