### PR TITLE
support cache file system

### DIFF
--- a/aicsimageio/readers/nd2_reader.py
+++ b/aicsimageio/readers/nd2_reader.py
@@ -2,17 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Tuple
 
-from fsspec.implementations.local import LocalFileSystem
-
+from .reader import Reader
 from .. import constants, exceptions, types
 from ..utils import io_utils
-from .reader import Reader
 
 if TYPE_CHECKING:
     import xarray as xr
     from fsspec.spec import AbstractFileSystem
     from ome_types import OME
-
 
 try:
     import nd2
@@ -52,12 +49,6 @@ class ND2Reader(Reader):
             enforce_exists=True,
             fs_kwargs=fs_kwargs,
         )
-        # Catch non-local file system
-        if not isinstance(self._fs, LocalFileSystem):
-            raise ValueError(
-                f"Cannot read ND2 from non-local file system. "
-                f"Received URI: {self._path}, which points to {type(self._fs)}."
-            )
 
         if not self._is_supported_image(self._fs, self._path):
             raise exceptions.UnsupportedFileFormatError(

--- a/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
+++ b/aicsimageio/tests/readers/extra_readers/test_nd2_reader.py
@@ -10,7 +10,6 @@ from ome_types import OME
 from aicsimageio import AICSImage, dimensions, exceptions
 from aicsimageio.readers.nd2_reader import ND2Reader
 from aicsimageio.tests.image_container_test_utils import run_image_file_checks
-
 from ...conftest import LOCAL, get_resource_full_path, host
 
 nd2 = pytest.importorskip("nd2")
@@ -266,6 +265,16 @@ def test_frame_metadata() -> None:
     filename = "ND2_dims_rgb_t3p2c2z3x64y64.nd2"
     uri = get_resource_full_path(filename, LOCAL)
     rdr = ND2Reader(uri)
+    rdr.set_scene(0)
+    assert isinstance(
+        rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata
+    )
+
+
+def test_non_local_read() -> None:
+    filename = "ND2_dims_rgb_t3p2c2z3x64y64.nd2"
+    uri = get_resource_full_path(filename, LOCAL)
+    rdr = ND2Reader("simplecache::" + str(uri))
     rdr.set_scene(0)
     assert isinstance(
         rdr.xarray_data.attrs["unprocessed"]["frame"], nd2.structures.FrameMetadata


### PR DESCRIPTION
Removes the check for instance of LocalFileSystem
Added test to read from simplecache filesytem

I can also remove the check in the other readers if you'd like. Thanks.