### PR TITLE
Allow more channels in metadata than in data

### DIFF
--- a/aicsimageio/readers/czi_reader.py
+++ b/aicsimageio/readers/czi_reader.py
@@ -557,7 +557,18 @@ class CziReader(Reader):
             # Construct channel name list
             scene_channel_list = []
             channels = img.findall("./Channel")
-            for i, channel in enumerate(channels):
+            number_of_channels_in_data = dims_shape[DimensionNames.Channel][1]
+
+            # There may be more channels in the metadata than in the data
+            # if so, we will just use the first N channels and log
+            # a warning to the user
+            if len(channels) > number_of_channels_in_data:
+                log.warning(
+                    "More channels in metadata than in data "
+                    f"({len(channels)} vs {number_of_channels_in_data})"
+                )
+
+            for i, channel in enumerate(channels[:number_of_channels_in_data]):
                 # Id is required, Name is not.
                 # But we prefer to use Name if it is present
                 channel_name = channel.attrib.get("Name")


### PR DESCRIPTION
## Description
In #532 Suraj has a use case for a file with more channels in the metadata than in the data. This becomes an issue for `xarray` since we give it coordinates for channels that don't exist. Instead, this will now report a warning and just use the first N channels up to the number of channels in the data.

## Testing
Where I was previously unable to load the image provided in the issue, this now loads and reports the configured warning. Let me know if anyone feels this seems to warrant adding a test file and matching unit test.

