### PR TITLE
Add warning about deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AICSImageIO
 
 > [!WARNING]  
-> Deprecated in favor of replacement tool `bioio` ([see here for migration guide](https://bioio-devs.github.io/bioio/MIGRATION.html))
+> AICSImageIO is now in maintenance mode only.  Please take a look at its compatible successor [`bioio`](https://github.com/bioio-devs/bioio) ([see here for migration guide](https://bioio-devs.github.io/bioio/MIGRATION.html))
 
 [![Build Status](https://github.com/AllenCellModeling/aicsimageio/actions/workflows/build-main.yml/badge.svg)](https://github.com/AllenCellModeling/aicsimageio/actions)
 [![Documentation](https://github.com/AllenCellModeling/aicsimageio/workflows/Documentation/badge.svg)](https://AllenCellModeling.github.io/aicsimageio/)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # AICSImageIO
 
+> [!WARNING]  
+> Deprecated in favor of replacement tool `bioio` ([see here for migration guide](https://bioio-devs.github.io/bioio/MIGRATION.html))
+
 [![Build Status](https://github.com/AllenCellModeling/aicsimageio/actions/workflows/build-main.yml/badge.svg)](https://github.com/AllenCellModeling/aicsimageio/actions)
 [![Documentation](https://github.com/AllenCellModeling/aicsimageio/workflows/Documentation/badge.svg)](https://AllenCellModeling.github.io/aicsimageio/)
 [![Code Coverage](https://codecov.io/gh/AllenCellModeling/aicsimageio/branch/main/graph/badge.svg)](https://app.codecov.io/gh/AllenCellModeling/aicsimageio/branch/main)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4906608.svg)](https://doi.org/10.5281/zenodo.4906608)
 
 Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in Pure Python
+
 
 ---
 


### PR DESCRIPTION
## Description
`aicsimageio` has been deprecated in favor of `bioio` there should be a warning highly visible on the README mentioning as much
