### PR TITLE
Disable "test-upstreams" action except in workflow dispatch case

### DIFF
--- a/.github/workflows/test-upstreams.yml
+++ b/.github/workflows/test-upstreams.yml
@@ -5,14 +5,14 @@ name: Test Upstreams
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  schedule:
-    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
-    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
-    # Run every Mon,Wed,Thurs at 19:00:00 UTC (Monday at 11:00:00 PST)
-    - cron: "0 19 * * 1,3,4"
+  # push:
+  #   branches:
+  #     - main
+  # schedule:
+  #   # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
+  #   # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
+  #   # Run every Mon,Wed,Thurs at 19:00:00 UTC (Monday at 11:00:00 PST)
+  #   - cron: "0 19 * * 1,3,4"
 
 jobs:
   test-core-lib:


### PR DESCRIPTION
Resolves #568 

With the quick opinion from @toloudis I am disabling the "test upstreams" action for this repo, except in the case of workflow dispatches (i.e. Web UI request). This should stop the annoying emails we are currently receiving each week when it runs on the CRON job.

I am leaving the workflow dispatch because it doesn't get in the way without fully breaking the CI. And I am choosing not to remove the file because this is something we may want to add to bioio in the future so it is easier to find if we don't remove it than if we do.